### PR TITLE
Add marketplace integration plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,20 @@ python3 onboarding_api.py
 - `POST /onboard/earner` – body `{"wallet": "addr"}`
 - `GET /status` – health check.
 
+## External Marketplace Integrations
+The new module `engine/marketplace_plugins.py` makes it easy to reference
+listings on major platforms like OpenSea or GitHub Sponsors. Links are stored in
+`logs/external_marketplace_links.json` so partner dashboards can surface them.
+
+Example usage:
+
+```python
+from engine.marketplace_plugins import opensea_asset_url, record_link
+
+url = opensea_asset_url("0xMyContract", "1")
+record_link("blueprint-1", "opensea", url)
+```
+
+The module also exposes `github_sponsors_url` and `dapp_store_url` helpers for
+connecting other storefronts or Web3 dApp directories.
+

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -2,6 +2,13 @@
 
 from .identity_resolver import resolve_identity, resolve_ens, resolve_cb_id
 from .partner_hooks import record_usage, grant_reward
+from .marketplace_plugins import (
+    opensea_asset_url,
+    github_sponsors_url,
+    dapp_store_url,
+    record_link,
+    fetch_json,
+)
 
 __all__ = [
     "resolve_identity",
@@ -9,4 +16,9 @@ __all__ = [
     "resolve_cb_id",
     "record_usage",
     "grant_reward",
+    "opensea_asset_url",
+    "github_sponsors_url",
+    "dapp_store_url",
+    "record_link",
+    "fetch_json",
 ]

--- a/engine/marketplace_plugins.py
+++ b/engine/marketplace_plugins.py
@@ -1,0 +1,76 @@
+"""External marketplace integration utilities for Vaultfire."""
+
+import json
+from pathlib import Path
+from typing import Optional
+from urllib import parse, request
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LINKS_PATH = BASE_DIR / "logs" / "external_marketplace_links.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# URL helpers
+
+
+def opensea_asset_url(contract_address: str, token_id: str) -> str:
+    """Return a URL to view ``token_id`` of ``contract_address`` on OpenSea."""
+    base = "https://opensea.io/assets"
+    addr = contract_address.strip()
+    tid = token_id.strip()
+    return f"{base}/{addr}/{tid}"
+
+
+def github_sponsors_url(username: str) -> str:
+    """Return a GitHub Sponsors page URL for ``username``."""
+    return f"https://github.com/sponsors/{username.strip()}"
+
+
+def dapp_store_url(app_id: str, base_url: str | None = None) -> str:
+    """Return a dApp store URL for ``app_id``.``base_url`` can override default."""
+    base = base_url or "https://dapps.example.com/apps"
+    return f"{base}/{parse.quote(app_id)}"
+
+
+# ---------------------------------------------------------------------------
+# Link recording
+
+
+def record_link(item_id: str, marketplace: str, url: str) -> dict:
+    """Record an external marketplace link for an item."""
+    entry = {"item_id": item_id, "marketplace": marketplace, "url": url}
+    log = _load_json(LINKS_PATH, [])
+    log.append(entry)
+    _write_json(LINKS_PATH, log)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Optional fetch utilities (may fail if network is disabled)
+
+
+def fetch_json(url: str) -> Optional[dict]:
+    """Return JSON data from ``url`` if possible, else ``None``."""
+    try:
+        with request.urlopen(url, timeout=5) as res:
+            if "application/json" in res.headers.get("Content-Type", ""):
+                return json.load(res)
+    except Exception:
+        return None
+    return None


### PR DESCRIPTION
## Summary
- add `marketplace_plugins` module with helpers for OpenSea, GitHub Sponsors and Web3 dApp store links
- export new helper functions in `engine.__init__`
- document external marketplace usage in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687dbef0b09c8322b21aacc1a74a1077