### PR TITLE
Add healing trust engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ If you don’t believe in that, walk away now.
 If you do—  
 **Welcome to Vaultfire. You just joined something real.**
 
+## Healing Trust Engine
+
+Vaultfire now includes a behavior-based trust engine for ranking community
+healing methods. Each method receives a score based on verified reports,
+consistency of results, and whether it is backed by non-commercial sources.
+Top contributors automatically earn protocol-level recognition tokens.
+
 # Vaultfire Init – Ghostkey-316
 
 > "Mark me eternal. Let the block remember my name."

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -37,6 +37,7 @@ from .ens_sync_status import read_sync_status
 from .public_health_matcher import match_symptom
 from .biofeedback import record_biofeedback, fetch_from_provider, get_latest_biofeedback
 from .health_node import recommendations as health_recommendations
+from .healing_trust_engine import rank_healing_methods, reward_top_contributors
 
 __all__ = [
     "resolve_identity",
@@ -74,4 +75,6 @@ __all__ = [
     "fetch_from_provider",
     "get_latest_biofeedback",
     "health_recommendations",
+    "rank_healing_methods",
+    "reward_top_contributors",
 ]

--- a/engine/healing_trust_engine.py
+++ b/engine/healing_trust_engine.py
@@ -1,0 +1,77 @@
+"""Rank community healing methods and reward top contributors."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict
+
+from .token_ops import send_token
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+REPORTS_PATH = BASE_DIR / "knowledge_repo" / "data" / "healing_reports.json"
+RANKS_PATH = BASE_DIR / "dashboards" / "healing_method_ranks.json"
+LOG_PATH = BASE_DIR / "logs" / "healing_reward_log.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _trust_score(entry: Dict) -> float:
+    reports = entry.get("verified_reports", 0)
+    consistency = entry.get("consistent_results", 0.0)
+    non_commercial = 0.1 if entry.get("non_commercial_backing") else 0.0
+    score = reports * 0.5 + consistency * 0.4 + non_commercial
+    return round(score, 2)
+
+
+def rank_healing_methods() -> List[Dict]:
+    """Return ranked healing methods sorted by trust score."""
+    data = _load_json(REPORTS_PATH, [])
+    ranked = []
+    for item in data:
+        score = _trust_score(item)
+        ranked.append({**item, "trust_score": score})
+    ranked.sort(key=lambda x: x["trust_score"], reverse=True)
+    _write_json(RANKS_PATH, ranked)
+    return ranked
+
+
+def _log_reward(entry: dict) -> None:
+    log = _load_json(LOG_PATH, [])
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    log.append({"timestamp": timestamp, **entry})
+    _write_json(LOG_PATH, log)
+
+
+def reward_top_contributors(top_n: int = 3) -> List[Dict]:
+    """Send recognition tokens to contributors of top-ranked methods."""
+    ranked = rank_healing_methods()
+    top = ranked[:top_n]
+    rewards = []
+    for item in top:
+        wallet = item.get("contributor")
+        if wallet:
+            send_token(wallet, 1, "RECOG")
+            entry = {"contributor": wallet, "method": item.get("method")}
+            rewards.append(entry)
+            _log_reward(entry)
+    return rewards
+
+
+if __name__ == "__main__":
+    info = reward_top_contributors()
+    print(json.dumps(info, indent=2))

--- a/knowledge_repo/data/healing_reports.json
+++ b/knowledge_repo/data/healing_reports.json
@@ -1,0 +1,23 @@
+[
+  {
+    "method": "Cold Shower Therapy",
+    "verified_reports": 10,
+    "consistent_results": 0.7,
+    "non_commercial_backing": true,
+    "contributor": "alice.eth"
+  },
+  {
+    "method": "Herbal Steam Inhalation",
+    "verified_reports": 5,
+    "consistent_results": 0.6,
+    "non_commercial_backing": true,
+    "contributor": "bob.eth"
+  },
+  {
+    "method": "Sound Bath Meditation",
+    "verified_reports": 2,
+    "consistent_results": 0.4,
+    "non_commercial_backing": false,
+    "contributor": "carol.eth"
+  }
+]


### PR DESCRIPTION
## Summary
- integrate healing trust engine for ranking remedies
- reward top contributors with recognition tokens
- export new utilities in the engine package
- document the new system in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe9fd10488322866a89840ed0e09b