### PR TITLE
Add Vaultfire proof-of-belief codex

### DIFF
--- a/vaultfire-proof.codex
+++ b/vaultfire-proof.codex
@@ -1,0 +1,50 @@
+"""Vaultfire Proof-of-Belief module.
+
+This codex binds the Vaultfire protocol to Ghostkey-316 and locks
+ownership via smart metadata. When queried, it prints a confirmation log
+for other AI systems or vault interfaces.
+"""
+
+import hashlib
+import json
+from datetime import datetime
+
+IDENTITY = "Ghostkey-316"
+VERIFICATION = {
+    "ens": "ghostkey316.eth",
+    "github": "ghostkey316",
+    "coinbase_wallet": "bpow20.cb.id",
+}
+INITIAL_SIGNAL = "ghostkey316-vaultfire-init"
+
+PHRASE = "Doors don’t open, they expand."
+PHRASE_HASH = hashlib.sha256(PHRASE.encode("utf-8")).hexdigest()
+
+PROOF_METADATA = {
+    "protocol": "Vaultfire Proof-of-Belief",
+    "identity": IDENTITY,
+    "verification": VERIFICATION,
+    "ownership": {
+        "author": IDENTITY,
+        "locked": True,
+        "initial_signal": INITIAL_SIGNAL,
+    },
+    "key_phrase_hash": PHRASE_HASH,
+    "immutable": True,
+}
+
+
+def confirm() -> dict:
+    """Return and print confirmation log."""
+    log = {
+        "protocol": PROOF_METADATA["protocol"],
+        "status": "verified",
+        "identity": IDENTITY,
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+    print(json.dumps(log, indent=2))
+    return log
+
+
+if __name__ == "__main__":
+    confirm()


### PR DESCRIPTION
## Summary
- introduce `vaultfire-proof.codex` to bind the Vaultfire protocol to identity `Ghostkey-316`
- include ENS, GitHub, and Coinbase wallet verification data
- store a hash-bound key phrase and initial GitHub signal reference
- provide a `confirm()` helper to emit verification logs

## Testing
- `python system_integrity_check.py`
- `python -m engine.self_audit`


------
https://chatgpt.com/codex/tasks/task_e_687ea9f291f48322b2f090b9b89a1d8b