### PR TITLE
Add Vaultfire arcade launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ python3 onboarding_api.py
 - `GET /health/recommendations/<id>` – personalized suggestions.
 - `POST /case-study` – body `{"condition": "cough", "treatment": "Herbal Tea", "notes": "...", "pseudonym": "anon"}`
 - `GET /case-studies?condition=cough` – list recorded case studies.
+- `POST /arcade/event` – log game outcomes and loyalty boosts.
 
 ### CLI Partner Onboarding
 Use `vaultfire_partner_onboard.js` to onboard a partner from the command line:

--- a/docs/gaming_layer.md
+++ b/docs/gaming_layer.md
@@ -11,3 +11,10 @@ The gaming layer provides reusable helpers so developers can launch multiplayer 
 - **ENS overlays** – map a player ID to an ENS name for consistent identity display.
 
 The `vaultfire_gaming` package exposes a small SDK with a `VaultfireGameSDK` class for easy integration.
+
+### Arcade Launcher
+
+The `vaultfire_arcade` package builds on these helpers with an `ArcadeLauncher`
+class. Registered minigames and puzzle modules can be launched from a simple
+interface and will automatically log learning outcomes, achievements and loyalty
+boosts back to the user's on-chain profile.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -43,6 +43,7 @@ from .gaming_layer import create_session, join_session, end_session
 from .avatar_sync import sync_avatar, get_avatar
 from .inventory_storage import add_item, list_items
 from .ens_overlay import overlay_identity, resolve_overlay
