### PR TITLE
Add vaultfire yield distributor CLI

### DIFF
--- a/vaultfire_yield_distributor.py
+++ b/vaultfire_yield_distributor.py
@@ -1,0 +1,109 @@
+"""Yield distributor CLI for Vaultfire.
+
+This script triggers yield drops for specific actions. A base payout amount is
+assigned to each ``action_type`` and multiplied by the caller's Ghostscore
+(reputation). The payout is sent in ASM, ETH or USDC. Use ``--dry-run`` to
+simulate without persisting changes.
+
+Ready for integration with partner activation and belief alignment modules.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Tuple
+
+from engine.token_ops import send_token
+from engine.marketplace import currency_allowed
+from engine.ghostscore_engine import (
+    get_ghostscore,
+    record_belief_sync,
+    record_partner_activation,
+    record_yield_claim,
+)
+
+
+SUPPORTED_TOKENS = {"ASM", "ETH", "USDC"}
+
+# Base payout amounts for each allowed action type
+BASE_PAYOUTS = {
+    "belief_sync": 2.0,
+    "partner_activation": 5.0,
+    "yield_claim": 1.0,
+}
+
+
+def _payout_for_action(ens: str, action: str) -> Tuple[float, float, int]:
+    """Return (amount, multiplier, score) for ``action`` and ``ens``."""
+    score = get_ghostscore(ens)
+    multiplier = 1 + score / 100
+    base = BASE_PAYOUTS.get(action, 1.0)
+    return base * multiplier, multiplier, score
+
+
+def trigger_yield_drop(
+    ens: str,
+    wallet: str,
+    action_type: str,
+    token: str = "ASM",
+    dry_run: bool = False,
+) -> dict:
+    """Execute or simulate a yield drop and return details."""
+    if token not in SUPPORTED_TOKENS or not currency_allowed(token):
+        raise ValueError(f"Token {token} not supported")
+
+    amount, multiplier, score = _payout_for_action(ens, action_type)
+    result = {
+        "ens": ens,
+        "wallet": wallet,
+        "action": action_type,
+        "token": token,
+        "base_payout": BASE_PAYOUTS.get(action_type, 1.0),
+        "ghostscore": score,
+        "multiplier": round(multiplier, 3),
+        "amount": amount,
+        "dry_run": dry_run,
+    }
+
+    if not dry_run:
+        send_token(wallet, amount, token)
+        if action_type == "yield_claim":
+            record_yield_claim(ens)
+        elif action_type == "partner_activation":
+            record_partner_activation(ens)
+        elif action_type == "belief_sync":
+            record_belief_sync(ens)
+        result["status"] = "sent"
+    else:
+        result["status"] = "simulated"
+
+    return result
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Trigger a Vaultfire yield drop")
+    parser.add_argument("ens", help="ENS name")
+    parser.add_argument("wallet", help="wallet address or ENS")
+    parser.add_argument("action_type", choices=sorted(BASE_PAYOUTS.keys()))
+    parser.add_argument(
+        "--token",
+        choices=sorted(SUPPORTED_TOKENS),
+        default="ASM",
+        help="payout currency",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="simulate without sending tokens",
+    )
+
+    args = parser.parse_args(argv)
+    data = trigger_yield_drop(
+        args.ens, args.wallet, args.action_type, args.token, args.dry_run
+    )
+    print(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `vaultfire_yield_distributor.py` for triggering yield drops

## Testing
- `pytest -q`
- `python3 vaultfire_yield_distributor.py --help`
- `python3 vaultfire_yield_distributor.py ghostkey316.eth wallet.eth belief_sync --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_687f0b3c67788322b258cf230f6a119b