### PR TITLE
Add Vaultfire gaming layer and SDK

### DIFF
--- a/docs/gaming_layer.md
+++ b/docs/gaming_layer.md
@@ -1,0 +1,13 @@
+# Vaultfire Gaming Layer
+
+The gaming layer provides reusable helpers so developers can launch multiplayer games that plug into the Vaultfire reward system.
+
+## Features
+
+- **Game sessions** – create, join and end multiplayer rounds using `engine.gaming_layer`.
+- **Reward hooks** – finished sessions can trigger token rewards via Vaultfire partner hooks.
+- **Avatar sync** – players can store an avatar URL which games may display.
+- **On-chain inventory** – record blockchain items per player and fetch them later.
+- **ENS overlays** – map a player ID to an ENS name for consistent identity display.
+
+The `vaultfire_gaming` package exposes a small SDK with a `VaultfireGameSDK` class for easy integration.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -39,6 +39,10 @@ from .biofeedback import record_biofeedback, fetch_from_provider, get_latest_bio
 from .health_node import recommendations as health_recommendations
 from .healing_trust_engine import rank_healing_methods, reward_top_contributors
 from .curewatch import flag_effective_patterns
+from .gaming_layer import create_session, join_session, end_session
+from .avatar_sync import sync_avatar, get_avatar
+from .inventory_storage import add_item, list_items
+from .ens_overlay import overlay_identity, resolve_overlay
 
 __all__ = [
     "resolve_identity",
@@ -79,4 +83,13 @@ __all__ = [
     "rank_healing_methods",
     "reward_top_contributors",
     "flag_effective_patterns",
+    "create_session",
+    "join_session",
+    "end_session",
+    "sync_avatar",
+    "get_avatar",
+    "add_item",
+    "list_items",
+    "overlay_identity",
+    "resolve_overlay",
 ]

--- a/engine/avatar_sync.py
+++ b/engine/avatar_sync.py
@@ -1,0 +1,39 @@
+"""Avatar synchronization utilities for players."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+AVATAR_PATH = BASE_DIR / "logs" / "avatars.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def sync_avatar(user_id: str, avatar_url: str) -> dict:
+    """Store ``avatar_url`` for ``user_id``."""
+    data = _load_json(AVATAR_PATH, {})
+    data[user_id] = avatar_url
+    _write_json(AVATAR_PATH, data)
+    return {"user_id": user_id, "avatar": avatar_url}
+
+
+def get_avatar(user_id: str) -> str | None:
+    """Return avatar URL for ``user_id`` if known."""
+    data = _load_json(AVATAR_PATH, {})
+    return data.get(user_id)

--- a/engine/ens_overlay.py
+++ b/engine/ens_overlay.py
@@ -1,0 +1,39 @@
+"""ENS identity overlays for avatars."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+OVERLAY_PATH = BASE_DIR / "logs" / "ens_overlays.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def overlay_identity(user_id: str, ens_name: str) -> dict:
+    """Associate ``user_id`` with ``ens_name``."""
+    data = _load_json(OVERLAY_PATH, {})
+    data[user_id] = ens_name
+    _write_json(OVERLAY_PATH, data)
+    return {"user_id": user_id, "ens": ens_name}
+
+
+def resolve_overlay(user_id: str) -> str | None:
+    """Return ENS name overlay for ``user_id``."""
+    data = _load_json(OVERLAY_PATH, {})
+    return data.get(user_id)

--- a/engine/gaming_layer.py
+++ b/engine/gaming_layer.py
@@ -1,0 +1,75 @@
+"""Manage multiplayer game sessions with reward hooks."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .partner_hooks import grant_reward
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+SESSIONS_PATH = BASE_DIR / "logs" / "game_sessions.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def create_session(game_id: str, creator: str, metadata: Optional[Dict] = None) -> Dict:
+    """Create a new game session and return the record."""
+    sessions: List[Dict] = _load_json(SESSIONS_PATH, [])
+    session = {
+        "game_id": game_id,
+        "creator": creator,
+        "players": [creator],
+        "metadata": metadata or {},
+        "created": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "active": True,
+    }
+    sessions.append(session)
+    _write_json(SESSIONS_PATH, sessions)
+    return session
+
+
+def join_session(game_id: str, player: str) -> Optional[Dict]:
+    """Add ``player`` to the session ``game_id``."""
+    sessions: List[Dict] = _load_json(SESSIONS_PATH, [])
+    for session in sessions:
+        if session.get("game_id") == game_id and session.get("active"):
+            if player not in session["players"]:
+                session["players"].append(player)
+                _write_json(SESSIONS_PATH, sessions)
+            return session
+    return None
+
+
+def end_session(game_id: str, reward_per_player: float = 0.0, token: str = "ASM") -> Optional[Dict]:
+    """End ``game_id`` session and optionally reward each player."""
+    sessions: List[Dict] = _load_json(SESSIONS_PATH, [])
+    for session in sessions:
+        if session.get("game_id") == game_id and session.get("active"):
+            session["active"] = False
+            session["ended"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            _write_json(SESSIONS_PATH, sessions)
+            if reward_per_player > 0:
+                for player in session.get("players", []):
+                    try:
+                        grant_reward(player, player, reward_per_player, token)
+                    except Exception:
+                        pass
+            return session
+    return None

--- a/engine/inventory_storage.py
+++ b/engine/inventory_storage.py
@@ -1,0 +1,42 @@
+"""Simple on-chain inventory tracking for game items."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+INV_PATH = BASE_DIR / "logs" / "onchain_inventory.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def add_item(user_id: str, item_id: str, tx_hash: str) -> Dict:
+    """Record an item minted on-chain for ``user_id``."""
+    data: Dict[str, List[Dict]] = _load_json(INV_PATH, {})
+    items = data.setdefault(user_id, [])
+    entry = {"item_id": item_id, "tx": tx_hash}
+    items.append(entry)
+    _write_json(INV_PATH, data)
+    return entry
+
+
+def list_items(user_id: str) -> List[Dict]:
+    """Return inventory entries for ``user_id``."""
+    data: Dict[str, List[Dict]] = _load_json(INV_PATH, {})
+    return data.get(user_id, [])

--- a/vaultfire_gaming/__init__.py
+++ b/vaultfire_gaming/__init__.py
@@ -1,0 +1,51 @@
+"""Vaultfire Gaming SDK exposing game session utilities."""
+
+from engine.gaming_layer import create_session, join_session, end_session
+from engine.avatar_sync import sync_avatar, get_avatar
+from engine.inventory_storage import add_item, list_items
+from engine.ens_overlay import overlay_identity, resolve_overlay
+
+__all__ = [
+    "create_session",
+    "join_session",
+    "end_session",
+    "sync_avatar",
+    "get_avatar",
+    "add_item",
+    "list_items",
+    "overlay_identity",
+    "resolve_overlay",
+]
+
+class VaultfireGameSDK:
+    """High-level wrapper for Vaultfire game features."""
+
+    def __init__(self, partner_id: str):
+        self.partner_id = partner_id
+
+    def new_game(self, game_id: str, metadata: dict | None = None):
+        return create_session(game_id, self.partner_id, metadata)
+
+    def join(self, game_id: str, player: str):
+        return join_session(game_id, player)
+
+    def end(self, game_id: str, reward_per_player: float = 0.0, token: str = "ASM"):
+        return end_session(game_id, reward_per_player, token)
+
+    def sync_avatar(self, user_id: str, avatar_url: str):
+        return sync_avatar(user_id, avatar_url)
+
+    def record_item(self, user_id: str, item_id: str, tx_hash: str):
+        return add_item(user_id, item_id, tx_hash)
+
+    def overlay_ens(self, user_id: str, ens_name: str):
+        return overlay_identity(user_id, ens_name)
+
+    def avatar(self, user_id: str):
+        return get_avatar(user_id)
+
+    def items(self, user_id: str):
+        return list_items(user_id)
+
+    def ens(self, user_id: str):
+        return resolve_overlay(user_id)


### PR DESCRIPTION
## Summary
- introduce a modular gaming layer
- add avatar sync, ENS overlays, and on-chain inventory tracking
- expose a `VaultfireGameSDK` package
- document new gaming utilities

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff575d9588322b5915cce5d222702