### PR TITLE
Add passive yield simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,13 @@ Run the sandbox:
 python3 sandbox_belieftech.py
 ```
 
+## Passive Yield Simulator
+Use `engine/passive_yield_simulator.py` to generate passive yield payouts for
+contributors. Provide a JSON file mapping user IDs to engagement data.
+
+```bash
+python3 engine/passive_yield_simulator.py --data path/to/contributors.json --token ASM
+```
+
+Supported tokens are `ASM`, `USDC`, and `ETH`.
+

--- a/contributors_sample.json
+++ b/contributors_sample.json
@@ -1,0 +1,12 @@
+{
+  "alice": {
+    "wallet": "alice.eth",
+    "engagement": 5,
+    "behavior": ["mission_complete", "help_new_user"]
+  },
+  "bob": {
+    "wallet": "bob.eth",
+    "engagement": 2,
+    "behavior": ["ethical_action"]
+  }
+}

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -4,6 +4,7 @@
 from .identity_resolver import resolve_identity, resolve_ens, resolve_cb_id
 from .partner_hooks import record_usage, grant_reward
 from .revenue_hooks import record_contract_revenue, distribute_revenue
+from .passive_yield_simulator import simulate_passive_yield
 from .marketplace_plugins import (
     opensea_asset_url,
     github_sponsors_url,
@@ -25,4 +26,5 @@ __all__ = [
     "dapp_store_url",
     "record_link",
     "fetch_json",
+    "simulate_passive_yield",
 ]

--- a/engine/passive_yield_simulator.py
+++ b/engine/passive_yield_simulator.py
@@ -1,0 +1,110 @@
+# Reference: ethics/core.mdx
+"""Simulate passive yield payouts based on engagement and loyalty."""
+
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import Dict, List
+
+if __package__:
+    from .loyalty_engine import loyalty_score
+    from .token_ops import send_token
+else:  # pragma: no cover - executed as script
+    import sys
+    import importlib
+    CURRENT = Path(__file__).resolve()
+    sys.path.append(str(CURRENT.parents[1]))
+    loyalty_engine = importlib.import_module("engine.loyalty_engine")
+    token_ops = importlib.import_module("engine.token_ops")
+    loyalty_score = loyalty_engine.loyalty_score
+    send_token = token_ops.send_token
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+
+
+SUPPORTED_TOKENS = {"ASM", "USDC", "ETH"}
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+LEDGER_PATH = BASE_DIR / "logs" / "passive_yield_sim.json"
+
+
+# ---------------------------------------------------------------------------
+
+
+def simulate_passive_yield(contributors: Dict[str, Dict], token: str = "ASM") -> Dict[str, Dict]:
+    """Return payout ledger based on loyalty tier, engagement and behavior.
+
+    Parameters
+    ----------
+    contributors : dict
+        Mapping of ``user_id`` -> {"wallet": str, "engagement": int, "behavior": list[str]}
+    token : str
+        Currency for payouts. Must be one of ASM, ETH or USDC.
+    """
+    if token not in SUPPORTED_TOKENS:
+        raise ValueError(f"Unsupported token {token}")
+
+    ledger = {}
+    for user_id, info in contributors.items():
+        wallet = info.get("wallet")
+        if not wallet:
+            continue
+        loyalty = loyalty_score(user_id)
+        tier_score = loyalty.get("score", 0)
+        engagement = info.get("engagement", 0)
+        behavior_score = len(info.get("behavior", []))
+
+        # Weighted yield computation
+        yield_amount = 0.5 * tier_score + 0.3 * engagement + 0.2 * behavior_score
+        if yield_amount <= 0:
+            continue
+
+        send_token(wallet, yield_amount, token)
+        ledger[wallet] = {"amount": yield_amount, "currency": token}
+
+    _update_sim_ledger(ledger)
+    return ledger
+
+
+def _update_sim_ledger(entries: Dict[str, Dict]) -> None:
+    log = _load_json(LEDGER_PATH, [])
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    for wallet, data in entries.items():
+        log.append({"timestamp": timestamp, "wallet": wallet, **data})
+    _write_json(LEDGER_PATH, log)
+
+
+# ---------------------------------------------------------------------------
+
+
+def _cli():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Simulate passive yield payouts")
+    parser.add_argument("--data", required=True, help="JSON file of contributor data")
+    parser.add_argument("--token", choices=sorted(SUPPORTED_TOKENS), default="ASM", help="Payout currency")
+    args = parser.parse_args()
+
+    data = _load_json(Path(args.data), {})
+    ledger = simulate_passive_yield(data, args.token)
+    print(json.dumps(ledger, indent=2))
+
+
+if __name__ == "__main__":
+    _cli()


### PR DESCRIPTION
## Summary
- create `engine/passive_yield_simulator.py` with ETH/USDC/ASM support
- expose `simulate_passive_yield` in `engine.__init__`
- add documentation and sample contributor data

## Testing
- `python3 -m py_compile engine/passive_yield_simulator.py`
- `python3 engine/passive_yield_simulator.py --data contributors_sample.json --token ASM`


------
https://chatgpt.com/codex/tasks/task_e_687dd093192483229d37fd67ee7251ea