### PR TITLE
Add CureWatch trigger for healing submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Vaultfire Init represents the first development signal from **Ghostkey-316** (Br
 - `engine/signal_engine.py` – calculates alignment scores and triggers rewards.
 - `engine/loyalty_engine.py` – ranks contributors using tiered behavior multipliers.
 - `engine/signal_reward.py` – awards contributor badges and token drops for verified signal events.
+- `engine/curewatch.py` – flags recurring high-effectiveness treatments as `CureWatch` for governance review.
 - `logs/` – location for generated log files (ignored by Git). This now includes
   `token_ledger.json` which tracks token rewards when partnerships enable direct
   payouts.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -38,6 +38,7 @@ from .public_health_matcher import match_symptom
 from .biofeedback import record_biofeedback, fetch_from_provider, get_latest_biofeedback
 from .health_node import recommendations as health_recommendations
 from .healing_trust_engine import rank_healing_methods, reward_top_contributors
+from .curewatch import flag_effective_patterns
 
 __all__ = [
     "resolve_identity",
@@ -77,4 +78,5 @@ __all__ = [
     "health_recommendations",
     "rank_healing_methods",
     "reward_top_contributors",
+    "flag_effective_patterns",
 ]

--- a/engine/curewatch.py
+++ b/engine/curewatch.py
@@ -1,0 +1,71 @@
+"""Monitor healing submissions for high-effectiveness patterns.
+
+This module flags recurring treatment methods with strong trust scores and
+notifies governance under a 'CureWatch' tag.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+REPORTS_PATH = BASE_DIR / "knowledge_repo" / "data" / "healing_reports.json"
+NOTIFY_PATH = BASE_DIR / "governance" / "curewatch_notifications.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _trust_score(entry: Dict) -> float:
+    reports = entry.get("verified_reports", 0)
+    consistency = entry.get("consistent_results", 0.0)
+    non_commercial = 0.1 if entry.get("non_commercial_backing") else 0.0
+    score = reports * 0.5 + consistency * 0.4 + non_commercial
+    return round(score, 2)
+
+
+def flag_effective_patterns(min_reports: int = 2, threshold: float = 5.0) -> List[Dict]:
+    """Return flagged methods that exceed ``threshold`` trust on ``min_reports`` submissions."""
+    data = _load_json(REPORTS_PATH, [])
+    methods: Dict[str, List[float]] = {}
+    for item in data:
+        method = item.get("method")
+        if not method:
+            continue
+        methods.setdefault(method, []).append(_trust_score(item))
+
+    flags = []
+    for method, scores in methods.items():
+        if len(scores) >= min_reports:
+            avg_score = sum(scores) / len(scores)
+            if avg_score >= threshold:
+                flags.append({"method": method, "count": len(scores), "avg_score": round(avg_score, 2)})
+
+    if not flags:
+        return []
+
+    log = _load_json(NOTIFY_PATH, [])
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    for entry in flags:
+        log.append({"timestamp": timestamp, "tag": "CureWatch", **entry})
+    _write_json(NOTIFY_PATH, log)
+    return flags
+
+
+if __name__ == "__main__":
+    print(json.dumps(flag_effective_patterns(), indent=2))


### PR DESCRIPTION
## Summary
- monitor healing reports for recurring high trust scores
- log flagged treatment patterns under `governance/curewatch_notifications.json`
- expose `flag_effective_patterns` via `engine/__init__`
- mention the new CureWatch module in the README

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff145589083228da21ed71bce3ee4