### PR TITLE
Add fork script hashing

### DIFF
--- a/codex_fork.py
+++ b/codex_fork.py
@@ -5,6 +5,7 @@ This script performs a full protocol fork with identity sync, belief injection, 
 import argparse
 import subprocess
 import datetime
+import hashlib
 
 def main():
     parser = argparse.ArgumentParser(description="Codex Fork Utility")
@@ -28,6 +29,10 @@ def main():
     if args.validate_all:
         print("🛡️ Validating system integrity…")
         subprocess.run(['python3', 'system_integrity_check.py', '--test-mode', '--silent'])
+
+    with open(__file__, 'rb') as f:
+        file_hash = hashlib.sha256(f.read()).hexdigest()
+    print(f"🧾 Fork hash: {file_hash}")
 
     now = datetime.datetime.utcnow()
     print(f"\n📦 Fork completed at {now.isoformat()} UTC")


### PR DESCRIPTION
## Summary
- show sha256 hash after running the fork utility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f216b3ff883229c71fa45dc34d98a