### PR TITLE
Implement governance shutdown vote

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The onboarding API exposes `/engagement` for recording events and `/credit/<id>`
 The project includes a short guide in `docs/design_culture.md` detailing the 90s-inspired look and our ethics-first approach to branding. It also covers simple UX principles and how to write human messages throughout the interface.
 
 ## Governance
-The `engine/governance.py` module handles steward elections and proposal freezes. See `docs/governance.md` for details.
+The `engine/governance.py` module handles steward elections and proposal freezes. See `docs/governance.md` for details. It now exposes an emergency shutdown vote if stewards detect system abuse or partner corruption. Approved votes pause all partners and run a transparency audit.
 
 ## Soulprint Journal
 Contributors may append immutable entries to `journals/<id>.json` using the

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -8,3 +8,11 @@ This module introduces election-based oversight.
 - Stewards cannot execute protocol changes. Their sole power is freezing a proposal that breaches **truth**, **loyalty**, or **transparency**.
 - Any contributor may anonymously flag a proposal. After a 24‑hour delay, flagged items are reviewed and frozen if warranted.
 - Proposal status and steward votes are stored under the `governance/` directory.
+
+## Emergency Shutdown Vote
+
+If governance detects **system abuse**, **false beliefs**, or **partner corruption**, any steward may call `propose_shutdown`.
+A majority of stewards must vote yes for the shutdown to proceed. Once approved,
+all partners are paused and a transparency audit runs automatically. The
+`governance/shutdown_log.json` file records every trigger condition, vote, and
+audit outcome for public review.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -25,6 +25,11 @@ from .target_lock import (
     claim_bonus as claim_target_bonus,
 )
 from .ethics_filter import rank_listings
