### PR TITLE
Implement global sync pulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,18 @@ Configuration is defined in `vaultfire_config.json` and moral principles in
 `ghostkey_values.json`. Modules under `monetization/` and `ethics/` ensure all
 partnerships align with Ghostkey Alignment Code v2.0 and the Ghostkey Ethics
 Framework v1.0.
+
+## Global Sync Pulse
+Run the sync pulse to refresh all dashboards. `users.json` should contain a JSON
+array of user identifiers:
+
+```bash
+python3 weekly_sync.py --users path/to/users.json
+```
+
+Schedule this command weekly with cron:
+
+```cron
+0 0 * * 0 /usr/bin/python3 /path/to/weekly_sync.py >> logs/sync.log 2>&1
+```
+

--- a/engine/sync_protocol.py
+++ b/engine/sync_protocol.py
@@ -96,3 +96,23 @@ def sync_worldcoin(user_id):
     _log_audit({"action": "sync_worldcoin", "user_id": user_id,
                 "verified": verified, "trust_bonus": trust_bonus})
 
+
+def global_sync_pulse(user_list=None):
+    """Run all sync functions for each user in ``user_list``.
+
+    Parameters
+    ----------
+    user_list : list[str] or None
+        Iterable of user identifiers. If ``None`` the list is loaded from
+        ``user_scorecard.json`` keys.
+    """
+    if user_list is None:
+        scorecard = _load_json(SCORECARD_PATH, {})
+        user_list = list(scorecard.keys())
+
+    for user in user_list:
+        sync_ns3(user)
+        sync_openai(user)
+        sync_worldcoin(user)
+
+

--- a/user_list.json
+++ b/user_list.json
@@ -1,0 +1,1 @@
+["sample_user"]

--- a/weekly_sync.py
+++ b/weekly_sync.py
@@ -1,0 +1,29 @@
+"""Run global sync pulse for all users."""
+
+import argparse
+import json
+
+from engine.sync_protocol import global_sync_pulse
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run global sync pulse")
+    parser.add_argument(
+        "--users",
+        default="user_list.json",
+        help="Path to JSON file containing list of user IDs",
+    )
+    args = parser.parse_args()
+
+    try:
+        with open(args.users) as f:
+            user_list = json.load(f)
+    except FileNotFoundError:
+        user_list = []
+
+    global_sync_pulse(user_list)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a global sync pulse routine in `sync_protocol`
- provide a `weekly_sync.py` script to trigger the pulse
- document how to run the weekly sync in README
- add a sample `user_list.json` file

## Testing
- `python3 weekly_sync.py --users user_list.json`

------
https://chatgpt.com/codex/tasks/task_e_687d5b606c1483228da44e976baeb3f5