### PR TITLE
Add marketplace config and integrate currency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Vaultfire Init represents the first development signal from **Ghostkey-316** (Br
 - `README.md` – project overview and usage notes.
 - `vaultfire-core/` – base protocol framework containing configuration, ethics,
   and monetization modules.
+- `vaultfire-core/marketplace_config.json` – settings for the Vaultfire Exchange marketplace.
 
 ## Usage
 Run the logger to append a timestamped entry:
@@ -78,7 +79,8 @@ The script creates `logs/vaultfire_log.txt` automatically if it does not exist.
 
 ## Vaultfire Core
 The `vaultfire-core` directory contains the ethical monetization framework.
-Configuration is defined in `vaultfire_config.json` and moral principles in
+Configuration is defined in `vaultfire_config.json`, marketplace settings in
+`marketplace_config.json`, and moral principles in
 `ghostkey_values.json`. Modules under `monetization/` and `ethics/` ensure all
 partnerships align with Ghostkey Alignment Code v2.0 and the Ghostkey Ethics
 Framework v1.0.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -3,3 +3,4 @@ from .feedback_loop import track_behavior, check_thresholds
 from .sync_protocol import sync_ns3, sync_openai, sync_worldcoin
 from .signal_engine import pulse_tick, calculate_alignment_score
 from .token_ops import send_token
+from .marketplace import currency_allowed

--- a/engine/marketplace.py
+++ b/engine/marketplace.py
@@ -1,0 +1,24 @@
+"""Marketplace configuration utilities."""
+
+import json
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+CONFIG_PATH = BASE_DIR / "vaultfire-core" / "marketplace_config.json"
+
+
+def _load_config():
+    with open(CONFIG_PATH) as f:
+        return json.load(f)
+
+
+def currency_allowed(token: str) -> bool:
+    """Return ``True`` if ``token`` is supported by the marketplace."""
+    config = _load_config()
+    currencies = config.get("currency", [])
+    return token in currencies
+
+
+if __name__ == "__main__":
+    cfg = _load_config()
+    print(cfg)

--- a/engine/token_ops.py
+++ b/engine/token_ops.py
@@ -3,6 +3,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 
+from .marketplace import currency_allowed
+
 BASE_DIR = Path(__file__).resolve().parents[1]
 LEDGER_PATH = BASE_DIR / "logs" / "token_ledger.json"
 
@@ -24,7 +26,9 @@ def _write_json(path: Path, data) -> None:
 
 
 def send_token(wallet: str, amount: float, token: str) -> None:
-    """Record a token transfer to ``wallet``."""
+    """Record a token transfer to ``wallet`` if ``token`` is allowed."""
+    if not currency_allowed(token):
+        raise ValueError(f"Token {token} not supported by marketplace")
     ledger = _load_json(LEDGER_PATH, [])
     entry = {
         "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/vaultfire-core/marketplace_config.json
+++ b/vaultfire-core/marketplace_config.json
@@ -1,0 +1,14 @@
+{
+  "marketplace_name": "Vaultfire Exchange",
+  "ethics_layer": "Ghostkey-316",
+  "verified_sellers_only": true,
+  "currency": ["ASM", "USDC", "ETH"],
+  "public_display": [
+    "signal_score",
+    "trust_rank",
+    "contributor_role",
+    "manifesto alignment"
+  ],
+  "yield_rebates_enabled": true,
+  "buyers_can_earn_loyalty": true
+}


### PR DESCRIPTION
## Summary
- add `marketplace_config.json` with Vaultfire Exchange settings
- provide `engine.marketplace` helpers
- enforce allowed currencies in token_ops
- expose new helper via `engine.__init__`
- document marketplace configuration in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d7e2b97a48322a47516f47f350cb6