### PR TITLE
Add alignment beacon broadcast utility

### DIFF
--- a/alignment_beacon.py
+++ b/alignment_beacon.py
@@ -1,0 +1,67 @@
+# Reference: ethics/core.mdx
+"""Broadcast Vaultfire alignment beacon."""
+
+import json
+import hashlib
+from pathlib import Path
+from datetime import datetime
+
+from vaultfire_signal import DEFAULT_IDENTITY, DEFAULT_WALLET
+from engine.identity_resolver import resolve_identity
+from record_signal_feed import update_signal_feed
+
+BASE_DIR = Path(__file__).resolve().parent
+ETHICS_PATH = BASE_DIR / "ethics" / "core.mdx"
+LOG_PATH = BASE_DIR / "logs" / "beacon_log.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def ethics_checksum() -> str:
+    """Return SHA256 checksum of the ethics core file."""
+    data = ETHICS_PATH.read_bytes()
+    return hashlib.sha256(data).hexdigest()
+
+
+def activation_state(identity: str = DEFAULT_IDENTITY, wallet: str = DEFAULT_WALLET) -> str:
+    """Return formatted activation state string and log entry."""
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    resolved = resolve_identity(wallet) or "unknown"
+    status = f"Vaultfire status: ACTIVE | Identity: {identity} | Wallet: {wallet} ({resolved})"
+    entry = f"[{timestamp}] {status}"
+    log = _load_json(LOG_PATH, [])
+    log.append({"timestamp": timestamp, "identity": identity, "wallet": wallet, "resolved": resolved})
+    _write_json(LOG_PATH, log)
+    print(entry)
+    return status
+
+
+def trigger_beacon():
+    """Broadcast ethics checksum and activation state via signal feed."""
+    checksum = ethics_checksum()
+    activation = activation_state()
+    beacon_entry = {
+        "ethics_checksum": checksum[:10],
+        "activation_state": activation,
+        "market_ready": True,
+    }
+    result = update_signal_feed(beacon_entry)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    trigger_beacon()

--- a/dashboards/signal_feed.json
+++ b/dashboards/signal_feed.json
@@ -17,5 +17,11 @@
     "ethics_trend": "\u2191",
     "last_payout": "2025-07-20T04:00:00Z",
     "next_unlock": "2025-07-24T12:00:00Z"
+  },
+  {
+    "timestamp": "2025-07-21T05:16:40Z",
+    "ethics_checksum": "8801d07ceb",
+    "activation_state": "Vaultfire status: ACTIVE | Identity: ghostkey316.eth | Wallet: bpow20.cb.id (cb1qexampleaddress0000000000000000000000)",
+    "market_ready": true
   }
 ]


### PR DESCRIPTION
## Summary
- add `alignment_beacon.py` for broadcasting ethics checksum and activation state
- log beacon messages to `logs/beacon_log.json`
- append beacon output to `dashboards/signal_feed.json`

## Testing
- `python3 -m py_compile alignment_beacon.py`
- `python3 alignment_beacon.py`

------
https://chatgpt.com/codex/tasks/task_e_687dcc62d07083229c981e025c17f182