### PR TITLE
Fix circular import in marketplace module

### DIFF
--- a/engine/marketplace.py
+++ b/engine/marketplace.py
@@ -5,7 +5,6 @@ import json
 import os
 from pathlib import Path
 
-from .token_ops import send_token
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 CONFIG_PATH = BASE_DIR / "vaultfire-core" / "marketplace_config.json"
@@ -122,6 +121,7 @@ def buyer_loyalty_bonus(buyer) -> None:
     if score is None or wallet is None:
         return None
     if score > 90:
+        from .token_ops import send_token
         send_token(wallet, 100, "ASM")
     return None
 
@@ -138,6 +138,7 @@ def seller_yield_boost(seller, item_price: float, item_quality: str) -> None:
     if score > 95:
         base += 0.05
     amount = item_price * base
+    from .token_ops import send_token
     send_token(wallet, amount, "ASM")
     return None
 


### PR DESCRIPTION
## Summary
- avoid circular import between `token_ops` and `marketplace`
- load `send_token` lazily inside buyer/seller reward helpers

## Testing
- `python3 -m engine.signal_engine`
- `python3 generate_partner_dashboard.py >/tmp/dashboard_output.json`
- `python3 weekly_sync.py --users user_list.json`
- `python3 vaultfire_signal.py --identity testuser.eth --wallet testwallet`
- `python3 record_signal_feed.py`
- `node manifesto_broadcast.js >/tmp/manifesto_log.txt`
- `python3 -m engine.marketplace | head`

------
https://chatgpt.com/codex/tasks/task_e_687dc5038de88322bed855ca85fda838