### PR TITLE
Add ENS sync React UI and API

### DIFF
--- a/frontend/pages/ens_sync.html
+++ b/frontend/pages/ens_sync.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Vaultfire ENS Sync</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding:20px; }
+    button { margin-top:10px; }
+  </style>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script src="https://unpkg.com/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+  <script src="https://unpkg.com/web3modal@1.9.12/dist/index.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="ens_sync.js"></script>
+</body>
+</html>

--- a/frontend/pages/ens_sync.js
+++ b/frontend/pages/ens_sync.js
@@ -1,0 +1,109 @@
+const FIELDS = {
+  vaultfire_sync: 'true',
+  ghostkey_id: 'Ghostkey-316',
+  loyalty_tier: 'Legacy Tier',
+  status: 'Active Contributor'
+};
+
+function App() {
+  const [ens, setEns] = React.useState('');
+  const [status, setStatus] = React.useState(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState('');
+  const [provider, setProvider] = React.useState(null);
+  const web3ModalRef = React.useRef(null);
+
+  React.useEffect(() => {
+    web3ModalRef.current = new window.Web3Modal.default({ cacheProvider: false });
+  }, []);
+
+  async function checkStatus(e) {
+    e.preventDefault();
+    setError('');
+    setStatus(null);
+    if (!ens) {
+      setError('ENS name required');
+      return;
+    }
+    setLoading(true);
+    try {
+      const resp = await fetch(`/ens_sync_status?ens=${encodeURIComponent(ens)}`);
+      if (!resp.ok) throw new Error('API error');
+      const data = await resp.json();
+      if (!data || Object.keys(data).length === 0) {
+        setStatus({ vaultfire_sync: 'false', message: 'No record found' });
+      } else {
+        setStatus(data);
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function connectWallet() {
+    try {
+      const instance = await web3ModalRef.current.connect();
+      const prov = new ethers.providers.Web3Provider(instance);
+      setProvider(prov);
+      return prov;
+    } catch (err) {
+      setError('Wallet connection failed');
+      return null;
+    }
+  }
+
+  async function updateRecords() {
+    const prov = provider || await connectWallet();
+    if (!prov) return;
+    setLoading(true);
+    setError('');
+    try {
+      const signer = prov.getSigner();
+      const resolver = await prov.getResolver(ens);
+      if (!resolver) throw new Error('Resolver not found');
+      const withSigner = resolver.connect(signer);
+      for (const [key, value] of Object.entries(FIELDS)) {
+        await withSigner.setText(key, value);
+      }
+      alert('Records updated');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const outOfSync = status && status.vaultfire_sync !== 'true';
+
+  return (
+    <div>
+      <h1>Vaultfire ENS Sync</h1>
+      <form onSubmit={checkStatus}>
+        <input
+          value={ens}
+          onChange={e => setEns(e.target.value)}
+          placeholder="yourname.eth"
+        />
+        <button type="submit">Check Status</button>
+      </form>
+      {loading && <p>Loading...</p>}
+      {error && <p style={{color:'red'}}>{error}</p>}
+      {status && (
+        <div>
+          <h3>Status</h3>
+          <pre>{JSON.stringify(status, null, 2)}</pre>
+          {outOfSync ? (
+            <button onClick={updateRecords}>Update Text Records</button>
+          ) : (
+            <p>Records in sync</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));
+

--- a/onboarding_api.py
+++ b/onboarding_api.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 from flask import Flask, request, jsonify
 from simulate_partner_activation import simulate_activation, ALIGNMENT_PHRASE
+from engine.ens_sync_status import read_sync_status
 
 app = Flask(__name__)
 BASE_DIR = Path(__file__).resolve().parent
@@ -144,6 +145,16 @@ def get_vaultfire_credits(user_id):
     update_credit(user_id)
     balance = credit_balance(user_id)
     return jsonify({"user_id": user_id, "credits": balance})
+
+
+@app.get("/ens_sync_status")
+def ens_sync_status_route():
+    """Return last Vaultfire sync audit entry for an ENS name."""
+    ens_name = request.args.get("ens", "")
+    if not ens_name:
+        return jsonify({"error": "ens parameter required"}), 400
+    info = read_sync_status(ens_name)
+    return jsonify(info or {})
 
 
 @app.get("/status")


### PR DESCRIPTION
## Summary
- expose `read_sync_status` via new `/ens_sync_status` endpoint
- add React page to check and update ENS text records

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eddd54db883229c3d00eaaa16e477