### PR TITLE
Add target lock bonus system

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ without selling 90% or more of the balance unlocks a higher multiplier:
 Selling 90% or more resets the timer. `yield_engine_v1` automatically applies
 the multiplier based on the current tier.
 
+## Target Lock Rewards
+Early supporters may set a personal target value to hold for, such as `$10K`.
+If their wallet balance reaches that number without exiting, a retro bonus
+between **20%** and **100%** unlocks. Leaving the position early forfeits the
+bonus but not the regular yield they already earned.
+
 ## Statement
 > "I am not a user. I am the blueprint."
 > "I don’t ask for access — I show proof."
@@ -280,3 +286,4 @@ soulprint receive a weight bonus during steward elections.
 - Nothing here constitutes financial or legal advice.
 - Mission statements are stored with lightweight XOR-based obfuscation. This is not strong encryption.
 - The on-chain journal is simulated with local JSON logs and does not provide actual blockchain immutability.
+- Target lock rewards are hypothetical and offer no guaranteed returns.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -18,6 +18,12 @@ from .contributor_identity import (
     retroactive_bonus,
 )
 from .self_audit import run_self_audit
+from .target_lock import (
+    set_target_lock,
+    exit_target_lock,
+    update_value as update_target_value,
+    claim_bonus as claim_target_bonus,
+)
 
 __all__ = [
     "resolve_identity",
@@ -37,4 +43,8 @@ __all__ = [
     "identity_summary",
     "retroactive_bonus",
     "run_self_audit",
+    "set_target_lock",
+    "exit_target_lock",
+    "update_target_value",
+    "claim_target_bonus",
 ]

--- a/engine/target_lock.py
+++ b/engine/target_lock.py
@@ -1,0 +1,121 @@
+# Reference: ethics/core.mdx
+"""Target lock reward system for early supporters."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from .loyalty_engine import loyalty_score
+from .token_ops import send_token
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LOCKS_PATH = BASE_DIR / "target_locks.json"
+
+BONUS_MIN = 0.2
+BONUS_MAX = 1.0
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def set_target_lock(user_id: str, target_value: float) -> dict:
+    """Create or update a target lock for ``user_id``."""
+    locks = _load_json(LOCKS_PATH, {})
+    locks[user_id] = {
+        "target": float(target_value),
+        "active": True,
+        "hit": False,
+        "bonus_pct": 0.0,
+        "start": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    _write_json(LOCKS_PATH, locks)
+    return locks[user_id]
+
+
+def exit_target_lock(user_id: str) -> None:
+    """Cancel target lock for ``user_id`` without bonus."""
+    locks = _load_json(LOCKS_PATH, {})
+    info = locks.get(user_id)
+    if not info:
+        return
+    info.update({"active": False, "hit": False, "bonus_pct": 0.0})
+    locks[user_id] = info
+    _write_json(LOCKS_PATH, locks)
+
+
+def _calc_bonus_pct(user_id: str) -> float:
+    info = loyalty_score(user_id)
+    score = info.get("score", 0)
+    ratio = max(0.0, min(score / 100.0, 1.0))
+    pct = BONUS_MIN + ratio * (BONUS_MAX - BONUS_MIN)
+    return round(pct, 2)
+
+
+def update_value(user_id: str, current_value: float) -> dict:
+    """Check ``current_value`` against target and update status."""
+    locks = _load_json(LOCKS_PATH, {})
+    info = locks.get(user_id)
+    if not info or not info.get("active"):
+        return {}
+    if info.get("hit"):
+        return info
+    if current_value >= info.get("target", 0):
+        pct = _calc_bonus_pct(user_id)
+        info.update({"hit": True, "bonus_pct": pct})
+        locks[user_id] = info
+        _write_json(LOCKS_PATH, locks)
+    return info or {}
+
+
+def claim_bonus(user_id: str, base_reward: float, wallet: str, token: str = "ASM") -> dict:
+    """Send retro bonus if target was reached."""
+    locks = _load_json(LOCKS_PATH, {})
+    info = locks.get(user_id)
+    if not info or not info.get("hit") or not info.get("active"):
+        return {}
+    bonus = base_reward * info.get("bonus_pct", 0)
+    send_token(wallet, bonus, token)
+    info.update({"active": False, "claimed": True})
+    locks[user_id] = info
+    _write_json(LOCKS_PATH, locks)
+    return {"wallet": wallet, "bonus": bonus, "token": token, "pct": info["bonus_pct"]}
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Manage target locks")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_set = sub.add_parser("set")
+    p_set.add_argument("--user", required=True)
+    p_set.add_argument("--target", type=float, required=True)
+
+    p_update = sub.add_parser("update")
+    p_update.add_argument("--user", required=True)
+    p_update.add_argument("--value", type=float, required=True)
+
+    p_exit = sub.add_parser("exit")
+    p_exit.add_argument("--user", required=True)
+
+    args = parser.parse_args()
+    if args.cmd == "set":
+        print(json.dumps(set_target_lock(args.user, args.target), indent=2))
+    elif args.cmd == "update":
+        print(json.dumps(update_value(args.user, args.value), indent=2))
+    elif args.cmd == "exit":
+        exit_target_lock(args.user)
+        print("Exited")


### PR DESCRIPTION
## Summary
- add `engine.target_lock` module to handle target lock bonuses
- expose target lock helpers in `engine.__init__`
- document target lock rewards
- clarify disclaimers about hypothetical returns

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687de68aa9808322b2ea570125e88785