### PR TITLE
Add belief validation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,12 @@ Run the pulse engine to compute alignment scores and reward top users:
 ```bash
 python3 -m engine.signal_engine
 ```
+
+## Belief Validation
+Use the belief validator to check contributor statements against Ghostkey ethics.
+
+```bash
+python3 engine/belief_validation.py
+```
+
+Results are stored in `vaultfire-core/ethics/belief_checkpoints.json`.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -12,3 +12,4 @@ from .marketplace import (
     buyer_loyalty_bonus,
     seller_yield_boost,
 )
+from .belief_validation import validate_belief, get_user_checkpoints

--- a/engine/belief_validation.py
+++ b/engine/belief_validation.py
@@ -1,0 +1,73 @@
+"""Belief validation with ethical checkpointing."""
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+VALUES_PATH = BASE_DIR / "vaultfire-core" / "ghostkey_values.json"
+CONFIG_PATH = BASE_DIR / "vaultfire-core" / "vaultfire_config.json"
+CHECKPOINT_PATH = BASE_DIR / "vaultfire-core" / "ethics" / "belief_checkpoints.json"
+
+PROHIBITED_TERMS = ["pump", "scam", "deceive", "exploit", "harm"]
+
+
+def _load_json(path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path, data):
+    os.makedirs(path.parent, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _ethics_enabled():
+    cfg = _load_json(CONFIG_PATH, {})
+    return bool(cfg.get("ethics_anchor", False))
+
+
+def _log_checkpoint(entry):
+    log = _load_json(CHECKPOINT_PATH, [])
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    log.append({"timestamp": timestamp, **entry})
+    _write_json(CHECKPOINT_PATH, log)
+
+
+def validate_belief(user_id, belief):
+    """Validate ``belief`` for ``user_id`` and log result."""
+    if not _ethics_enabled():
+        _log_checkpoint({"user_id": user_id, "belief": belief,
+                         "approved": False, "reason": "ethics_anchor disabled"})
+        return False
+
+    b_lower = belief.lower()
+    if any(term in b_lower for term in PROHIBITED_TERMS):
+        _log_checkpoint({"user_id": user_id, "belief": belief,
+                         "approved": False, "reason": "prohibited_term"})
+        return False
+
+    values = _load_json(VALUES_PATH, {})
+    keywords = [k.replace("_", " ") for k in values.keys()]
+    aligned = any(word.lower() in b_lower for word in keywords)
+
+    _log_checkpoint({"user_id": user_id, "belief": belief,
+                     "approved": aligned, "reason": "auto-check"})
+    return aligned
+
+
+def get_user_checkpoints(user_id):
+    """Return checkpoint log entries for ``user_id``."""
+    log = _load_json(CHECKPOINT_PATH, [])
+    return [e for e in log if e.get("user_id") == user_id]
+
+
+if __name__ == "__main__":
+    print(validate_belief("sample_user", "I believe in truth over hype"))

--- a/engine/feedback_loop.py
+++ b/engine/feedback_loop.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from vaultfire_signal import log_vaultfire_status
 from .yield_engine_v1 import mark_yield_boost
+from .belief_validation import validate_belief
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 EVENT_LOG_PATH = BASE_DIR / "event_log.json"
@@ -17,6 +18,7 @@ ACTION_VALUE_MAP = {
     "mission_complete": {"belief_level": 1, "impact_score": 3},
     "help_new_user": {"loyalty": 2},
     "ethical_action": {"belief_level": 1, "loyalty": 1, "impact_score": 1},
+    "submit_belief": {},
 }
 
 THRESHOLD = 10
@@ -52,6 +54,14 @@ def track_behavior(event):
     increments = ACTION_VALUE_MAP.get(action, {})
     for key, inc in increments.items():
         user_scores[key] = user_scores.get(key, 0) + inc
+
+    belief = event.get("belief")
+    if belief:
+        approved = validate_belief(uid, belief)
+        _log_audit({"action": "belief_validation", "user_id": uid,
+                    "belief": belief, "approved": approved})
+        if approved:
+            user_scores["belief_level"] = user_scores.get("belief_level", 0) + 1
 
     scorecard[uid] = user_scores
     _write_json(SCORECARD_PATH, scorecard)

--- a/vaultfire-core/ethics/belief_checkpoints.json
+++ b/vaultfire-core/ethics/belief_checkpoints.json
@@ -1,0 +1,37 @@
+[
+  {
+    "timestamp": "2025-07-21T03:42:24Z",
+    "user_id": "sample_user",
+    "belief": "I believe in truth over hype",
+    "approved": false,
+    "reason": "prohibited_term"
+  },
+  {
+    "timestamp": "2025-07-21T03:42:32Z",
+    "user_id": "sample_user",
+    "belief": "I believe in truth over hype",
+    "approved": false,
+    "reason": "prohibited_term"
+  },
+  {
+    "timestamp": "2025-07-21T03:42:52Z",
+    "user_id": "u1",
+    "belief": "I believe in truth over hype",
+    "approved": false,
+    "reason": "prohibited_term"
+  },
+  {
+    "timestamp": "2025-07-21T03:43:02Z",
+    "user_id": "u1",
+    "belief": "I believe in truth over hype",
+    "approved": false,
+    "reason": "prohibited_term"
+  },
+  {
+    "timestamp": "2025-07-21T03:43:10Z",
+    "user_id": "sample_user",
+    "belief": "I believe in truth over hype",
+    "approved": true,
+    "reason": "auto-check"
+  }
+]


### PR DESCRIPTION
## Summary
- implement `belief_validation` module to validate beliefs and log results
- add checkpoint file to track belief review data
- integrate belief checks into `feedback_loop`
- expose new helpers from `engine.__init__`
- document belief validation usage

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 engine/belief_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_687db67c8210832283bbe8e90f7b04e1