### PR TITLE
Add mission registry with encrypted statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,3 +272,4 @@ The `engine/governance.py` module handles steward elections and proposal freezes
 ## Disclaimers
 - This repository is experimental software provided for learning and discussion.
 - Nothing here constitutes financial or legal advice.
+- Mission statements are stored with lightweight XOR-based obfuscation. This is not strong encryption.

--- a/engine/alignment_feedback.py
+++ b/engine/alignment_feedback.py
@@ -2,6 +2,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
+from engine.mission_registry import get_mission
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 FEEDBACK_PATH = BASE_DIR / "logs" / "alignment_feedback.json"
@@ -49,6 +50,9 @@ def record_alignment_feedback(user_id: str, decision: str, rating: int, comment:
     }
     if comment:
         entry["comment"] = comment
+    mission = get_mission(user_id)
+    if mission:
+        entry["mission"] = mission
     log = _load_json(FEEDBACK_PATH, [])
     log.append(entry)
     _write_json(FEEDBACK_PATH, log)

--- a/engine/mission_registry.py
+++ b/engine/mission_registry.py
@@ -1,0 +1,85 @@
+# Reference: ethics/core.mdx
+"""Mission statement registry with simple XOR-based encryption."""
+
+import json
+import os
+import base64
+from pathlib import Path
+from datetime import datetime
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DATA_PATH = BASE_DIR / "missions.json"
+DEFAULT_KEY = os.environ.get("MISSION_KEY", "vaultfire")
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+# --- Very lightweight XOR cipher (not secure) ------------------------------
+
+def _xor_cipher(text: str, key: str) -> bytes:
+    key_bytes = key.encode()
+    data_bytes = text.encode()
+    return bytes(b ^ key_bytes[i % len(key_bytes)] for i, b in enumerate(data_bytes))
+
+
+def encrypt_mission(mission: str, key: str | None = None) -> str:
+    key = key or DEFAULT_KEY
+    cipher = _xor_cipher(mission, key)
+    return base64.urlsafe_b64encode(cipher).decode()
+
+
+def decrypt_mission(token: str, key: str | None = None) -> str:
+    key = key or DEFAULT_KEY
+    data = base64.urlsafe_b64decode(token.encode())
+    plain = bytes(b ^ key.encode()[i % len(key) ] for i, b in enumerate(data))
+    return plain.decode()
+
+
+# --- Mission registry functions -------------------------------------------
+
+def record_mission(user_id: str, wallet: str, mission: str, key: str | None = None) -> dict:
+    """Store encrypted ``mission`` for ``user_id`` and associated ``wallet``."""
+    data = _load_json(DATA_PATH, {})
+    enc = encrypt_mission(mission, key)
+    entry = {"wallet": wallet, "mission": enc, "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")}
+    data[user_id] = entry
+    _write_json(DATA_PATH, data)
+    return entry
+
+
+def get_mission(user_id: str, key: str | None = None) -> str | None:
+    data = _load_json(DATA_PATH, {})
+    entry = data.get(user_id)
+    if not entry:
+        return None
+    try:
+        return decrypt_mission(entry.get("mission", ""), key)
+    except Exception:
+        return None
+
+
+def get_mission_by_wallet(wallet: str, key: str | None = None) -> str | None:
+    data = _load_json(DATA_PATH, {})
+    for uid, entry in data.items():
+        if entry.get("wallet") == wallet:
+            try:
+                return decrypt_mission(entry.get("mission", ""), key)
+            except Exception:
+                return None
+    return None
+
+

--- a/engine/yield_engine_v1.py
+++ b/engine/yield_engine_v1.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from .loyalty_engine import loyalty_score
 from .token_ops import send_token
+from .mission_registry import get_mission
 
 # Paths to data and config files
 BASE_DIR = Path(__file__).resolve().parents[1]
@@ -168,11 +169,15 @@ def distribute_rewards(contributor_data):
         wallet = info.get("wallet")
         behavior = info.get("behavior", [])
         amount = calculate_yield(user_id, wallet, behavior)
-        ledger[wallet] = {
+        mission = get_mission(user_id)
+        entry = {
             "amount": amount,
             "currency": "ASM",
             "morals_approved": True,
         }
+        if mission:
+            entry["mission_echo"] = mission
+        ledger[wallet] = entry
         _log_audit({"action": "reward", "user_id": user_id,
                     "wallet": wallet, "approved": True,
                     "amount": amount})

--- a/onboarding_api.py
+++ b/onboarding_api.py
@@ -82,6 +82,21 @@ def onboard_earner():
     return jsonify({"message": "earner onboarded"}), 201
 
 
+@app.post("/mission")
+def submit_mission():
+    """Record a personal mission statement for a contributor."""
+    data = request.get_json(silent=True) or {}
+    user_id = data.get("user_id")
+    mission = data.get("mission")
+    if not user_id or not mission:
+        return jsonify({"error": "user_id and mission required"}), 400
+    scorecard = _load_json(SCORECARD_PATH, {})
+    wallet = data.get("wallet") or scorecard.get(user_id, {}).get("wallet", "")
+    from engine.mission_registry import record_mission
+    record_mission(user_id, wallet, mission)
+    return jsonify({"message": "mission recorded"}), 201
+
+
 @app.post("/engagement")
 def record_engagement():
     """Record a user engagement event."""


### PR DESCRIPTION
## Summary
- enable mission statements via new `mission_registry` module
- accept mission submissions in `onboarding_api`
- echo mission during reward distribution
- include mission info in alignment feedback
- note lightweight XOR obfuscation in README disclaimers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687de2d7a6dc832282deffa0d71914c7