### PR TITLE
Add frontend manifesto broadcast script

### DIFF
--- a/frontend/manifesto_broadcast.js
+++ b/frontend/manifesto_broadcast.js
@@ -1,0 +1,31 @@
+// Pull ghostkey_heartbeat.json and display community metrics
+
+/*
+Render visual belief trends, moral spikes, and alignment rankings.
+Weekly rotation: "Ghostkey Pulse Report"
+Public mirror of what the system values.
+*/
+
+function renderChart(alignmentScores) {
+  // Placeholder: implement chart rendering with your preferred library
+  console.log('render chart', alignmentScores);
+}
+
+function displayTopUsers(loyaltyRanks) {
+  // Placeholder: populate top user list in the UI
+  console.log('top users', loyaltyRanks);
+}
+
+function showSystemQuoteOfWeek(summary) {
+  // Placeholder: display a weekly quote or summary
+  console.log('system quote', summary);
+}
+
+fetch('/dashboards/ghostkey_heartbeat.json')
+  .then(response => response.json())
+  .then(data => {
+    renderChart(data.alignment_scores);
+    displayTopUsers(data.loyalty_ranks);
+    showSystemQuoteOfWeek(data.ethics_summary);
+  })
+  .catch(err => console.error('Failed to load heartbeat', err));


### PR DESCRIPTION
## Summary
- add a small frontend script that fetches `ghostkey_heartbeat.json`
- provide placeholder functions to render chart info and weekly quotes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d70147f008322b19ac1bc5ccb50da