### PR TITLE
Implement token reward ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Vaultfire Init represents the first development signal from **Ghostkey-316** (Br
 ## Repository Structure
 - `vaultfire_signal.py` – logs activation messages to `logs/vaultfire_log.txt`.
 - `engine/signal_engine.py` – calculates alignment scores and triggers rewards.
-- `logs/` – location for generated log files (ignored by Git).
+- `logs/` – location for generated log files (ignored by Git). This now includes
+  `token_ledger.json` which tracks token rewards when partnerships enable direct
+  payouts.
 - `README.md` – project overview and usage notes.
 - `vaultfire-core/` – base protocol framework containing configuration, ethics,
   and monetization modules.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -2,3 +2,4 @@ from .yield_engine_v1 import calculate_yield, distribute_rewards, mark_yield_boo
 from .feedback_loop import track_behavior, check_thresholds
 from .sync_protocol import sync_ns3, sync_openai, sync_worldcoin
 from .signal_engine import pulse_tick, calculate_alignment_score
+from .token_ops import send_token

--- a/engine/signal_engine.py
+++ b/engine/signal_engine.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from .ghostkey_commandments import GHOSTKEY_COMMANDMENTS
 from .sync_protocol import sync_ns3, sync_openai, sync_worldcoin
 from .yield_engine_v1 import mark_yield_boost
+from .token_ops import send_token
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 USER_LIST_PATH = BASE_DIR / "user_list.json"
@@ -51,9 +52,22 @@ def grant_role(user_id: str, role: str) -> None:
     _write_json(SCORECARD_PATH, scorecard)
 
 
-def reward(user_id: str, reason: str) -> None:
+TOKEN_TIERS = {
+    "WEEKLY_YIELD_BONUS": {"amount": 1000, "token": "ASM"},
+    "AMBASSADOR": {"amount": 5000, "token": "USDC", "role": "Vaultfire Recruiter"},
+}
+
+
+def reward(user_id: str, tier: str) -> None:
+    """Grant reward ``tier`` to ``user_id`` and log the event."""
     mark_yield_boost(user_id)
-    log_to_broadcast({"action": "reward", "user_id": user_id, "reason": reason})
+    tier_info = TOKEN_TIERS.get(tier)
+    if tier_info:
+        send_token(user_id, tier_info["amount"], tier_info["token"])
+        role = tier_info.get("role")
+        if role:
+            grant_role(user_id, role)
+    log_to_broadcast({"action": "reward", "user_id": user_id, "reason": tier})
 
 
 def calculate_alignment_score(user_id: str) -> float:

--- a/engine/token_ops.py
+++ b/engine/token_ops.py
@@ -1,0 +1,37 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LEDGER_PATH = BASE_DIR / "logs" / "token_ledger.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    os.makedirs(path.parent, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def send_token(wallet: str, amount: float, token: str) -> None:
+    """Record a token transfer to ``wallet``."""
+    ledger = _load_json(LEDGER_PATH, [])
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "wallet": wallet,
+        "amount": amount,
+        "token": token,
+    }
+    ledger.append(entry)
+    _write_json(LEDGER_PATH, ledger)
+    return None


### PR DESCRIPTION
## Summary
- create `token_ops` utility for logging token transfers
- extend `signal_engine.reward` to send tokens based on tier
- expose `send_token` in `engine.__init__`
- document new token ledger in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d7ba22e9083228679bffa167078dd