### PR TITLE
Add Vaultfire modding layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,3 +458,5 @@ Results are written to `dashboards/contributor_scores.json` and merged into `use
 - Biofeedback integrations do not store raw data and respect device permissions.
 - Case study submissions are anonymized and stored publicly for research.
 - Health sync data is locally encrypted with user keys and has not undergone security review.
+- Modding modules are stored locally and not reviewed for security or content.
+- Loyalty boosts from upvotes carry no monetary value.

--- a/docs/gaming_layer.md
+++ b/docs/gaming_layer.md
@@ -28,3 +28,11 @@ game outcomes are cached locally under this guest ID. Once the player confirms
 their identity through ENS or a partner protocol, calling
 `overlay_ens(guest_id, "name.eth")` merges the cached progress into the final
 profile.
+
+### Modding Layer
+
+The `vaultfire_modding` package lets community members design new game modules
+based on selected belief systems. Modules register a belief theme and an array of
+quest identifiers. A simple visual editor is provided under `frontend/pages/modding_editor.html`.
+Created modules can be upvoted, and each upvote grants a small loyalty boost to
+the voter via `engine.modding_layer.upvote_module`.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -59,6 +59,7 @@ from .health_sync_engine import (
     link_journal_entry,
     get_journal_entries,
 )
+from .modding_layer import create_module, list_modules, upvote_module
 
 __all__ = [
     "resolve_identity",
@@ -124,4 +125,7 @@ __all__ = [
     "get_wearable_data",
     "link_journal_entry",
     "get_journal_entries",
+    "create_module",
+    "list_modules",
+    "upvote_module",
 ]

--- a/engine/modding_layer.py
+++ b/engine/modding_layer.py
@@ -1,0 +1,63 @@
+"""User-generated module system for Vaultfire games."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .game_logger import log_outcome
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+MODS_PATH = BASE_DIR / "logs" / "modding_modules.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def create_module(mod_id: str, creator: str, belief: str,
+                   quests: List[str]) -> Dict:
+    """Register a new modding module with associated quests."""
+    modules: Dict[str, Dict] = _load_json(MODS_PATH, {})
+    if mod_id in modules:
+        return {"error": "module_exists"}
+    modules[mod_id] = {
+        "creator": creator,
+        "belief": belief,
+        "quests": quests,
+        "created": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "votes": 0,
+    }
+    _write_json(MODS_PATH, modules)
+    return modules[mod_id]
+
+
+def list_modules() -> Dict[str, Dict]:
+    """Return all registered modules."""
+    return _load_json(MODS_PATH, {})
+
+
+def upvote_module(mod_id: str, user_id: str, loyalty: float = 0.1) -> Optional[Dict]:
+    """Upvote a module and reward the voter with a loyalty boost."""
+    modules: Dict[str, Dict] = _load_json(MODS_PATH, {})
+    if mod_id not in modules:
+        return None
+    entry = modules[mod_id]
+    entry["votes"] = entry.get("votes", 0) + 1
+    _write_json(MODS_PATH, modules)
+    log_outcome(user_id, mod_id, {"upvote": True}, loyalty_boost=loyalty)
+    return entry

--- a/frontend/pages/modding_editor.html
+++ b/frontend/pages/modding_editor.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Vaultfire Modding Editor</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding:20px; }
+    textarea { width:100%; height:100px; }
+  </style>
+</head>
+<body>
+  <h1>Modding Editor</h1>
+  <label>Module ID: <input id="modId"></label><br><br>
+  <label>Belief System: <input id="belief"></label><br><br>
+  <label>Quests (one per line):</label><br>
+  <textarea id="quests"></textarea><br>
+  <button id="saveBtn">Create Module</button>
+  <pre id="result"></pre>
+  <script src="modding_editor.js"></script>
+</body>
+</html>

--- a/frontend/pages/modding_editor.js
+++ b/frontend/pages/modding_editor.js
@@ -1,0 +1,19 @@
+async function createModule() {
+  const id = document.getElementById('modId').value.trim();
+  const belief = document.getElementById('belief').value.trim();
+  const quests = document.getElementById('quests').value
+    .split('\n')
+    .map(q => q.trim())
+    .filter(q => q);
+  const payload = { mod_id: id, belief, quests };
+  const res = await fetch('/modding/module', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  }).catch(() => null);
+  const output = document.getElementById('result');
+  if (res && res.ok) output.textContent = 'saved';
+  else output.textContent = 'error';
+}
+
+document.getElementById('saveBtn').addEventListener('click', createModule);

--- a/vaultfire_modding/__init__.py
+++ b/vaultfire_modding/__init__.py
@@ -1,0 +1,9 @@
+"""Vaultfire Modding layer exposing module helpers."""
+
+from engine.modding_layer import create_module, list_modules, upvote_module
+
+__all__ = [
+    "create_module",
+    "list_modules",
+    "upvote_module",
+]


### PR DESCRIPTION
## Summary
- expose modding helpers in the engine
- document modding layer in the gaming docs
- add visual editor page for new modules
- include a small upvote-based loyalty system
- extend repository disclaimers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68800280cf108322a917e2de887b3123