### PR TITLE
Add ENS sync status checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Vaultfire Init represents the first development signal from **Ghostkey-316** (Br
   `token_ledger.json` which tracks token rewards when partnerships enable direct
   payouts.
 - `generate_partner_dashboard.py` – builds `dashboards/partner_earnings.json` summarizing contributor earnings.
+- `ens_sync_status.py` – reads `logs/sync_audit.json` for the latest sync entry of an ENS name.
 - `README.md` – project overview and usage notes.
 - `vaultfire-core/` – base protocol framework containing configuration, ethics,
   and monetization modules.
@@ -73,6 +74,12 @@ wallet address alongside the identifier.
 The script creates `logs/vaultfire_log.txt` automatically if it does not exist.
 
 Run `python3 generate_partner_dashboard.py` to refresh partner earnings.
+
+Check sync status for an ENS name:
+
+```bash
+python3 ens_sync_status.py ghostkey316.eth
+```
 
 ## Identity
 - Architect: **ghostkey316.eth**

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -33,6 +33,7 @@ from .shutdown_manager import (
     tally_votes as tally_shutdown_votes,
 )
 from .signal_reward import reward_signal_event
+from .ens_sync_status import read_sync_status
 
 __all__ = [
     "resolve_identity",
@@ -64,4 +65,5 @@ __all__ = [
     "cast_shutdown_vote",
     "tally_shutdown_votes",
     "reward_signal_event",
+    "read_sync_status",
 ]

--- a/engine/ens_sync_status.py
+++ b/engine/ens_sync_status.py
@@ -1,0 +1,47 @@
+# Reference: ethics/core.mdx
+"""ENS sync status helper."""
+
+import json
+from pathlib import Path
+from typing import Dict
+
+from .identity_resolver import resolve_ens
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
+AUDIT_PATH = BASE_DIR / "logs" / "sync_audit.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def read_sync_status(ens_name: str) -> Dict:
+    """Return latest sync audit entry for ``ens_name``."""
+    scorecard = _load_json(SCORECARD_PATH, {})
+    user_id = None
+    for uid, info in scorecard.items():
+        if info.get("wallet", "").lower() == ens_name.lower():
+            user_id = uid
+            break
+    if user_id is None:
+        address = resolve_ens(ens_name)
+        for uid, info in scorecard.items():
+            if info.get("wallet", "").lower() == (address or "").lower():
+                user_id = uid
+                break
+    if user_id is None:
+        return {}
+
+    audit_log = _load_json(AUDIT_PATH, [])
+    entries = [e for e in audit_log if e.get("user_id") == user_id]
+    if not entries:
+        return {}
+    entries.sort(key=lambda x: x.get("timestamp", ""))
+    return entries[-1]

--- a/ens_sync_status.py
+++ b/ens_sync_status.py
@@ -1,0 +1,20 @@
+# Reference: ethics/core.mdx
+"""CLI tool to read sync status for an ENS name."""
+
+import argparse
+import json
+
+from engine.ens_sync_status import read_sync_status
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check sync status via ENS")
+    parser.add_argument("ens", help="ENS name to query")
+    args = parser.parse_args()
+
+    status = read_sync_status(args.ens)
+    print(json.dumps(status, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ens_sync_status.py` CLI script
- export `read_sync_status` helper in `engine.__init__`
- document script usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eda2b8964832286b0d389d822cda3