### PR TITLE
Add partner activation simulation API and hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,27 @@ python3 simulate_partner_activation.py demo_id demo_wallet.eth --phrase "Morals 
 ```
 
 Multiple wallets are accepted by listing them separated by spaces.
+
+To use a JSON payload offline, pipe it to `activation_hook.py`:
+
+```bash
+echo '{"partner_id": "demo_id", "wallets": ["demo_wallet.eth"], "phrase": "Morals Before Metrics."}' \
+  | python3 activation_hook.py -
+```
+
+### Activation Simulation API
+POST `/activate/simulate` accepts a JSON body containing `partner_id`, a list of
+`wallets`, and an optional `phrase`. The endpoint returns a status object for UI
+rendering:
+
+```bash
+curl -X POST http://localhost:5000/activate/simulate \
+  -H "Content-Type: application/json" \
+  -d '{"partner_id": "demo_id", "wallets": ["demo_wallet.eth"],
+       "phrase": "Morals Before Metrics."}'
+```
+
+The response indicates `PASS` or `FAIL` and lists any failures.
 ## Partner SDK
 A modular SDK is provided in `vaultfire_sdk/`. See `docs/partner_sdk.md` for activation steps and API usage. A login demo using ENS and Coinbase IDs lives in `frontend/pages/login_example.html`.
 

--- a/activation_hook.py
+++ b/activation_hook.py
@@ -1,0 +1,37 @@
+"""Offline hook for partner activation simulation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from simulate_partner_activation import simulate_activation, ALIGNMENT_PHRASE
+
+
+def _load_input(path: str) -> dict[str, Any]:
+    if path == "-":
+        return json.load(sys.stdin)
+    return json.load(Path(path).open())
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    if not argv:
+        print("Usage: activation_hook.py <input_json or ->")
+        return 1
+
+    data = _load_input(argv[0])
+    partner_id = data.get("partner_id")
+    wallets = data.get("wallets", [])
+    phrase = data.get("phrase", ALIGNMENT_PHRASE)
+
+    result = simulate_activation(partner_id, wallets, phrase)
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/partner_sdk.md
+++ b/docs/partner_sdk.md
@@ -11,12 +11,16 @@ activation utilities so external projects can integrate quickly.
    python3 -m vaultfire_sdk
    ```
 
+For offline automation, run `activation_hook.py` with a JSON file or `-` for
+stdin. The script outputs a pass/fail status object.
+
 ## API Routes
 - `POST /onboard/partner`
 - `POST /onboard/contributor`
 - `POST /onboard/earner`
 - `POST /mission`
 - `POST /engagement`
+- `POST /activate/simulate`
 - `GET /credit/<identifier>`
 - `GET /vaultfire_credits/<user_id>`
 - `GET /status`

--- a/onboarding_api.py
+++ b/onboarding_api.py
@@ -2,6 +2,7 @@
 import json
 from pathlib import Path
 from flask import Flask, request, jsonify
+from simulate_partner_activation import simulate_activation, ALIGNMENT_PHRASE
 
 app = Flask(__name__)
 BASE_DIR = Path(__file__).resolve().parent
@@ -26,6 +27,22 @@ def _load_json(path: Path, default):
 def _write_json(path: Path, data) -> None:
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
+
+
+@app.post("/activate/simulate")
+def simulate_activation_endpoint():
+    """Run partner activation simulation and return status."""
+    data = request.get_json(silent=True) or {}
+    partner_id = data.get("partner_id")
+    wallets = data.get("wallets", [])
+    phrase = data.get("phrase", ALIGNMENT_PHRASE)
+
+    if not partner_id or not wallets:
+        return jsonify({"error": "partner_id and wallets required"}), 400
+
+    result = simulate_activation(partner_id, wallets, phrase)
+    status = 200 if result["success"] else 400
+    return jsonify(result), status
 
 
 @app.post("/onboard/partner")

--- a/simulate_partner_activation.py
+++ b/simulate_partner_activation.py
@@ -15,6 +15,35 @@ PARTNERS_PATH = BASE_DIR / "partners.json"
 ALIGNMENT_PHRASE = "Morals Before Metrics."
 
 
+def simulate_activation(partner_id: str, wallets: list[str],
+                        phrase: str = ALIGNMENT_PHRASE) -> dict:
+    """Run activation checks and return a result object."""
+    failures: list[str] = []
+
+    if not check_alignment_phrase(phrase):
+        failures.append("alignment phrase mismatch")
+
+    if not check_ethics_anchor():
+        failures.append("ethics_anchor disabled")
+
+    if not init_loyalty_engine():
+        failures.append("loyalty_engine initialization failed")
+
+    success = not failures
+    resolved_wallets = resolve_wallets(wallets) if success else wallets
+    if success:
+        activate_partner(partner_id, resolved_wallets)
+
+    return {
+        "partner_id": partner_id,
+        "wallets": resolved_wallets,
+        "phrase": phrase,
+        "success": success,
+        "failures": failures,
+        "status": "PASS" if success else "FAIL",
+    }
+
+
 def _load_json(path: Path, default):
     if path.exists():
         try:
@@ -84,26 +113,14 @@ def main(argv: list[str] | None = None) -> int:
     alignment_phrase = args.phrase
 
     print("Starting partner activation handshake...")
-    failures = []
+    result = simulate_activation(partner_id, wallets, alignment_phrase)
 
-    if not check_alignment_phrase(alignment_phrase):
-        failures.append("alignment phrase mismatch")
-
-    if not check_ethics_anchor():
-        failures.append("ethics_anchor disabled")
-
-    if not init_loyalty_engine():
-        failures.append("loyalty_engine initialization failed")
-
-    if failures:
+    if not result["success"]:
         print("Activation failed due to:")
-        for msg in failures:
+        for msg in result["failures"]:
             print(f"- {msg}")
         print("System integration readiness: FAIL")
         return 1
-
-    resolved_wallets = resolve_wallets(wallets)
-    activate_partner(partner_id, resolved_wallets)
 
     print("Activation successful for partner", partner_id)
     print("System integration readiness: PASS")


### PR DESCRIPTION
## Summary
- modular `simulate_activation` helper added
- `/activate/simulate` endpoint for real-time activation checks
- CLI `activation_hook.py` for JSON/stdin workflows
- document new usage in README and partner SDK docs

## Testing
- `python3 -m py_compile activation_hook.py onboarding_api.py simulate_partner_activation.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687ece4ce6ac8322961318902917aff6