### PR TITLE
Repository audit and activation gate

### DIFF
--- a/engine/activation_gate.py
+++ b/engine/activation_gate.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+"""Protocol activation gate utilities."""
+
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+HALT_PATH = BASE_DIR / "vaultfire-core" / "ethics" / "halt.flag"
+
+
+def activation_allowed() -> bool:
+    """Return ``True`` if the protocol is not halted."""
+    return not HALT_PATH.exists()
+
+
+def enforce_activation() -> None:
+    """Raise ``RuntimeError`` if the protocol is halted."""
+    if not activation_allowed():
+        raise RuntimeError("Protocol halted by ethics audit")

--- a/engine/partner_hooks.py
+++ b/engine/partner_hooks.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from .token_ops import send_token
+from .activation_gate import enforce_activation
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 CONFIG_PATH = BASE_DIR / "vaultfire-core" / "vaultfire_config.json"
@@ -34,6 +35,7 @@ def _load_config():
 
 
 def _check_enabled():
+    enforce_activation()
     config = _load_config()
     if not config.get("ethics_anchor", False):
         raise RuntimeError("Ethics anchor disabled. Monetization halted.")

--- a/engine/token_ops.py
+++ b/engine/token_ops.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .marketplace import currency_allowed
 from .wallet_loyalty import update_wallet_loyalty
+from .activation_gate import enforce_activation
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 LEDGER_PATH = BASE_DIR / "logs" / "token_ledger.json"
@@ -28,7 +29,11 @@ def _write_json(path: Path, data) -> None:
 
 
 def send_token(wallet: str, amount: float, token: str) -> None:
-    """Record a token transfer to ``wallet`` if ``token`` is allowed."""
+    """Record a token transfer to ``wallet`` if ``token`` is allowed.
+
+    Raises ``RuntimeError`` if the protocol is halted.
+    """
+    enforce_activation()
     if not currency_allowed(token):
         raise ValueError(f"Token {token} not supported by marketplace")
     ledger = _load_json(LEDGER_PATH, [])


### PR DESCRIPTION
## Summary
- audit repo for Web3 features and logic issues
- add a missing activation gate check
- prevent token/partner functions when protocol is halted

## Testing
- `python system_integrity_check.py`
- `python -m compileall -q engine`


------
https://chatgpt.com/codex/tasks/task_e_687ebe3121048322b05727a9044cd6fb