### PR TITLE
Add partner monetization hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ Schedule this command weekly with cron:
 0 0 * * 0 /usr/bin/python3 /path/to/weekly_sync.py >> logs/sync.log 2>&1
 ```
 
+## Partner Monetization Hooks
+Partners can track usage and payouts with functions in `engine.partner_hooks`.
+Use `record_usage(partner_id, feature, tokens, wallet)` to deduct tokens for
+API usage. Rewards may be granted with `grant_reward(partner_id, wallet, amount)`.
+All entries are logged to `logs/partner_usage.json` and mirrored in
+`logs/token_ledger.json`.
+
 
 ## Signal Engine
 Run the pulse engine to compute alignment scores and reward top users:

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,9 +1,12 @@
 """Vaultfire engine package."""
 
 from .identity_resolver import resolve_identity, resolve_ens, resolve_cb_id
+from .partner_hooks import record_usage, grant_reward
 
 __all__ = [
     "resolve_identity",
     "resolve_ens",
     "resolve_cb_id",
+    "record_usage",
+    "grant_reward",
 ]

--- a/engine/partner_hooks.py
+++ b/engine/partner_hooks.py
@@ -1,0 +1,84 @@
+"""Partner integration hooks for token-based usage."""
+
+from datetime import datetime
+import json
+from pathlib import Path
+
+from .token_ops import send_token
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+CONFIG_PATH = BASE_DIR / "vaultfire-core" / "vaultfire_config.json"
+USAGE_LOG_PATH = BASE_DIR / "logs" / "partner_usage.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _load_config():
+    with open(CONFIG_PATH) as f:
+        return json.load(f)
+
+
+def _check_enabled():
+    config = _load_config()
+    if not config.get("ethics_anchor", False):
+        raise RuntimeError("Ethics anchor disabled. Monetization halted.")
+    if not config.get("partner_hooks_enabled", False):
+        raise RuntimeError("Partner hooks disabled in configuration.")
+
+
+# ---------------------------------------------------------------------------
+
+def record_usage(partner_id: str, feature: str, tokens: float, wallet: str,
+                 token: str = "ASM") -> dict:
+    """Record ``tokens`` consumed by ``partner_id`` for ``feature``.
+
+    A negative token amount is stored in ``token_ledger.json`` to denote
+    a deduction from the partner's wallet.
+    """
+    _check_enabled()
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "partner_id": partner_id,
+        "feature": feature,
+        "wallet": wallet,
+        "token": token,
+        "tokens_used": tokens,
+    }
+    log = _load_json(USAGE_LOG_PATH, [])
+    log.append(entry)
+    _write_json(USAGE_LOG_PATH, log)
+    # Deduct tokens by recording a negative ledger entry
+    send_token(wallet, -tokens, token)
+    return entry
+
+
+def grant_reward(partner_id: str, wallet: str, amount: float,
+                 token: str = "ASM") -> dict:
+    """Grant ``amount`` tokens to ``partner_id``."""
+    _check_enabled()
+    send_token(wallet, amount, token)
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "partner_id": partner_id,
+        "wallet": wallet,
+        "token": token,
+        "reward": amount,
+    }
+    log = _load_json(USAGE_LOG_PATH, [])
+    log.append(entry)
+    _write_json(USAGE_LOG_PATH, log)
+    return entry


### PR DESCRIPTION
## Summary
- add new `engine.partner_hooks` for partner usage tracking
- expose partner monetization helpers in `engine/__init__`
- document new partner token hooks in README

## Testing
- `python -m py_compile engine/partner_hooks.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687dbcc6512483228b494e43d9a1285a