### PR TITLE
Update ENS sync CLI with new flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Vaultfire Init represents the first development signal from **Ghostkey-316** (Br
   `token_ledger.json` which tracks token rewards when partnerships enable direct
   payouts.
 - `generate_partner_dashboard.py` – builds `dashboards/partner_earnings.json` summarizing contributor earnings.
-- `ens_sync_status.py` – reads `logs/sync_audit.json` for the latest sync entry of an ENS name.
+- `ens_sync_status.py` – reads `logs/sync_audit.json` for the latest sync entry of an ENS name. Optional flags allow resync simulation and belief logging.
 - `README.md` – project overview and usage notes.
 - `vaultfire-core/` – base protocol framework containing configuration, ethics,
   and monetization modules.
@@ -79,6 +79,12 @@ Check sync status for an ENS name:
 
 ```bash
 python3 ens_sync_status.py ghostkey316.eth
+```
+
+Use optional flags to force a resync and log your belief phrase:
+
+```bash
+python3 ens_sync_status.py ghostkey316.eth --force-sync --belief "Morals Before Metrics."
 ```
 
 ## Identity

--- a/ens_sync_status.py
+++ b/ens_sync_status.py
@@ -3,16 +3,35 @@
 
 import argparse
 import json
+from datetime import datetime
 
 from engine.ens_sync_status import read_sync_status
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Check sync status via ENS")
     parser.add_argument("ens", help="ENS name to query")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--force-sync",
+        action="store_true",
+        help="simulate resync even if status is current",
+    )
+    parser.add_argument(
+        "--belief",
+        default="None",
+        help="alignment belief phrase",
+    )
+    args = parser.parse_args(argv)
 
     status = read_sync_status(args.ens)
+
+    if args.force_sync:
+        status["resync"] = f"Simulated re-sync triggered for {args.ens}"
+        status["resync_timestamp"] = datetime.utcnow().isoformat()
+
+    if args.belief != "None":
+        status["belief"] = args.belief
+
     print(json.dumps(status, indent=2))
 
 


### PR DESCRIPTION
## Summary
- extend `ens_sync_status.py` CLI with `--force-sync` and `--belief`
- document new options in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 system_integrity_check.py --silent`


------
https://chatgpt.com/codex/tasks/task_e_687efbe0901c8322945f05b3875e563c