### PR TITLE
Add protocol status manifest generator

### DIFF
--- a/dashboards/protocol_status.json
+++ b/dashboards/protocol_status.json
@@ -1,0 +1,57 @@
+{
+  "timestamp": "2025-07-21T22:44:10Z",
+  "version": "1.0",
+  "modules": [
+    "activation_gate",
+    "alignment_feedback",
+    "belief_validation",
+    "contributor_identity",
+    "contributor_protocol",
+    "contributor_xp",
+    "engagement_tracker",
+    "ethics_filter",
+    "feedback_loop",
+    "ghostkey_commandments",
+    "governance",
+    "identity_resolver",
+    "loyalty_engine",
+    "loyalty_multiplier",
+    "marketplace",
+    "marketplace_plugins",
+    "mission_registry",
+    "partner_hooks",
+    "passive_yield_simulator",
+    "revenue_hooks",
+    "reward_guard",
+    "self_audit",
+    "shutdown_manager",
+    "signal_engine",
+    "signal_reward",
+    "soul_journal",
+    "sync_protocol",
+    "target_lock",
+    "token_ops",
+    "truth_guard",
+    "vaultfire_credits",
+    "wallet_bonding",
+    "wallet_loyalty",
+    "yield_engine_v1",
+    "yield_protocol_prep"
+  ],
+  "ethics_config": {
+    "system_name": "Vaultfire",
+    "ethics_anchor": true,
+    "monetization_mode": "Behavioral Yield + Contributor Split",
+    "public_visibility": "controlled",
+    "partner_hooks_enabled": true,
+    "wallet_auth_hook": true,
+    "fail_safe": "Hard shutdown on ethics breach"
+  },
+  "partners": [
+    {
+      "partner_id": "sandbox_partner",
+      "aligned": false
+    }
+  ],
+  "ethics_checksum": "8801d07cebc9f0c000a7efef197e51cb0db95536715fe5d89d4bd70d7e53da25"
+}

--- a/generate_protocol_manifest.py
+++ b/generate_protocol_manifest.py
@@ -1,0 +1,82 @@
+# Reference: ethics/core.mdx
+"""Generate protocol status manifest."""
+
+import json
+import hashlib
+from datetime import datetime
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+ENGINE_DIR = BASE_DIR / "engine"
+CONFIG_PATH = BASE_DIR / "vaultfire-core" / "vaultfire_config.json"
+ETHICS_PATH = BASE_DIR / "ethics" / "core.mdx"
+PARTNERS_PATH = BASE_DIR / "partners.json"
+OUTPUT_PATH = BASE_DIR / "dashboards" / "protocol_status.json"
+
+
+def ethics_checksum() -> str:
+    data = ETHICS_PATH.read_bytes()
+    return hashlib.sha256(data).hexdigest()
+
+
+def extract_version() -> str:
+    with open(ETHICS_PATH) as f:
+        first = f.readline().strip()
+    # Expect format like "# Ghostkey Ethics Framework v1.0"
+    if "v" in first:
+        return first.split("v")[-1]
+    return "unknown"
+
+
+def list_modules() -> list[str]:
+    modules = []
+    for path in ENGINE_DIR.glob("*.py"):
+        if path.stem != "__init__":
+            modules.append(path.stem)
+    modules.sort()
+    return modules
+
+
+def load_config() -> dict:
+    with open(CONFIG_PATH) as f:
+        return json.load(f)
+
+
+def partner_status() -> list[dict]:
+    partners = []
+    if PARTNERS_PATH.exists():
+        try:
+            partners = json.loads(PARTNERS_PATH.read_text())
+        except json.JSONDecodeError:
+            partners = []
+    result = []
+    for entry in partners:
+        result.append({
+            "partner_id": entry.get("partner_id"),
+            "aligned": bool(entry.get("aligned"))
+        })
+    return result
+
+
+def build_manifest() -> dict:
+    manifest = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "version": extract_version(),
+        "modules": list_modules(),
+        "ethics_config": load_config(),
+        "partners": partner_status(),
+        "ethics_checksum": ethics_checksum(),
+    }
+    return manifest
+
+
+def main() -> None:
+    manifest = build_manifest()
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(OUTPUT_PATH, "w") as f:
+        json.dump(manifest, f, indent=2)
+    print(json.dumps(manifest, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generate_protocol_manifest.py` script to build a status manifest
- commit resulting `protocol_status.json` file in dashboards

## Testing
- `python3 generate_protocol_manifest.py`
- `python3 system_integrity_check.py`
- `python3 -m engine.self_audit` *(fails: partner not aligned, missing logs)*

------
https://chatgpt.com/codex/tasks/task_e_687ec23dd730832296685ecc17d10b81