### PR TITLE
Add wallet auth module

### DIFF
--- a/vaultfire-core/vaultfire_config.json
+++ b/vaultfire-core/vaultfire_config.json
@@ -4,5 +4,6 @@
   "monetization_mode": "Behavioral Yield + Contributor Split",
   "public_visibility": "controlled",
   "partner_hooks_enabled": true,
+  "wallet_auth_hook": true,
   "fail_safe": "Hard shutdown on ethics breach"
 }

--- a/wallet_auth.ts
+++ b/wallet_auth.ts
@@ -1,0 +1,41 @@
+const ENS_MAP: Record<string, string> = {
+  'ghostkey316.eth': '0x9abCDEF1234567890abcdefABCDEF1234567890',
+  'sample.eth': '0x0000000000000000000000000000000000000001',
+};
+
+const CB_ID_MAP: Record<string, string> = {
+  'bpow20.cb.id': 'cb1qexampleaddress0000000000000000000000',
+};
+
+const ALLOWED_DOMAINS = ['.eth', '.cb.id'];
+const FALLBACK_DOMAIN = 'vaultfire.eth';
+
+export function authenticateWallet(identifier: string, acceptedDomains: string[] = ALLOWED_DOMAINS): string {
+  let name = identifier.trim().toLowerCase();
+  const hasDomain = /\.[^\.\s]+$/.test(name);
+
+  if (hasDomain) {
+    if (!acceptedDomains.some(domain => name.endsWith(domain))) {
+      throw new Error('Wallet domain not accepted');
+    }
+    return name;
+  }
+
+  // fallback to default ENS domain
+  if (acceptedDomains.includes('.eth')) {
+    return `${name}.${FALLBACK_DOMAIN}`;
+  }
+
+  throw new Error('Wallet domain not accepted');
+}
+
+export function resolveAddress(identifier: string): string | null {
+  const wallet = authenticateWallet(identifier);
+  if (wallet.endsWith('.eth')) {
+    return ENS_MAP[wallet] || null;
+  }
+  if (wallet.endsWith('.cb.id')) {
+    return CB_ID_MAP[wallet] || null;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- implement `wallet_auth.ts` to authenticate ENS and `.cb.id` wallets
- enable wallet auth hook in `vaultfire_config.json`

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687eb959bdb083228479e4e10f0c8ffc