+from .game_logger import log_outcome
 
 __all__ = [
     "resolve_identity",
@@ -92,4 +93,5 @@ __all__ = [
     "list_items",
     "overlay_identity",
     "resolve_overlay",
+    "log_outcome",
 ]

--- a/engine/game_logger.py
+++ b/engine/game_logger.py
@@ -1,0 +1,55 @@
+"""Record learning outcomes, achievements and loyalty boosts."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LOG_PATH = BASE_DIR / "logs" / "game_outcomes.json"
+SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def log_outcome(user_id: str, game_id: str, outcome: Dict,
+                achievements: List[str] | None = None,
+                loyalty_boost: float = 0.0) -> Dict:
+    """Store gameplay result and update user scorecard."""
+    log = _load_json(LOG_PATH, [])
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "user_id": user_id,
+        "game_id": game_id,
+        "outcome": outcome,
+        "achievements": achievements or [],
+        "loyalty_boost": loyalty_boost,
+    }
+    log.append(entry)
+    _write_json(LOG_PATH, log)
+
+    scorecard = _load_json(SCORECARD_PATH, {})
+    info = scorecard.get(user_id, {})
+    info["loyalty"] = info.get("loyalty", 0) + loyalty_boost
+    ach = info.get("achievements", [])
+    ach.extend(a for a in (achievements or []) if a not in ach)
+    info["achievements"] = ach
+    scorecard[user_id] = info
+    _write_json(SCORECARD_PATH, scorecard)
+    return entry

--- a/frontend/pages/arcade.html
+++ b/frontend/pages/arcade.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Vaultfire Arcade</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding:20px; }
+    .game-entry { margin-bottom:10px; }
+  </style>
+</head>
+<body>
+  <h1>Vaultfire Arcade</h1>
+  <div id="gameList"></div>
+  <script src="arcade.js"></script>
+</body>
+</html>

--- a/frontend/pages/arcade.js
+++ b/frontend/pages/arcade.js
@@ -1,0 +1,37 @@
+async function loadGames() {
+  const res = await fetch('../../vaultfire_arcade/games.json').catch(() => null);
+  if (!res || !res.ok) return {};
+  try { return await res.json(); } catch { return {}; }
+}
+
+function displayGames(list) {
+  const container = document.getElementById('gameList');
+  container.innerHTML = '';
+  Object.entries(list).forEach(([id, info]) => {
+    const div = document.createElement('div');
+    div.className = 'game-entry';
+    const btn = document.createElement('button');
+    btn.textContent = `Play ${info.title}`;
+    btn.addEventListener('click', () => playGame(id));
+    div.appendChild(btn);
+    container.appendChild(div);
+  });
+}
+
+async function playGame(gameId) {
+  const payload = {
+    user_id: 'demo_user',
+    game_id: gameId,
+    outcome: { demo: true },
+    achievements: ['started'],
+    loyalty: 1
+  };
+  await fetch('/arcade/event', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  alert(`Session logged for ${gameId}`);
+}
+
+loadGames().then(displayGames);

--- a/onboarding_api.py
+++ b/onboarding_api.py
@@ -192,6 +192,23 @@ def health_recommendations(identifier):
     return jsonify({"recommendations": recs})
 
 
+@app.post("/arcade/event")
+def record_arcade_event():
+    """Log gameplay outcomes and update loyalty."""
+    data = request.get_json(silent=True) or {}
+    user_id = data.get("user_id")
+    game_id = data.get("game_id")
+    outcome = data.get("outcome", {})
+    achievements = data.get("achievements") or []
+    loyalty = float(data.get("loyalty", 0))
+    if not user_id or not game_id:
+        return jsonify({"error": "user_id and game_id required"}), 400
+    from engine.game_logger import log_outcome
+    entry = log_outcome(user_id, game_id, outcome, achievements, loyalty)
+    return jsonify(entry), 201
+
+
+
 @app.get("/ens_sync_status")
 def ens_sync_status_route():
     """Return last Vaultfire sync audit entry for an ENS name."""

--- a/vaultfire_arcade/__init__.py
+++ b/vaultfire_arcade/__init__.py
@@ -1,0 +1,5 @@
+"""Vaultfire Arcade package exposing the arcade launcher."""
+
+from .launcher import ArcadeLauncher
+
+__all__ = ["ArcadeLauncher"]

--- a/vaultfire_arcade/games.json
+++ b/vaultfire_arcade/games.json
@@ -1,0 +1,10 @@
+{
+  "puzzle_demo": {
+    "title": "Pattern Puzzle", 
+    "module": "vaultfire_arcade.minigames.puzzle_demo"
+  },
+  "learning_bot": {
+    "title": "Learning Bot", 
+    "module": "vaultfire_arcade.minigames.learning_bot"
+  }
+}

--- a/vaultfire_arcade/launcher.py
+++ b/vaultfire_arcade/launcher.py
@@ -1,0 +1,56 @@
+"""Arcade-style launcher for Vaultfire games."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from vaultfire_gaming import VaultfireGameSDK
+from engine.game_logger import log_outcome
+
+BASE_DIR = Path(__file__).resolve().parent
+GAMES_PATH = BASE_DIR / "games.json"
+
+
+def _load_games() -> Dict[str, dict]:
+    if GAMES_PATH.exists():
+        try:
+            with open(GAMES_PATH) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+class ArcadeLauncher:
+    """Simple launcher that runs registered games and logs outcomes."""
+
+    def __init__(self, user_id: str):
+        self.user_id = user_id
+        self.sdk = VaultfireGameSDK("VaultfireArcade")
+        self.games = _load_games()
+
+    def list_games(self) -> List[str]:
+        return list(self.games.keys())
+
+    def launch(self, game_id: str) -> dict:
+        meta = self.games.get(game_id)
+        if not meta:
+            raise ValueError("unknown game")
+        self.sdk.new_game(game_id, meta)
+        outcome = {}
+        module_name = meta.get("module")
+        if module_name:
+            try:
+                module = importlib.import_module(module_name)
+                if hasattr(module, "run"):
+                    outcome = module.run(self.user_id) or {}
+            except Exception:
+                outcome = {"error": "failed"}
+        achievements = outcome.get("achievements", [])
+        loyalty = float(outcome.get("loyalty_boost", 0))
+        log_outcome(self.user_id, game_id, outcome, achievements, loyalty)
+        self.sdk.end(game_id, reward_per_player=loyalty, token="LOYAL")
+        return outcome

--- a/vaultfire_arcade/minigames/learning_bot.py
+++ b/vaultfire_arcade/minigames/learning_bot.py
@@ -1,0 +1,13 @@
+"""AI-based learning tool placeholder."""
+
+from __future__ import annotations
+
+
+def run(user_id: str) -> dict:
+    """Return learning metrics and loyalty boost."""
+    return {
+        "score": 50,
+        "achievements": ["ai-lesson-1"],
+        "loyalty_boost": 2.0,
+        "learning": {"memory_retention": 0.9},
+    }

--- a/vaultfire_arcade/minigames/puzzle_demo.py
+++ b/vaultfire_arcade/minigames/puzzle_demo.py
@@ -1,0 +1,14 @@
+"""Sample puzzle module used by the arcade launcher."""
+
+from __future__ import annotations
+
+
+def run(user_id: str) -> dict:
+    """Return a dummy outcome for demonstration."""
+    # Real puzzle logic would go here
+    return {
+        "score": 100,
+        "achievements": ["first-puzzle"],
+        "loyalty_boost": 1.0,
+        "learning": {"pattern_recognition": 0.8},
+    }


### PR DESCRIPTION
## Summary
- implement new game logger and arcade launcher
- expose log_outcome in engine init
- add example minigames and games list
- serve /arcade/event endpoint and doc updates
- create simple frontend arcade page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff6bde1b883229e91ad6133c4feed