### PR TITLE
Add guest mode to Vaultfire Arcade

### DIFF
--- a/docs/gaming_layer.md
+++ b/docs/gaming_layer.md
@@ -19,3 +19,12 @@ The `vaultfire_arcade` package builds on these helpers with an `ArcadeLauncher`
 class. Registered minigames and puzzle modules can be launched from a simple
 interface and will automatically log learning outcomes, achievements and loyalty
 boosts back to the user's on-chain profile.
+
+#### Guest Mode
+
+`ArcadeLauncher` now accepts an optional `user_id`. When omitted, a guest
+identifier is generated so visitors can play without connecting a wallet. All
+game outcomes are cached locally under this guest ID. Once the player confirms
+their identity through ENS or a partner protocol, calling
+`overlay_ens(guest_id, "name.eth")` merges the cached progress into the final
+profile.

--- a/vaultfire_arcade/guest_progress.py
+++ b/vaultfire_arcade/guest_progress.py
@@ -1,0 +1,58 @@
+"""Utilities for caching guest progress and merging into a profile."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LOG_PATH = BASE_DIR / "logs" / "game_outcomes.json"
+SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def merge_guest_progress(guest_id: str, user_id: str) -> None:
+    """Merge cached progress from ``guest_id`` into ``user_id``."""
+    if not guest_id or not user_id or guest_id == user_id:
+        return
+
+    log: List[Dict] = _load_json(LOG_PATH, [])
+    updated = False
+    for entry in log:
+        if entry.get("user_id") == guest_id:
+            entry["user_id"] = user_id
+            updated = True
+    if updated:
+        _write_json(LOG_PATH, log)
+
+    scorecard: Dict[str, Dict] = _load_json(SCORECARD_PATH, {})
+    guest = scorecard.pop(guest_id, None)
+    if guest:
+        user = scorecard.get(user_id, {})
+        for key, value in guest.items():
+            if isinstance(value, list):
+                combined = set(user.get(key, []))
+                combined.update(value)
+                user[key] = sorted(combined)
+            elif isinstance(value, (int, float)):
+                user[key] = user.get(key, 0) + value
+            elif key not in user:
+                user[key] = value
+        scorecard[user_id] = user
+        _write_json(SCORECARD_PATH, scorecard)

--- a/vaultfire_arcade/launcher.py
+++ b/vaultfire_arcade/launcher.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import importlib
 import json
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
+from uuid import uuid4
 
 from vaultfire_gaming import VaultfireGameSDK
 from engine.game_logger import log_outcome
@@ -27,10 +28,25 @@ def _load_games() -> Dict[str, dict]:
 class ArcadeLauncher:
     """Simple launcher that runs registered games and logs outcomes."""
 
-    def __init__(self, user_id: str):
-        self.user_id = user_id
+    def __init__(self, user_id: Optional[str] = None):
+        if user_id:
+            self.user_id = user_id
+            self.is_guest = False
+        else:
+            self.user_id = f"guest-{uuid4().hex}"
+            self.is_guest = True
         self.sdk = VaultfireGameSDK("VaultfireArcade")
         self.games = _load_games()
+
+    def merge_progress(self, new_user_id: str) -> None:
+        """Merge guest session data into ``new_user_id``."""
+        if not self.is_guest or not new_user_id:
+            return
+        from .guest_progress import merge_guest_progress
+
+        merge_guest_progress(self.user_id, new_user_id)
+        self.user_id = new_user_id
+        self.is_guest = False
 
     def list_games(self) -> List[str]:
         return list(self.games.keys())

--- a/vaultfire_gaming/__init__.py
+++ b/vaultfire_gaming/__init__.py
@@ -5,6 +5,7 @@ from engine.avatar_sync import sync_avatar, get_avatar
 from engine.avatar_mirror import record_avatar_event, get_mirrored_profile
 from engine.inventory_storage import add_item, list_items
 from engine.ens_overlay import overlay_identity, resolve_overlay
+from vaultfire_arcade.guest_progress import merge_guest_progress
 
 __all__ = [
     "create_session",
@@ -45,7 +46,10 @@ class VaultfireGameSDK:
         return add_item(user_id, item_id, tx_hash)
 
     def overlay_ens(self, user_id: str, ens_name: str):
-        return overlay_identity(user_id, ens_name)
+        result = overlay_identity(user_id, ens_name)
+        if user_id.startswith("guest-"):
+            merge_guest_progress(user_id, ens_name)
+        return result
 
     def avatar(self, user_id: str):
         return get_avatar(user_id)


### PR DESCRIPTION
## Summary
- add optional guest identifiers for ArcadeLauncher
- store guest game outcomes locally and merge when ENS overlay occurs
- expose helper to merge guest progress
- document guest mode in gaming layer docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff97c27f0832291910aa983937de9