### PR TITLE
Add contributor snapshot generator

### DIFF
--- a/dashboards/contributor_snapshot.json
+++ b/dashboards/contributor_snapshot.json
@@ -1,0 +1,21 @@
+{
+  "title": "Ghostkey-316: The Ethics Origin",
+  "ens": "ghostkey316.eth",
+  "wallet": "bpow20.cb.id",
+  "resolved_wallet": "cb1qexampleaddress0000000000000000000000",
+  "visual_signature": "signature-df681d19e6",
+  "moral_framework": [
+    "**Truth over hype** \u2013 never create fake urgency or scarcity.",
+    "**Loyalty over trend** \u2013 reward sustained contribution more than short\u2011term buzz.",
+    "**Wisdom over speed** \u2013 prioritize careful decision making.",
+    "**Service over status** \u2013 design for everyday users before influencers.",
+    "**Humanity over everything** \u2013 shut it down if the system causes harm."
+  ],
+  "loyalty_status": {
+    "user_id": "ghostkey316",
+    "base": 0,
+    "tier": "default",
+    "score": 0.0
+  },
+  "system_phase": "Vaultfire Init"
+}

--- a/generate_contributor_snapshot.py
+++ b/generate_contributor_snapshot.py
@@ -1,0 +1,63 @@
+import json
+import hashlib
+from pathlib import Path
+
+from engine.identity_resolver import resolve_identity
+from engine.loyalty_engine import loyalty_score
+
+BASE_DIR = Path(__file__).resolve().parent
+CORE_PATH = BASE_DIR / "ethics" / "core.mdx"
+SNAPSHOT_PATH = BASE_DIR / "dashboards" / "contributor_snapshot.json"
+
+DEFAULT_USER_ID = "ghostkey316"
+DEFAULT_ENS = "ghostkey316.eth"
+DEFAULT_WALLET = "bpow20.cb.id"
+
+
+def parse_moral_framework(path: Path) -> list[str]:
+    values = []
+    capture = False
+    with open(path) as f:
+        for line in f:
+            line = line.rstrip()
+            if line.lower().startswith("## core values"):
+                capture = True
+                continue
+            if capture:
+                if line.startswith("##"):
+                    break
+                if line.lstrip().startswith("-"):
+                    values.append(line.lstrip("- ").strip())
+    return values
+
+
+def build_snapshot(user_id: str = DEFAULT_USER_ID) -> dict:
+    ens = DEFAULT_ENS
+    wallet = DEFAULT_WALLET
+    resolved_wallet = resolve_identity(wallet) or "unknown"
+    loyalty = loyalty_score(user_id)
+    moral_values = parse_moral_framework(CORE_PATH)
+    sig_hash = hashlib.sha256(f"{ens}-{wallet}".encode()).hexdigest()[:10]
+
+    return {
+        "title": "Ghostkey-316: The Ethics Origin",
+        "ens": ens,
+        "wallet": wallet,
+        "resolved_wallet": resolved_wallet,
+        "visual_signature": f"signature-{sig_hash}",
+        "moral_framework": moral_values,
+        "loyalty_status": loyalty,
+        "system_phase": "Vaultfire Init",
+    }
+
+
+def main():
+    snapshot = build_snapshot()
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(SNAPSHOT_PATH, "w") as f:
+        json.dump(snapshot, f, indent=2)
+    print(json.dumps(snapshot, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a utility script `generate_contributor_snapshot.py`
- produce `dashboards/contributor_snapshot.json` with snapshot info

## Testing
- `python3 generate_contributor_snapshot.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687dcafb8964832298570305469394d8