### PR TITLE
Add partner export JSON

### DIFF
--- a/codex_fork_bundle.json
+++ b/codex_fork_bundle.json
@@ -1,0 +1,7 @@
+{
+  "wallet": "ghostkey316.eth",
+  "ethic": "Morals Before Metrics.",
+  "encoded_metrics": "VFv1.0::C316::VaultfireProtocol",
+  "timestamp": 1753164046,
+  "version": "codex_fork_1.0"
+}


### PR DESCRIPTION
## Summary
- run final activation commands per request
- store partner export JSON bundle generated by the CLI

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f28d33694832289d9351818873d21