### PR TITLE
Create Vaultfire Partner SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ node vaultfire_partner_onboard.js <partner_id> <wallet> "alignment phrase"
 
 The script verifies ENS/Coinbase mapping and only writes to `partners.json` when
 `ethics_anchor` is enabled.
+## Partner SDK
+A modular SDK is provided in `vaultfire_sdk/`. See `docs/partner_sdk.md` for activation steps and API usage. A login demo using ENS and Coinbase IDs lives in `frontend/pages/login_example.html`.
+
 
 ## Alignment Key Access
 Partners who embody Ghostkey values can unlock additional features by

--- a/docs/partner_sdk.md
+++ b/docs/partner_sdk.md
@@ -1,0 +1,27 @@
+# Vaultfire Partner SDK
+
+The `vaultfire_sdk` package bundles the onboarding API, partner hooks and
+activation utilities so external projects can integrate quickly.
+
+## Activation
+1. Ensure `vaultfire-core/vaultfire_config.json` has `"ethics_anchor": true`.
+2. Install dependencies with `pip install -r requirements.txt`.
+3. Launch the API server:
+   ```bash
+   python3 -m vaultfire_sdk
+   ```
+
+## API Routes
+- `POST /onboard/partner`
+- `POST /onboard/contributor`
+- `POST /onboard/earner`
+- `POST /mission`
+- `POST /engagement`
+- `GET /credit/<identifier>`
+- `GET /vaultfire_credits/<user_id>`
+- `GET /status`
+
+## Frontend Login Example
+`frontend/pages/login_example.html` demonstrates wallet resolution for
+ENS names or Coinbase IDs using `login_example.js`. Partners can adapt this
+snippet to add wallet login support.

--- a/frontend/pages/login_example.html
+++ b/frontend/pages/login_example.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Vaultfire Login Example</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding:20px; }
+    form { margin-top:10px; }
+  </style>
+</head>
+<body>
+  <h1>ENS + Coinbase Login</h1>
+  <form id="walletForm">
+    <input id="walletInput" placeholder="alice.eth or user.cb.id" />
+    <button type="submit">Resolve</button>
+  </form>
+  <p id="walletResult"></p>
+  <script src="login_example.js"></script>
+</body>
+</html>

--- a/frontend/pages/login_example.js
+++ b/frontend/pages/login_example.js
@@ -1,0 +1,56 @@
+const ENS_MAP = {
+  'ghostkey316.eth': '0x9abCDEF1234567890abcdefABCDEF1234567890',
+  'sample.eth': '0x0000000000000000000000000000000000000001',
+};
+
+const CB_ID_MAP = {
+  'bpow20.cb.id': 'cb1qexampleaddress0000000000000000000000',
+};
+
+const ALLOWED_DOMAINS = ['.eth', '.cb.id'];
+const FALLBACK_DOMAIN = 'vaultfire.eth';
+
+function authenticateWallet(identifier, acceptedDomains = ALLOWED_DOMAINS) {
+  let name = identifier.trim().toLowerCase();
+  const hasDomain = /\.[^\.\s]+$/.test(name);
+
+  if (hasDomain) {
+    if (!acceptedDomains.some(domain => name.endsWith(domain))) {
+      throw new Error('Wallet domain not accepted');
+    }
+    return name;
+  }
+
+  if (acceptedDomains.includes('.eth')) {
+    return `${name}.${FALLBACK_DOMAIN}`;
+  }
+
+  throw new Error('Wallet domain not accepted');
+}
+
+function resolveAddress(identifier) {
+  const wallet = authenticateWallet(identifier);
+  if (wallet.endsWith('.eth')) {
+    return ENS_MAP[wallet] || null;
+  }
+  if (wallet.endsWith('.cb.id')) {
+    return CB_ID_MAP[wallet] || null;
+  }
+  return null;
+}
+
+function handleLogin(event) {
+  event.preventDefault();
+  const input = document.getElementById('walletInput');
+  const result = document.getElementById('walletResult');
+  try {
+    const addr = resolveAddress(input.value);
+    result.textContent = addr || 'Unknown wallet';
+  } catch (err) {
+    result.textContent = err.message;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('walletForm').addEventListener('submit', handleLogin);
+});

--- a/vaultfire_sdk/__init__.py
+++ b/vaultfire_sdk/__init__.py
@@ -1,0 +1,12 @@
+"""Vaultfire Partner SDK."""
+
+from .api import create_app
+import engine
+from engine import *
+from engine.activation_gate import activation_allowed, enforce_activation
+
+__all__ = [
+    "create_app",
+    "activation_allowed",
+    "enforce_activation",
+] + engine.__all__

--- a/vaultfire_sdk/api.py
+++ b/vaultfire_sdk/api.py
@@ -1,0 +1,9 @@
+"""Flask app loader for Vaultfire SDK."""
+from onboarding_api import app
+
+def create_app():
+    """Return the Flask app with all Vaultfire API routes."""
+    return app
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary
- package modules under `vaultfire_sdk` for partner consumption
- document activation instructions and API routes
- show a basic ENS + Coinbase login example
- link the new SDK in the README

## Testing
- `python3 -m unittest discover` *(fails: ModuleNotFoundError for flask)*

------
https://chatgpt.com/codex/tasks/task_e_687ec01bccd0832291d73d97ec5332de