### PR TITLE
Implement off-chain engagement tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,21 @@ python3 engine/passive_yield_simulator.py --data path/to/contributors.json --tok
 
 Supported tokens are `ASM`, `USDC`, and `ETH`.
 
+## Off-Chain Engagement Tracker
+The module `engine/engagement_tracker.py` records likes, shares, scroll depth and reading time for any wallet or biometric identifier. Engagement data lives in `logs/engagement_data.json` with hashed IDs so metrics stay private. Use the tracker from the command line:
+
+```bash
+python3 engine/engagement_tracker.py mywallet.eth likes --value 1
+```
+
+Reveal a user's invisible credit when a reward is triggered:
+
+```bash
+python3 engine/engagement_tracker.py mywallet.eth --reveal
+```
+
+The onboarding API exposes `/engagement` for recording events and `/credit/<id>` to fetch the current score. No token purchase is required to qualify for rewards.
+
 
 ## Design DNA
 The project includes a short guide in `docs/design_culture.md` detailing the 90s-inspired look and our ethics-first approach to branding. It also covers simple UX principles and how to write human messages throughout the interface.

--- a/engine/engagement_tracker.py
+++ b/engine/engagement_tracker.py
@@ -1,0 +1,98 @@
+import json
+import hashlib
+from datetime import datetime
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DATA_PATH = BASE_DIR / "logs" / "engagement_data.json"
+LOG_PATH = BASE_DIR / "logs" / "engagement_log.json"
+
+DEFAULT_METRICS = {
+    "likes": 0,
+    "shares": 0,
+    "scroll_depth": 0.0,
+    "read_time": 0.0,
+}
+
+WEIGHTS = {
+    "likes": 0.5,
+    "shares": 1.0,
+    "scroll_depth": 0.3,
+    "read_time": 0.2,
+}
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _hash_identifier(identifier: str) -> str:
+    return hashlib.sha256(identifier.encode()).hexdigest()
+
+
+def record_event(identifier: str, event_type: str, value: float = 1.0) -> None:
+    """Record a user engagement event."""
+    hashed = _hash_identifier(identifier)
+    data = _load_json(DATA_PATH, {})
+    user = data.get(hashed, DEFAULT_METRICS.copy())
+    if event_type in user:
+        user[event_type] += value
+    data[hashed] = user
+    _write_json(DATA_PATH, data)
+
+    log = _load_json(LOG_PATH, [])
+    log.append({
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "id": hashed,
+        "event": event_type,
+        "value": value,
+    })
+    _write_json(LOG_PATH, log)
+
+
+def compute_credit(identifier: str) -> float:
+    """Return the invisible credit score for ``identifier``."""
+    hashed = _hash_identifier(identifier)
+    data = _load_json(DATA_PATH, {})
+    metrics = data.get(hashed)
+    if not metrics:
+        return 0.0
+    score = 0.0
+    for metric, weight in WEIGHTS.items():
+        score += metrics.get(metric, 0) * weight
+    return score
+
+
+def reveal_credit(identifier: str) -> dict:
+    """Return credit details for ``identifier``."""
+    credit = compute_credit(identifier)
+    return {"id": _hash_identifier(identifier), "credit": credit}
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Off-chain engagement tracker")
+    parser.add_argument("identifier", help="wallet or biometric identifier")
+    parser.add_argument("event", nargs="?", help="event type to record")
+    parser.add_argument("--value", type=float, default=1.0, help="event value")
+    parser.add_argument("--reveal", action="store_true", help="reveal credit")
+    args = parser.parse_args()
+
+    if args.event:
+        record_event(args.identifier, args.event, args.value)
+    if args.reveal:
+        info = reveal_credit(args.identifier)
+        print(json.dumps(info, indent=2))

--- a/onboarding_api.py
+++ b/onboarding_api.py
@@ -82,6 +82,28 @@ def onboard_earner():
     return jsonify({"message": "earner onboarded"}), 201
 
 
+@app.post("/engagement")
+def record_engagement():
+    """Record a user engagement event."""
+    data = request.get_json(silent=True) or {}
+    identifier = data.get("identifier")
+    event = data.get("event")
+    value = float(data.get("value", 1))
+    if not identifier or not event:
+        return jsonify({"error": "identifier and event required"}), 400
+    from engine.engagement_tracker import record_event
+    record_event(identifier, event, value)
+    return jsonify({"message": "event recorded"}), 201
+
+
+@app.get("/credit/<identifier>")
+def reveal_credit(identifier):
+    """Reveal invisible credit score for identifier."""
+    from engine.engagement_tracker import reveal_credit
+    info = reveal_credit(identifier)
+    return jsonify(info)
+
+
 @app.get("/status")
 def status():
     return jsonify({"status": "ok"})


### PR DESCRIPTION
## Summary
- add `engagement_tracker.py` for invisible credit calculation
- expose `/engagement` and `/credit/<identifier>` endpoints in `onboarding_api.py`
- document usage in README

## Testing
- `python3 system_integrity_check.py` *(fails: no wallet for user sample_user)*

------
https://chatgpt.com/codex/tasks/task_e_687ddeb0727c8322b63cc408524aca88