### PR TITLE
Add contributor unlock NFT contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 logs/
 __pycache__/
+node_modules/
+artifacts/
+cache/

--- a/README.md
+++ b/README.md
@@ -425,3 +425,4 @@ Results are written to `dashboards/contributor_scores.json` and merged into `use
 - Use at your own risk; the maintainers provide no warranty.
 - Local JSON files are not meant for secure or permanent storage.
 - All contributions must respect the Ghostkey Commandments and ethics guidelines.
+- The Contributor Unlock Key NFT is a demo access mechanism on Base and does not provide production-grade security.

--- a/contracts/ContributorUnlockKey.sol
+++ b/contracts/ContributorUnlockKey.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title ContributorUnlockKey
+ * @notice NFT access token that unlocks elevated Vaultfire features when minted.
+ */
+interface IUnlockHook {
+    function onMint(address to, uint256 tokenId) external;
+}
+
+contract ContributorUnlockKey is ERC721, Ownable {
+    uint256 private _tokenId;
+    address public unlockHook;
+
+    event UnlockHookSet(address indexed hook);
+
+    constructor() ERC721("Contributor Unlock Key", "CUK") {}
+
+    function setUnlockHook(address hook) external onlyOwner {
+        unlockHook = hook;
+        emit UnlockHookSet(hook);
+    }
+
+    function mint(address to) external onlyOwner returns (uint256) {
+        _tokenId += 1;
+        uint256 newId = _tokenId;
+        _mint(to, newId);
+        if (unlockHook != address(0)) {
+            IUnlockHook(unlockHook).onMint(to, newId);
+        }
+        return newId;
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,11 @@
+require("@nomicfoundation/hardhat-toolbox");
+
+module.exports = {
+  solidity: "0.8.19",
+  networks: {
+    base: {
+      url: process.env.BASE_RPC_URL || "http://localhost:8545",
+      accounts: process.env.BASE_PRIVATE_KEY ? [process.env.BASE_PRIVATE_KEY] : [],
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ghostkey-316-vaultfire-init",
+  "version": "1.0.0",
+  "description": "**This system is not built for profit. It is built for people.**",
+  "main": "manifesto_broadcast.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,13 @@
+const hre = require("hardhat");
+
+async function main() {
+  const Unlock = await hre.ethers.getContractFactory("ContributorUnlockKey");
+  const unlock = await Unlock.deploy();
+  await unlock.deployed();
+  console.log(`ContributorUnlockKey deployed to ${unlock.address}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/vaultfire_cli.py
+++ b/vaultfire_cli.py
@@ -2,6 +2,7 @@ import argparse
 import json
 from pathlib import Path
 import zipfile
+from web3 import Web3
 
 from engine.self_audit import run_self_audit
 from simulate_partner_activation import activation_hook, ALIGNMENT_PHRASE
@@ -66,6 +67,37 @@ def cmd_export_logs(args: argparse.Namespace) -> None:
     print(f"Logs exported to {out_path}")
 
 
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def cmd_unlock_access(args: argparse.Namespace) -> None:
+    """Verify NFT ownership and enable access hooks."""
+    w3 = get_web3()
+    contract = w3.eth.contract(address=Web3.to_checksum_address(args.contract), abi=json.loads(Path(args.abi).read_text()))
+    balance = contract.functions.balanceOf(Web3.to_checksum_address(args.wallet)).call()
+    if balance > 0:
+        cfg_path = Path("vaultfire_crypto_hooks.json")
+        cfg = _load_json(cfg_path, {})
+        cfg["nft_access_unlocked"] = True
+        _write_json(cfg_path, cfg)
+        print("Access unlocked for", args.wallet)
+    else:
+        print("NFT not found for", args.wallet)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="vaultfire-cli", description="Vaultfire multi-tool")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -90,6 +122,12 @@ def main(argv: list[str] | None = None) -> int:
     p_logs = sub.add_parser("export-logs", help="Export logs as zip")
     p_logs.add_argument("--output", default="logs.zip", help="Output zip file")
     p_logs.set_defaults(func=cmd_export_logs)
+
+    p_unlock = sub.add_parser("unlock", help="Unlock access via NFT")
+    p_unlock.add_argument("contract", help="ContributorUnlockKey contract")
+    p_unlock.add_argument("abi", help="Path to contract ABI JSON")
+    p_unlock.add_argument("wallet", help="Wallet address to check")
+    p_unlock.set_defaults(func=cmd_unlock_access)
 
     args = parser.parse_args(argv)
     args.func(args)

--- a/vaultfire_crypto_hooks.json
+++ b/vaultfire_crypto_hooks.json
@@ -2,5 +2,6 @@
   "wallet_auth_hook": true,
   "ethics_gate": true,
   "signature_verification": true,
-  "xp_token_bridge": true
+  "xp_token_bridge": true,
+  "nft_access_unlocked": false
 }


### PR DESCRIPTION
## Summary
- add ContributorUnlockKey NFT contract with optional hook
- setup minimal Hardhat config
- add deploy script and ignore node artifacts
- extend CLI with `unlock` command to verify NFT ownership and toggle config
- document new NFT security disclaimer

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npx hardhat compile` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687f1aadc1fc8322a39a4a3fe15ed2c1