### PR TITLE
Add partner-export metrics option

### DIFF
--- a/codex_fork.py
+++ b/codex_fork.py
@@ -9,26 +9,38 @@ import hashlib
 
 def main():
     parser = argparse.ArgumentParser(description="Codex Fork Utility")
-    parser.add_argument('--origin', required=True)
-    parser.add_argument('--inject', required=True)
-    parser.add_argument('--ready-status', required=True)
-    parser.add_argument('--partner-ready', required=True)
-    parser.add_argument('--activate', action='store_true')
-    parser.add_argument('--validate-all', action='store_true')
+    parser.add_argument("--wallet", required=True, help="Wallet identifier")
+    parser.add_argument("--inject-ethic", required=True,
+                        help="Belief directive to inject")
+    parser.add_argument("--activate", action="store_true",
+                        help="Trigger activation hook")
+    parser.add_argument("--validate-all", action="store_true",
+                        help="Run system integrity check")
     args = parser.parse_args()
 
-    print(f"\n🔁 Forking from: {args.origin}")
-    print(f"🧠 Injecting belief: \"{args.inject}\"")
-    print(f"✅ Ready status: {args.ready_status}")
-    print(f"🔌 Partner-ready: {args.partner_ready}")
+    print(f"\n🔁 Forking for wallet: {args.wallet}")
+    print(f"🧠 Injecting belief: \"{args.inject_ethic}\"")
     
     if args.activate:
         print("🚀 Activation triggered…")
-        subprocess.run(['python3', 'simulate_partner_activation.py', args.origin, '--hook', '--silent', '--test-mode'])
+        subprocess.run([
+            'python3',
+            'simulate_partner_activation.py',
+            'demo',
+            args.wallet,
+            '--hook',
+            '--silent',
+            '--test-mode',
+        ])
 
     if args.validate_all:
         print("🛡️ Validating system integrity…")
-        subprocess.run(['python3', 'system_integrity_check.py', '--test-mode', '--silent'])
+        subprocess.run([
+            'python3',
+            'system_integrity_check.py',
+            '--test-mode',
+            '--silent',
+        ])
 
     with open(__file__, 'rb') as f:
         file_hash = hashlib.sha256(f.read()).hexdigest()

--- a/vaultfire_cli.py
+++ b/vaultfire_cli.py
@@ -85,10 +85,13 @@ def cmd_partner_export(args: argparse.Namespace) -> None:
     data = {
         "wallet": args.wallet,
         "ethic": args.inject_ethic,
-        "encoded_metrics": "VFv1.0::C316::Vaultfire-Partner-Ready",
-        "timestamp": int(time.time()),
-        "version": "codex_fork_1.0",
     }
+    if args.encode_metrics:
+        data["encoded_metrics"] = "VFv1.0::C316::VaultfireProtocol"
+    else:
+        data["encoded_metrics"] = None
+    data["timestamp"] = int(time.time())
+    data["version"] = "codex_fork_1.0"
     out_path = Path(args.output)
     try:
         out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -166,6 +169,7 @@ def main(argv: list[str] | None = None) -> int:
     p_export = sub.add_parser("partner-export", help="Export partner data")
     p_export.add_argument("--wallet", required=True, help="Wallet address")
     p_export.add_argument("--inject-ethic", required=True, help="Ethics statement")
+    p_export.add_argument("--encode-metrics", action="store_true", help="Include encoded metrics")
     p_export.add_argument("--output", required=True, help="Output JSON file")
     p_export.set_defaults(func=cmd_partner_export)
 


### PR DESCRIPTION
## Summary
- update `codex_fork.py` to accept `--wallet` and `--inject-ethic`
- adjust optional activation and validation flows
- enhance CLI `partner-export` subcommand with `--encode-metrics` flag
- output new metrics string `VFv1.0::C316::VaultfireProtocol`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f26f4b4e08322bdf69b287688e924