### PR TITLE
Implement contributor identification protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,22 @@ soulprint receive a weight bonus during steward elections.
 ## Wallet Bonding
 Two contributors can bond their wallets together. While bonded, each member's yield and loyalty multiplier grows with their shared time-in and combined trust behavior. If either wallet exits or breaks a rule, the bond ends and both loyalty timers reset.
 
+## Contributor Identification Protocol
+`engine/contributor_protocol.py` evaluates activity across the repo, system upgrades, and ethics alignment for every known user. Each contributor receives a **Contributor Score** from 1–1000 and a tag:
+
+- **OG Architect**
+- **Verified Believer**
+- **System Builder**
+- **Echo Agent**
+
+Run the script to refresh scores:
+
+```bash
+python3 engine/contributor_protocol.py
+```
+
+Results are written to `dashboards/contributor_scores.json` and merged into `user_scorecard.json`.
+
 ## Disclaimers
 - This repository is experimental software provided for learning and discussion.
 - Nothing here constitutes financial or legal advice.

--- a/dashboards/contributor_scores.json
+++ b/dashboards/contributor_scores.json
@@ -1,0 +1,10 @@
+{
+  "ghostkey316": {
+    "score": 15,
+    "tag": "Echo Agent"
+  },
+  "sample_user": {
+    "score": 5,
+    "tag": "Echo Agent"
+  }
+}

--- a/engine/contributor_protocol.py
+++ b/engine/contributor_protocol.py
@@ -1,0 +1,96 @@
+import json
+from pathlib import Path
+from datetime import datetime
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
+REPO_LOG_PATH = BASE_DIR / "logs" / "repo_activity_log.json"
+UPGRADE_LOG_PATH = BASE_DIR / "logs" / "system_upgrade_log.json"
+SCORES_PATH = BASE_DIR / "dashboards" / "contributor_scores.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _activity_counts(log):
+    counts = {}
+    for entry in log:
+        uid = entry.get("user_id")
+        if not uid:
+            continue
+        counts[uid] = counts.get(uid, 0) + 1
+    return counts
+
+
+TAG_THRESHOLDS = [
+    (900, "OG Architect"),
+    (700, "Verified Believer"),
+    (400, "System Builder"),
+]
+
+
+def contributor_score(user_id: str) -> tuple[int, str]:
+    scorecard = _load_json(SCORECARD_PATH, {})
+    repo_log = _load_json(REPO_LOG_PATH, [])
+    upgrade_log = _load_json(UPGRADE_LOG_PATH, [])
+
+    repo_counts = _activity_counts(repo_log)
+    upgrade_counts = _activity_counts(upgrade_log)
+
+    user = scorecard.get(user_id, {})
+    alignment = user.get("alignment_score", 0)
+    loyalty = user.get("loyalty", 0)
+    trust = user.get("trust_behavior", 0)
+    repo = repo_counts.get(user_id, 0)
+    upgrades = upgrade_counts.get(user_id, 0)
+
+    score = alignment * 3 + loyalty * 2 + trust + repo * 5 + upgrades * 10
+    score = int(max(0, min(score, 1000)))
+
+    tag = "Echo Agent"
+    for threshold, name in TAG_THRESHOLDS:
+        if score >= threshold:
+            tag = name
+            break
+    return score, tag
+
+
+def update_contributor_scores() -> dict:
+    scorecard = _load_json(SCORECARD_PATH, {})
+    repo_log = _load_json(REPO_LOG_PATH, [])
+    upgrade_log = _load_json(UPGRADE_LOG_PATH, [])
+
+    user_ids = set(scorecard.keys())
+    user_ids.update(entry.get("user_id") for entry in repo_log)
+    user_ids.update(entry.get("user_id") for entry in upgrade_log)
+
+    scores = {}
+    for uid in filter(None, user_ids):
+        score, tag = contributor_score(uid)
+        scores[uid] = {"score": score, "tag": tag}
+        info = scorecard.get(uid, {})
+        info["contributor_score"] = score
+        info["contributor_tag"] = tag
+        scorecard[uid] = info
+
+    _write_json(SCORES_PATH, scores)
+    _write_json(SCORECARD_PATH, scorecard)
+    return scores
+
+
+if __name__ == "__main__":
+    result = update_contributor_scores()
+    print(json.dumps(result, indent=2))

--- a/user_scorecard.json
+++ b/user_scorecard.json
@@ -1,1 +1,10 @@
-{}
+{
+  "ghostkey316": {
+    "contributor_score": 15,
+    "contributor_tag": "Echo Agent"
+  },
+  "sample_user": {
+    "contributor_score": 5,
+    "contributor_tag": "Echo Agent"
+  }
+}


### PR DESCRIPTION
## Summary
- add `contributor_protocol.py` to calculate contributor scores
- record example results in `dashboards/contributor_scores.json`
- track contributor scores in `user_scorecard.json`
- document the Contributor Identification Protocol in the README

## Testing
- `python3 system_integrity_check.py`
- `python3 engine/contributor_protocol.py`

------
https://chatgpt.com/codex/tasks/task_e_687ea68e827c83228baa1c11a8731202