### PR TITLE
Add marketplace categories and banned items

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -3,4 +3,4 @@ from .feedback_loop import track_behavior, check_thresholds
 from .sync_protocol import sync_ns3, sync_openai, sync_worldcoin
 from .signal_engine import pulse_tick, calculate_alignment_score
 from .token_ops import send_token
-from .marketplace import currency_allowed
+from .marketplace import currency_allowed, category_allowed, item_allowed

--- a/engine/marketplace.py
+++ b/engine/marketplace.py
@@ -7,6 +7,23 @@ BASE_DIR = Path(__file__).resolve().parents[1]
 CONFIG_PATH = BASE_DIR / "vaultfire-core" / "marketplace_config.json"
 
 
+LISTABLE_CATEGORIES = [
+    "Verified Vaultfire Tools",
+    "Prompt Blueprints",
+    "Signal Engine Extensions",
+    "Ethical Culture NFTs",
+    "Codex Hacks / Protocol Enhancements",
+    "IRL Gear from Contributors",
+]
+
+BANNED_ITEMS = [
+    "Pump Signals",
+    "Clickbait Prompts",
+    "Hype NFTs",
+    "Fake AI Agents",
+]
+
+
 def _load_config():
     with open(CONFIG_PATH) as f:
         return json.load(f)
@@ -17,6 +34,24 @@ def currency_allowed(token: str) -> bool:
     config = _load_config()
     currencies = config.get("currency", [])
     return token in currencies
+
+
+def category_allowed(category: str) -> bool:
+    """Return ``True`` if ``category`` is listed in the marketplace."""
+    config = _load_config()
+    categories = config.get("categories")
+    if categories is None:
+        categories = LISTABLE_CATEGORIES
+    return category in categories
+
+
+def item_allowed(item: str) -> bool:
+    """Return ``True`` if ``item`` is not banned from the marketplace."""
+    config = _load_config()
+    banned = config.get("banned_items")
+    if banned is None:
+        banned = BANNED_ITEMS
+    return item not in banned
 
 
 if __name__ == "__main__":

--- a/vaultfire-core/marketplace_config.json
+++ b/vaultfire-core/marketplace_config.json
@@ -2,7 +2,11 @@
   "marketplace_name": "Vaultfire Exchange",
   "ethics_layer": "Ghostkey-316",
   "verified_sellers_only": true,
-  "currency": ["ASM", "USDC", "ETH"],
+  "currency": [
+    "ASM",
+    "USDC",
+    "ETH"
+  ],
   "public_display": [
     "signal_score",
     "trust_rank",
@@ -10,5 +14,19 @@
     "manifesto alignment"
   ],
   "yield_rebates_enabled": true,
-  "buyers_can_earn_loyalty": true
+  "buyers_can_earn_loyalty": true,
+  "categories": [
+    "Verified Vaultfire Tools",
+    "Prompt Blueprints",
+    "Signal Engine Extensions",
+    "Ethical Culture NFTs",
+    "Codex Hacks / Protocol Enhancements",
+    "IRL Gear from Contributors"
+  ],
+  "banned_items": [
+    "Pump Signals",
+    "Clickbait Prompts",
+    "Hype NFTs",
+    "Fake AI Agents"
+  ]
 }


### PR DESCRIPTION
## Summary
- define LISTABLE_CATEGORIES and BANNED_ITEMS
- expose category_allowed and item_allowed helpers
- add new imports in engine package
- expand marketplace config with categories and banned items

## Testing
- `python3 -m compileall -q .`
- `python3 -m engine.marketplace`
- `python3 - <<'EOF'
from engine.marketplace import category_allowed,item_allowed
print(category_allowed('Verified Vaultfire Tools'))
print(category_allowed('Unknown Category'))
print(item_allowed('Pump Signals'))
print(item_allowed('Something Legit'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687d8061311c83229bd603f6c399ea14