### PR TITLE
Add universal activation hook

### DIFF
--- a/simulate_partner_activation.py
+++ b/simulate_partner_activation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from engine.loyalty_engine import update_loyalty_ranks
 from engine.identity_resolver import resolve_identity
+from system_integrity_check import run_integrity_check
 
 BASE_DIR = Path(__file__).resolve().parent
 CONFIG_PATH = BASE_DIR / "vaultfire-core" / "vaultfire_config.json"
@@ -16,7 +17,8 @@ ALIGNMENT_PHRASE = "Morals Before Metrics."
 
 
 def simulate_activation(partner_id: str, wallets: list[str],
-                        phrase: str = ALIGNMENT_PHRASE) -> dict:
+                        phrase: str = ALIGNMENT_PHRASE,
+                        test_mode: bool = False) -> dict:
     """Run activation checks and return a result object."""
     failures: list[str] = []
 
@@ -31,7 +33,7 @@ def simulate_activation(partner_id: str, wallets: list[str],
 
     success = not failures
     resolved_wallets = resolve_wallets(wallets) if success else wallets
-    if success:
+    if success and not test_mode:
         activate_partner(partner_id, resolved_wallets)
 
     return {
@@ -101,29 +103,66 @@ def activate_partner(partner_id: str, wallets: list[str]) -> None:
     _write_json(PARTNERS_PATH, partners)
 
 
+def activation_hook(partner_id: str, wallets: list[str],
+                    phrase: str = ALIGNMENT_PHRASE,
+                    silent: bool = False,
+                    test_mode: bool = False) -> dict:
+    """Run activation and integrity checks and return a result object."""
+    activation = simulate_activation(partner_id, wallets, phrase, test_mode)
+    integrity = run_integrity_check()
+    errors = activation["failures"][:]
+    for section, msgs in integrity.items():
+        errors.extend(f"{section}: {m}" for m in msgs)
+    status = "PASS" if not errors else "FAIL"
+    result = {
+        "partner_id": partner_id,
+        "wallets": activation["wallets"],
+        "status": status,
+        "errors": errors,
+        "activation": activation,
+        "integrity": integrity,
+    }
+    if not silent:
+        print(json.dumps(result, indent=2))
+    return result
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Simulate partner activation")
     parser.add_argument("partner_id", help="unique partner identifier")
     parser.add_argument("wallet", nargs="+", help="one or more wallet identifiers")
     parser.add_argument("--phrase", default=ALIGNMENT_PHRASE, help="alignment phrase")
+    parser.add_argument("--silent", action="store_true", help="suppress console output")
+    parser.add_argument("--test-mode", action="store_true", help="do not persist changes")
+    parser.add_argument("--hook", action="store_true", help="return JSON activation hook output")
     args = parser.parse_args(argv)
 
     partner_id = args.partner_id
     wallets = args.wallet
     alignment_phrase = args.phrase
+    silent = args.silent
+    test_mode = args.test_mode
 
-    print("Starting partner activation handshake...")
-    result = simulate_activation(partner_id, wallets, alignment_phrase)
+    if args.hook:
+        result = activation_hook(partner_id, wallets, alignment_phrase,
+                                 silent=silent, test_mode=test_mode)
+        return 0 if result["status"] == "PASS" else 1
+
+    if not silent:
+        print("Starting partner activation handshake...")
+    result = simulate_activation(partner_id, wallets, alignment_phrase, test_mode)
 
     if not result["success"]:
-        print("Activation failed due to:")
-        for msg in result["failures"]:
-            print(f"- {msg}")
-        print("System integration readiness: FAIL")
+        if not silent:
+            print("Activation failed due to:")
+            for msg in result["failures"]:
+                print(f"- {msg}")
+            print("System integration readiness: FAIL")
         return 1
 
-    print("Activation successful for partner", partner_id)
-    print("System integration readiness: PASS")
+    if not silent:
+        print("Activation successful for partner", partner_id)
+        print("System integration readiness: PASS")
     return 0
 
 

--- a/system_integrity_check.py
+++ b/system_integrity_check.py
@@ -1,4 +1,5 @@
 import json
+import argparse
 from pathlib import Path
 
 from engine.identity_resolver import resolve_identity
@@ -11,6 +12,8 @@ SNAPSHOT_PATH = BASE_DIR / "dashboards" / "contributor_snapshot.json"
 BINDINGS_PATH = BASE_DIR / "dashboards" / "contributor_bindings.json"
 USER_LIST_PATH = BASE_DIR / "user_list.json"
 SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
+
+ALIGNMENT_PHRASE = "Morals Before Metrics."
 
 
 def _load_json(path: Path, default):
@@ -81,14 +84,49 @@ def run_integrity_check() -> dict:
     }
 
 
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run system integrity checks")
+    parser.add_argument("--activation-hook", action="store_true",
+                        help="invoke universal activation hook")
+    parser.add_argument("--partner-id")
+    parser.add_argument("--wallet", action="append", dest="wallets",
+                        help="wallet identifier, may be repeated")
+    parser.add_argument("--phrase", default=ALIGNMENT_PHRASE,
+                        help="alignment phrase")
+    parser.add_argument("--silent", action="store_true",
+                        help="suppress console output")
+    parser.add_argument("--test-mode", action="store_true",
+                        help="do not persist changes")
+    args = parser.parse_args(argv)
+
+    if args.activation_hook:
+        from simulate_partner_activation import activation_hook
+        result = activation_hook(
+            args.partner_id or "",
+            args.wallets or [],
+            args.phrase,
+            silent=True,
+            test_mode=args.test_mode,
+        )
+        if not args.silent:
+            print(json.dumps(result, indent=2))
+        return 0 if result["status"] == "PASS" else 1
+
     result = run_integrity_check()
     print(json.dumps(result, indent=2))
     issues = [msg for msgs in result.values() for msg in msgs]
     if issues:
-        print("Integrity check issues detected:")
-        for category, msgs in result.items():
-            for msg in msgs:
-                print(f"- {category}: {msg}")
+        if not args.silent:
+            print("Integrity check issues detected:")
+            for category, msgs in result.items():
+                for msg in msgs:
+                    print(f"- {category}: {msg}")
+        return 1
     else:
-        print("All systems operational")
+        if not args.silent:
+            print("All systems operational")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- create a new `activation_hook` helper in `simulate_partner_activation.py`
- allow partners to run the hook via `--hook`, `--silent` and `--test-mode`
- add matching CLI entry in `system_integrity_check.py` through `--activation-hook`
- combine activation and system integrity results into a single JSON payload

## Testing
- `python3 -m py_compile system_integrity_check.py simulate_partner_activation.py`
- `python3 simulate_partner_activation.py demo_user demo_wallet --hook --test-mode`
- `python3 system_integrity_check.py --activation-hook --partner-id demo_user --wallet demo_wallet --test-mode`


------
https://chatgpt.com/codex/tasks/task_e_687ed80af7c08322ad030142646bac8b