### PR TITLE
Add avatar mirror module

### DIFF
--- a/docs/gaming_layer.md
+++ b/docs/gaming_layer.md
@@ -7,6 +7,7 @@ The gaming layer provides reusable helpers so developers can launch multiplayer 
 - **Game sessions** – create, join and end multiplayer rounds using `engine.gaming_layer`.
 - **Reward hooks** – finished sessions can trigger token rewards via Vaultfire partner hooks.
 - **Avatar sync** – players can store an avatar URL which games may display.
+- **Mirrored avatars** – contract events adjust stats, traits and questline.
 - **On-chain inventory** – record blockchain items per player and fetch them later.
 - **ENS overlays** – map a player ID to an ENS name for consistent identity display.
 

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -44,6 +44,7 @@ from .avatar_sync import sync_avatar, get_avatar
 from .inventory_storage import add_item, list_items
 from .ens_overlay import overlay_identity, resolve_overlay
 from .game_logger import log_outcome
+from .avatar_mirror import record_avatar_event, get_mirrored_profile
 
 __all__ = [
     "resolve_identity",
@@ -94,4 +95,6 @@ __all__ = [
     "overlay_identity",
     "resolve_overlay",
     "log_outcome",
+    "record_avatar_event",
+    "get_mirrored_profile",
 ]

--- a/engine/avatar_mirror.py
+++ b/engine/avatar_mirror.py
@@ -1,0 +1,67 @@
+"""Mirror avatar traits from contract events."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Any
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+PROFILE_PATH = BASE_DIR / "logs" / "mirrored_avatars.json"
+EVENTS_PATH = BASE_DIR / "logs" / "avatar_events.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _update_profile(profile: Dict, event_type: str, data: Dict[str, Any]) -> Dict:
+    if event_type == "stat_change":
+        stats = profile.setdefault("stats", {})
+        for key, val in data.items():
+            stats[key] = stats.get(key, 0) + float(val)
+    elif event_type == "trait_update":
+        traits = profile.setdefault("traits", {})
+        traits.update(data)
+    elif event_type == "quest_alignment":
+        profile["quest"] = data.get("quest", profile.get("quest"))
+    return profile
+
+
+def record_avatar_event(user_id: str, event_type: str, data: Dict[str, Any]) -> Dict:
+    """Record a contract event and mirror updates into the avatar profile."""
+    events: List[Dict] = _load_json(EVENTS_PATH, [])
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "user_id": user_id,
+        "event": event_type,
+        "data": data,
+    }
+    events.append(entry)
+    _write_json(EVENTS_PATH, events)
+
+    profiles: Dict[str, Dict] = _load_json(PROFILE_PATH, {})
+    profile = profiles.get(user_id, {})
+    profile = _update_profile(profile, event_type, data)
+    profiles[user_id] = profile
+    _write_json(PROFILE_PATH, profiles)
+    return profile
+
+
+def get_mirrored_profile(user_id: str) -> Dict | None:
+    """Return the mirrored avatar profile for ``user_id``."""
+    data: Dict[str, Dict] = _load_json(PROFILE_PATH, {})
+    return data.get(user_id)

--- a/vaultfire_gaming/__init__.py
+++ b/vaultfire_gaming/__init__.py
@@ -2,6 +2,7 @@
 
 from engine.gaming_layer import create_session, join_session, end_session
 from engine.avatar_sync import sync_avatar, get_avatar
+from engine.avatar_mirror import record_avatar_event, get_mirrored_profile
 from engine.inventory_storage import add_item, list_items
 from engine.ens_overlay import overlay_identity, resolve_overlay
 
@@ -11,6 +12,8 @@ __all__ = [
     "end_session",
     "sync_avatar",
     "get_avatar",
+    "record_avatar_event",
+    "get_mirrored_profile",
     "add_item",
     "list_items",
     "overlay_identity",
@@ -35,6 +38,9 @@ class VaultfireGameSDK:
     def sync_avatar(self, user_id: str, avatar_url: str):
         return sync_avatar(user_id, avatar_url)
 
+    def mirror_event(self, user_id: str, event_type: str, data: dict):
+        return record_avatar_event(user_id, event_type, data)
+
     def record_item(self, user_id: str, item_id: str, tx_hash: str):
         return add_item(user_id, item_id, tx_hash)
 
@@ -43,6 +49,9 @@ class VaultfireGameSDK:
 
     def avatar(self, user_id: str):
         return get_avatar(user_id)
+
+    def mirrored_profile(self, user_id: str):
+        return get_mirrored_profile(user_id)
 
     def items(self, user_id: str):
         return list_items(user_id)


### PR DESCRIPTION
## Summary
- build `avatar_mirror` to sync contract events with avatar profiles
- export new helper in the engine and gaming SDK
- document mirrored avatar support

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff8543484832289b08d1dafd80dc6