### PR TITLE
Add ethics filter ranking for marketplace listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,16 @@ record_link("blueprint-1", "opensea", url)
 The module also exposes `github_sponsors_url` and `dapp_store_url` helpers for
 connecting other storefronts or Web3 dApp directories.
 
+## Ethics Filter for Listings
+The module `engine.ethics_filter` scores each marketplace item in real time. Scores cover **Transparency**, **Truthfulness**, **User Care**, and **Fair Rewards** using `wallet_insights.json`, `community_reviews.json`, and `tokenomics_fairness.json`.
+
+```bash
+python3 -m engine.ethics_filter
+```
+
+Running the module refreshes `marketplace_ranked.json` so high-ethics listings appear first.
+
+
 ## Contributor Identity Sync
 The module `engine.contributor_identity` links wallets, social handles and
 behavior patterns into a single profile. Reputation multipliers and access

--- a/dashboards/community_reviews.json
+++ b/dashboards/community_reviews.json
@@ -1,0 +1,5 @@
+{
+  "tool_ai_booster": [5,5,4],
+  "prompt_pack_01": [4,4,5],
+  "basic_prompts_pack": [2,1,2]
+}

--- a/dashboards/marketplace_ranked.json
+++ b/dashboards/marketplace_ranked.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "tool_ai_booster",
+    "name": "AI Booster Tool",
+    "price": 100,
+    "currency": "ASM",
+    "category": "Verified Vaultfire Tools",
+    "seller": {
+      "name": "ghostkey316",
+      "signal_score": 97,
+      "avatar": ""
+    },
+    "ethics_rank": "A",
+    "signal": 98,
+    "ethics_verified": true,
+    "transparency": 1.0,
+    "truthfulness": 0.93,
+    "user_care": 0.28,
+    "fair_rewards": 1.0,
+    "ethics_score": 80.33
+  },
+  {
+    "id": "prompt_pack_01",
+    "name": "Productivity Prompt Pack",
+    "price": 25,
+    "currency": "USDC",
+    "category": "Prompt Blueprints",
+    "seller": {
+      "name": "builder__loop",
+      "signal_score": 92,
+      "avatar": ""
+    },
+    "ethics_rank": "A",
+    "signal": 89,
+    "ethics_verified": true,
+    "transparency": 1.0,
+    "truthfulness": 0.87,
+    "user_care": 0.26,
+    "fair_rewards": 0.8,
+    "ethics_score": 73.17
+  },
+  {
+    "id": "basic_prompts_pack",
+    "name": "Basic Prompts Pack",
+    "price": 5,
+    "currency": "USDC",
+    "category": "Prompt Blueprints",
+    "seller": {
+      "name": "low_score_vendor",
+      "signal_score": 75,
+      "avatar": ""
+    },
+    "ethics_rank": "B",
+    "signal": 70,
+    "ethics_verified": false,
+    "transparency": 0.0,
+    "truthfulness": 0.33,
+    "user_care": 0.1,
+    "fair_rewards": 0.4,
+    "ethics_score": 20.83
+  }
+]

--- a/dashboards/tokenomics_fairness.json
+++ b/dashboards/tokenomics_fairness.json
@@ -1,0 +1,5 @@
+{
+  "tool_ai_booster": 5,
+  "prompt_pack_01": 4,
+  "basic_prompts_pack": 2
+}

--- a/dashboards/wallet_insights.json
+++ b/dashboards/wallet_insights.json
@@ -1,0 +1,5 @@
+{
+  "ghostkey316": {"flagged": false},
+  "builder__loop": {"flagged": false},
+  "low_score_vendor": {"flagged": true}
+}

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -24,6 +24,7 @@ from .target_lock import (
     update_value as update_target_value,
     claim_bonus as claim_target_bonus,
 )
+from .ethics_filter import rank_listings
 
 __all__ = [
     "resolve_identity",
@@ -47,4 +48,5 @@ __all__ = [
     "exit_target_lock",
     "update_target_value",
     "claim_target_bonus",
+    "rank_listings",
 ]

--- a/engine/ethics_filter.py
+++ b/engine/ethics_filter.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LISTINGS_PATH = BASE_DIR / "dashboards" / "marketplace_listings.json"
+RANKED_PATH = BASE_DIR / "dashboards" / "marketplace_ranked.json"
+WALLET_PATH = BASE_DIR / "dashboards" / "wallet_insights.json"
+REVIEWS_PATH = BASE_DIR / "dashboards" / "community_reviews.json"
+TOKEN_PATH = BASE_DIR / "dashboards" / "tokenomics_fairness.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _avg(values: list[float]) -> float:
+    if not values:
+        return 3.0
+    return sum(values) / len(values)
+
+
+def calculate_score(listing: dict, wallets: dict, reviews: dict, tokenomics: dict) -> dict:
+    seller = listing.get("seller", {})
+    name = seller.get("name")
+    wallet_info = wallets.get(name, {})
+    flagged = wallet_info.get("flagged", False)
+
+    transparency = 1.0 if listing.get("ethics_verified") else 0.5
+    if flagged:
+        transparency = max(transparency - 0.5, 0.0)
+
+    rev_scores = reviews.get(listing.get("id"), [])
+    truthfulness = _avg(rev_scores) / 5.0
+    user_care = min(len(rev_scores) / 10, 1.0) * truthfulness
+
+    token_score = tokenomics.get(listing.get("id"), 3) / 5.0
+    fair_rewards = token_score
+
+    total = (transparency + truthfulness + user_care + fair_rewards) / 4 * 100
+    return {
+        "transparency": round(transparency, 2),
+        "truthfulness": round(truthfulness, 2),
+        "user_care": round(user_care, 2),
+        "fair_rewards": round(fair_rewards, 2),
+        "ethics_score": round(total, 2),
+    }
+
+
+def rank_listings() -> list[dict]:
+    listings = _load_json(LISTINGS_PATH, [])
+    wallets = _load_json(WALLET_PATH, {})
+    reviews = _load_json(REVIEWS_PATH, {})
+    tokenomics = _load_json(TOKEN_PATH, {})
+
+    ranked = []
+    for item in listings:
+        score = calculate_score(item, wallets, reviews, tokenomics)
+        ranked.append({**item, **score})
+
+    ranked.sort(key=lambda x: x["ethics_score"], reverse=True)
+    _write_json(RANKED_PATH, ranked)
+    return ranked
+
+
+if __name__ == "__main__":
+    data = rank_listings()
+    print(json.dumps(data, indent=2))


### PR DESCRIPTION
## Summary
- add `engine.ethics_filter` module for live ethics scoring
- expose `rank_listings` in `engine/__init__.py`
- document usage in README
- seed example data for wallet insights, community reviews, tokenomics
- generate `marketplace_ranked.json` from the scoring module

## Testing
- `python3 -m py_compile engine/ethics_filter.py`
- `python3 -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_687de97d0c8c8322b17aa0b531b9f8e0