### PR TITLE
Add Vaultfire confirmation overlay

### DIFF
--- a/frontend/pages/marketplace.html
+++ b/frontend/pages/marketplace.html
@@ -66,6 +66,7 @@
     <h3>AI Helper</h3>
     <div id="aiHelperContainer"></div>
   </section>
+  <script src="../vaultfire_confirm.js"></script>
   <script src="../ai_helper.js"></script>
   <script src="marketplace.js"></script>
   <script>

--- a/frontend/pages/partner_dashboard.html
+++ b/frontend/pages/partner_dashboard.html
@@ -35,6 +35,7 @@
     <div id="aiHelperContainer"></div>
   </section>
 
+  <script src="../vaultfire_confirm.js"></script>
   <script src="../ai_helper.js"></script>
   <script src="partner_dashboard.js"></script>
   <script>

--- a/frontend/vaultfire_confirm.js
+++ b/frontend/vaultfire_confirm.js
@@ -1,0 +1,34 @@
+function showVaultfireConfirmation() {
+  if (sessionStorage.getItem('vaultfireConfirmed')) return;
+  const overlay = document.createElement('div');
+  overlay.style.position = 'fixed';
+  overlay.style.top = 0;
+  overlay.style.left = 0;
+  overlay.style.right = 0;
+  overlay.style.bottom = 0;
+  overlay.style.background = 'rgba(0,0,0,0.8)';
+  overlay.style.color = '#fff';
+  overlay.style.display = 'flex';
+  overlay.style.alignItems = 'center';
+  overlay.style.justifyContent = 'center';
+  overlay.style.flexDirection = 'column';
+  overlay.style.zIndex = '10000';
+
+  const msg = document.createElement('p');
+  msg.textContent = 'You are building with Vaultfire. Proceed with honor.';
+  msg.style.marginBottom = '20px';
+
+  const btn = document.createElement('button');
+  btn.textContent = 'Continue';
+  btn.style.padding = '10px 20px';
+  btn.addEventListener('click', () => {
+    sessionStorage.setItem('vaultfireConfirmed', 'yes');
+    overlay.remove();
+  });
+
+  overlay.appendChild(msg);
+  overlay.appendChild(btn);
+  document.body.appendChild(overlay);
+}
+
+window.addEventListener('DOMContentLoaded', showVaultfireConfirmation);


### PR DESCRIPTION
## Summary
- add `vaultfire_confirm.js` to display an overlay on first page load
- load the confirmation script on Marketplace and Partner Dashboard pages

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687dc767081c8322b3b3ba875518d6c4