### PR TITLE
Add AI helper component

### DIFF
--- a/frontend/ai_helper.js
+++ b/frontend/ai_helper.js
@@ -1,0 +1,43 @@
+class ChatAssistant {
+  constructor({ mode, prompt, context }) {
+    this.mode = mode || 'Vaultfire';
+    this.prompt = prompt || 'Ask me anything';
+    this.context = context || {};
+  }
+
+  init(container) {
+    const wrap = document.createElement('div');
+    wrap.className = 'chat-assistant';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = this.prompt;
+    input.style.marginRight = '5px';
+
+    const btn = document.createElement('button');
+    btn.textContent = 'Send';
+
+    const output = document.createElement('div');
+    output.className = 'chat-output';
+    output.style.marginTop = '10px';
+    output.style.padding = '5px';
+    output.style.border = '1px solid #ccc';
+
+    btn.addEventListener('click', () => {
+      const q = input.value.trim();
+      if (!q) return;
+      const p = document.createElement('p');
+      p.textContent = `You asked: ${q}`;
+      output.appendChild(p);
+      input.value = '';
+    });
+
+    wrap.appendChild(input);
+    wrap.appendChild(btn);
+    wrap.appendChild(output);
+    container.appendChild(wrap);
+  }
+}
+
+// Expose globally
+window.ChatAssistant = ChatAssistant;

--- a/frontend/pages/marketplace.html
+++ b/frontend/pages/marketplace.html
@@ -62,6 +62,28 @@
     <pre id="stats"></pre>
   </section>
 
+  <section id="aiHelper">
+    <h3>AI Helper</h3>
+    <div id="aiHelperContainer"></div>
+  </section>
+  <script src="../ai_helper.js"></script>
   <script src="marketplace.js"></script>
+  <script>
+    const currentUser = {
+      signal_score: 0,
+      manifesto_alignment: []
+    };
+
+    const aiHelper = new ChatAssistant({
+      mode: "Vaultfire",
+      prompt: "What would you like to find or list today?",
+      context: {
+        userSignalScore: currentUser.signal_score,
+        values: currentUser.manifesto_alignment
+      }
+    });
+
+    aiHelper.init(document.getElementById('aiHelperContainer'));
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a simple `ChatAssistant` widget for Marketplace
- embed the assistant in the marketplace page

## Testing
- `python3 -m py_compile vaultfire_signal.py engine/*.py record_signal_feed.py weekly_sync.py`
- `node manifesto_broadcast.js`
- `python3 record_signal_feed.py --users user_list.json`
- `python3 weekly_sync.py --users user_list.json` *(fails: cannot import name 'send_token')*

------
https://chatgpt.com/codex/tasks/task_e_687db17aae708322b0b07d88001de524