### PR TITLE
Add codex_fork utility

### DIFF
--- a/codex_fork.py
+++ b/codex_fork.py
@@ -1,0 +1,36 @@
+"""
+This script performs a full protocol fork with identity sync, belief injection, and partner-readiness validation.
+"""
+
+import argparse
+import subprocess
+import datetime
+
+def main():
+    parser = argparse.ArgumentParser(description="Codex Fork Utility")
+    parser.add_argument('--origin', required=True)
+    parser.add_argument('--inject', required=True)
+    parser.add_argument('--ready-status', required=True)
+    parser.add_argument('--partner-ready', required=True)
+    parser.add_argument('--activate', action='store_true')
+    parser.add_argument('--validate-all', action='store_true')
+    args = parser.parse_args()
+
+    print(f"\n🔁 Forking from: {args.origin}")
+    print(f"🧠 Injecting belief: \"{args.inject}\"")
+    print(f"✅ Ready status: {args.ready_status}")
+    print(f"🔌 Partner-ready: {args.partner_ready}")
+    
+    if args.activate:
+        print("🚀 Activation triggered…")
+        subprocess.run(['python3', 'simulate_partner_activation.py', args.origin, '--hook', '--silent', '--test-mode'])
+
+    if args.validate_all:
+        print("🛡️ Validating system integrity…")
+        subprocess.run(['python3', 'system_integrity_check.py', '--test-mode', '--silent'])
+
+    now = datetime.datetime.utcnow()
+    print(f"\n📦 Fork completed at {now.isoformat()} UTC")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `codex_fork.py` as a minimal script for protocol forking operations

## Testing
- `npm test` *(fails: jest not found)*
- `python3 codex_fork.py --origin ghostkey316.eth --inject "Morals Before Metrics." --ready-status "✅" --partner-ready true --activate --validate-all`


------
https://chatgpt.com/codex/tasks/task_e_687f201957f083228bde809e7857c1ab