+from .shutdown_manager import (
+    initiate_shutdown_vote,
+    cast_vote as cast_shutdown_vote,
+    tally_votes as tally_shutdown_votes,
+)
 
 __all__ = [
     "resolve_identity",
@@ -49,4 +54,7 @@ __all__ = [
     "update_target_value",
     "claim_target_bonus",
     "rank_listings",
+    "initiate_shutdown_vote",
+    "cast_shutdown_vote",
+    "tally_shutdown_votes",
 ]

--- a/engine/governance.py
+++ b/engine/governance.py
@@ -77,6 +77,9 @@ def elect_stewards() -> List[str]:
 ETHICAL_VALUES = {"truth", "loyalty", "transparency"}
 DECISION_DELAY_HOURS = 24
 
+# Shutdown triggers
+SHUTDOWN_REASONS = {"system_abuse", "false_belief", "partner_corruption"}
+
 
 def submit_proposal(author: str, description: str) -> Dict:
     """Create a new proposal in pending state."""
@@ -140,6 +143,18 @@ def review_flags(min_delay_hours: int = DECISION_DELAY_HOURS) -> List[str]:
     return changed
 
 
+# ---------------------------------------------------------------------------
+# Shutdown vote helpers
+# ---------------------------------------------------------------------------
+
+def propose_shutdown(reason: str) -> dict:
+    """Trigger a shutdown vote for ``reason``."""
+    if reason not in SHUTDOWN_REASONS:
+        raise ValueError("invalid reason")
+    from .shutdown_manager import initiate_shutdown_vote
+    return initiate_shutdown_vote(reason)
+
+
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Governance utilities")
@@ -156,6 +171,15 @@ if __name__ == "__main__":
     p_flag.add_argument("reason")
     p_flag.add_argument("--id", help="flagger id")
 
+    p_shutdown = sub.add_parser("shutdown")
+    p_shutdown.add_argument("reason", choices=list(SHUTDOWN_REASONS))
+
+    p_vote = sub.add_parser("vote-shutdown")
+    p_vote.add_argument("steward")
+    p_vote.add_argument("vote", choices=["yes", "no"])
+
+    sub.add_parser("tally-shutdown")
+
     args = parser.parse_args()
     if args.cmd == "elect":
         print(json.dumps(elect_stewards(), indent=2))
@@ -164,5 +188,13 @@ if __name__ == "__main__":
     elif args.cmd == "flag":
         flag_proposal(args.pid, args.reason, anonymous=not bool(args.id))
         review_flags()
+    elif args.cmd == "shutdown":
+        print(json.dumps(propose_shutdown(args.reason), indent=2))
+    elif args.cmd == "vote-shutdown":
+        from .shutdown_manager import cast_vote
+        cast_vote(args.steward, args.vote == "yes")
+    elif args.cmd == "tally-shutdown":
+        from .shutdown_manager import tally_votes
+        print(json.dumps({"approved": tally_votes()}, indent=2))
     else:
         parser.print_help()

--- a/engine/shutdown_manager.py
+++ b/engine/shutdown_manager.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+"""Shutdown management utilities for Vaultfire governance."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+GOV_DIR = BASE_DIR / "governance"
+PARTNERS_PATH = BASE_DIR / "partners.json"
+SHUTDOWN_LOG_PATH = GOV_DIR / "shutdown_log.json"
+SHUTDOWN_STATE_PATH = GOV_DIR / "shutdown_state.json"
+SHUTDOWN_VOTES_PATH = GOV_DIR / "shutdown_votes.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _log(entry) -> None:
+    log = _load_json(SHUTDOWN_LOG_PATH, [])
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    log.append({"timestamp": timestamp, **entry})
+    _write_json(SHUTDOWN_LOG_PATH, log)
+
+
+# ---------------------------------------------------------------------------
+# Voting
+# ---------------------------------------------------------------------------
+
+def initiate_shutdown_vote(reason: str) -> dict:
+    """Start a new shutdown vote."""
+    state = {
+        "reason": reason,
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "active": True,
+    }
+    _write_json(SHUTDOWN_STATE_PATH, state)
+    _write_json(SHUTDOWN_VOTES_PATH, {})
+    _log({"action": "initiate_vote", "reason": reason})
+    return state
+
+
+def cast_vote(steward_id: str, approve: bool) -> dict:
+    """Record ``steward_id`` vote on active shutdown proposal."""
+    votes = _load_json(SHUTDOWN_VOTES_PATH, {})
+    votes[steward_id] = approve
+    _write_json(SHUTDOWN_VOTES_PATH, votes)
+    _log({"action": "cast_vote", "steward": steward_id, "approve": approve})
+    return votes
+
+
+def tally_votes() -> bool:
+    """Return True if majority of stewards approved shutdown."""
+    votes = _load_json(SHUTDOWN_VOTES_PATH, {})
+    stewards = _load_json(GOV_DIR / "stewards.json", [])
+    yes = sum(1 for v in votes.values() if v)
+    required = max(1, len(stewards) // 2 + 1)
+    approved = yes >= required
+    _log({"action": "tally", "yes": yes, "required": required, "approved": approved})
+    if approved:
+        activate_shutdown()
+    return approved
+
+
+# ---------------------------------------------------------------------------
+# Shutdown actions
+# ---------------------------------------------------------------------------
+
+def activate_shutdown() -> None:
+    """Pause partners and run transparency audit."""
+    partners = _load_json(PARTNERS_PATH, [])
+    for p in partners:
+        p["paused"] = True
+    _write_json(PARTNERS_PATH, partners)
+    _log({"action": "partners_paused", "count": len(partners)})
+
+    from .self_audit import run_self_audit
+
+    audit_result = run_self_audit()
+    _log({"action": "transparency_audit", "result": audit_result})
+
+    state = _load_json(SHUTDOWN_STATE_PATH, {})
+    state["active"] = False
+    state["shutdown"] = True
+    _write_json(SHUTDOWN_STATE_PATH, state)
+


### PR DESCRIPTION
## Summary
- add `shutdown_manager` with pause + audit logic
- extend governance module for emergency shutdown votes
- expose shutdown functions in engine API
- document emergency shutdown vote
- mention shutdown voting in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687deafe6ad48322a7570c6e03fa63fa