### PR TITLE
Add BeliefTech sandbox for partner onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,15 @@ python3 tools/log_pr_merge.py
 This records the UTC timestamp and ethics framework version to
 `vaultfire-core/ethics/pr_merge_log.json`.
 
+## BeliefTech Sandbox
+The script `sandbox_belieftech.py` demonstrates a full onboarding flow for the
+test partner **BeliefTech Inc.** It uses the API endpoints, performs an ethics
+check, and simulates a smart contract revenue callback. A simple UI is provided
+in `frontend/pages/belieftech_sandbox.html`.
+
+Run the sandbox:
+
+```bash
+python3 sandbox_belieftech.py
+```
+

--- a/frontend/pages/belieftech_sandbox.html
+++ b/frontend/pages/belieftech_sandbox.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>BeliefTech Sandbox</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin:0; padding:20px; }
+    header { background:#222; color:#fff; padding:10px; }
+    button { padding:8px 12px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>BeliefTech Inc. Sandbox Onboarding</h1>
+  </header>
+  <section>
+    <button id="onboardBtn">Onboard Partner</button>
+    <p id="result"></p>
+  </section>
+  <script src="../vaultfire_confirm.js"></script>
+  <script src="belieftech_sandbox.js"></script>
+</body>
+</html>

--- a/frontend/pages/belieftech_sandbox.js
+++ b/frontend/pages/belieftech_sandbox.js
@@ -1,0 +1,15 @@
+async function onboard() {
+  const res = await fetch('/onboard/partner', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ partner_id: 'belieftech', wallet: 'belieftech.eth' })
+  }).catch(() => null);
+  const out = document.getElementById('result');
+  if (res && res.ok) {
+    out.textContent = 'BeliefTech Inc. onboarded!';
+  } else {
+    out.textContent = 'Onboarding failed';
+  }
+}
+
+document.getElementById('onboardBtn').addEventListener('click', onboard);

--- a/sandbox_belieftech.py
+++ b/sandbox_belieftech.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+from onboarding_api import app
+from engine.revenue_hooks import record_contract_revenue
+from engine.belief_validation import validate_belief
+
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def run_sandbox():
+    partner_id = "belieftech"
+    wallet = "belieftech.eth"
+    statement = "We believe in truth over hype"
+
+    # API call: onboard partner
+    with app.test_client() as client:
+        res = client.post("/onboard/partner", json={"partner_id": partner_id, "wallet": wallet})
+        print("Onboard Response:", res.json)
+
+    # Ethics verification
+    ethics_ok = validate_belief(partner_id, statement)
+    print("Ethics Verification:", ethics_ok)
+
+    # Smart contract callback simulation
+    entry = record_contract_revenue("0xBeliefTechContract", 5000.0, "ASM")
+    print("Contract Revenue Entry:")
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    run_sandbox()


### PR DESCRIPTION
## Summary
- implement `sandbox_belieftech.py` to demo API, smart contract callback and ethics check
- add front-end page and script for BeliefTech onboarding
- document the sandbox usage in README

## Testing
- `python3 -m py_compile sandbox_belieftech.py`
- `python3 sandbox_belieftech.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687dc9bbce588322a8aefccfdd2d4b37