### PR TITLE
Add revenue sharing hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ API usage. Rewards may be granted with `grant_reward(partner_id, wallet, amount)
 All entries are logged to `logs/partner_usage.json` and mirrored in
 `logs/token_ledger.json`.
 
+Contract-based revenue can be handled automatically using
+`engine.revenue_hooks.record_contract_revenue`. This reads the list of
+wallets from `earners.json`, verifies each one, and distributes the configured
+share of revenue across them.
+
 
 ## Signal Engine
 Run the pulse engine to compute alignment scores and reward top users:

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -2,6 +2,7 @@
 
 from .identity_resolver import resolve_identity, resolve_ens, resolve_cb_id
 from .partner_hooks import record_usage, grant_reward
+from .revenue_hooks import record_contract_revenue, distribute_revenue
 from .marketplace_plugins import (
     opensea_asset_url,
     github_sponsors_url,
@@ -16,6 +17,8 @@ __all__ = [
     "resolve_cb_id",
     "record_usage",
     "grant_reward",
+    "record_contract_revenue",
+    "distribute_revenue",
     "opensea_asset_url",
     "github_sponsors_url",
     "dapp_store_url",

--- a/engine/revenue_hooks.py
+++ b/engine/revenue_hooks.py
@@ -1,0 +1,76 @@
+"""Revenue distribution hooks for on-chain contracts."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from .token_ops import send_token
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+EARNERS_PATH = BASE_DIR / "earners.json"
+CONFIG_PATH = BASE_DIR / "vaultfire-core" / "revenue_share.json"
+REVENUE_LOG_PATH = BASE_DIR / "logs" / "contract_revenue.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _wallet_verified(wallet: str) -> bool:
+    addr = wallet.lower()
+    return addr.endswith(".eth") or addr.startswith("world") or addr.startswith("0x")
+
+
+def _share_config() -> float:
+    cfg = _load_json(CONFIG_PATH, {"share_percentage": 0.1})
+    return float(cfg.get("share_percentage", 0.1))
+
+
+# ---------------------------------------------------------------------------
+
+
+def distribute_revenue(total_amount: float, token: str = "ASM") -> list[dict]:
+    """Distribute ``total_amount`` across verified earners."""
+    earners = _load_json(EARNERS_PATH, [])
+    wallets = [w for w in earners if _wallet_verified(w)]
+    if not wallets:
+        return []
+    per_wallet = total_amount / len(wallets)
+    results = []
+    for wallet in wallets:
+        send_token(wallet, per_wallet, token)
+        results.append({"wallet": wallet, "amount": per_wallet, "token": token})
+    return results
+
+
+def record_contract_revenue(contract: str, amount: float, token: str = "ASM") -> dict:
+    """Record revenue from ``contract`` and distribute the configured share."""
+    share_pct = _share_config()
+    share_amount = amount * share_pct
+    distribution = distribute_revenue(share_amount, token)
+
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "contract": contract,
+        "amount": amount,
+        "token": token,
+        "share_pct": share_pct,
+        "share_distributed": share_amount,
+        "distribution": distribution,
+    }
+    log = _load_json(REVENUE_LOG_PATH, [])
+    log.append(entry)
+    _write_json(REVENUE_LOG_PATH, log)
+    return entry

--- a/vaultfire-core/revenue_share.json
+++ b/vaultfire-core/revenue_share.json
@@ -1,0 +1,3 @@
+{
+  "share_percentage": 0.1
+}


### PR DESCRIPTION
## Summary
- expose new revenue sharing helpers from `engine`
- add `revenue_hooks` module for contract revenue distribution
- track share settings in `revenue_share.json`
- document contract revenue workflow in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687dbff8717483228e3ff9825295c09d