### PR TITLE
Add input validation for partner activation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ handshake. Pass a partner ID, one or more wallets and the alignment phrase:
 python3 simulate_partner_activation.py demo_id demo_wallet.eth --phrase "Morals Before Metrics."
 ```
 
-Multiple wallets are accepted by listing them separated by spaces.
+The `partner_id` and at least one wallet are required. Multiple wallets are accepted by listing them separated by spaces.
 
 To use a JSON payload offline, pipe it to `activation_hook.py`:
 

--- a/simulate_partner_activation.py
+++ b/simulate_partner_activation.py
@@ -22,6 +22,11 @@ def simulate_activation(partner_id: str, wallets: list[str],
     """Run activation checks and return a result object."""
     failures: list[str] = []
 
+    if not partner_id:
+        failures.append("partner_id missing")
+    if not wallets:
+        failures.append("wallets missing")
+
     if not check_alignment_phrase(phrase):
         failures.append("alignment phrase mismatch")
 


### PR DESCRIPTION
## Summary
- prevent activation when partner_id or wallet list missing
- clarify required inputs in README

## Testing
- `python3 -m py_compile simulate_partner_activation.py`
- `python3 simulate_partner_activation.py demo ghostkey316.eth --test-mode`
- `echo '{"partner_id": "demo", "wallets": [], "phrase": "Morals Before Metrics."}' | python3 activation_hook.py -`
- `python3 system_integrity_check.py --activation-hook --partner-id demo --wallet ghostkey316.eth --phrase "Morals Before Metrics." --test-mode`

------
https://chatgpt.com/codex/tasks/task_e_687f25082a988322aed175882855c407