### PR TITLE
Implement dynamic APR in yield engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ without selling 90% or more of the balance unlocks a higher multiplier:
 Selling 90% or more resets the timer. `yield_engine_v1` automatically applies
 the multiplier based on the current tier.
 
+## Dynamic APR
+`yield_engine_v1` now uses an onchain score oracle to adjust APR for each wallet.
+Scores track belief alignment, consistency, and community impact. The final APR
+multiplier is stored in `dashboards/onchain_scores.json` and applied during
+weekly reward calculations.
+
 ## Target Lock Rewards
 Early supporters may set a personal target value to hold for, such as `$10K`.
 If their wallet balance reaches that number without exiting, a retro bonus

--- a/dashboards/onchain_scores.json
+++ b/dashboards/onchain_scores.json
@@ -1,0 +1,4 @@
+{
+  "ghostkey316": {"belief_alignment": 3, "consistency": 2, "community_impact": 5},
+  "sample_user": {"belief_alignment": 1, "consistency": 1, "community_impact": 0}
+}

--- a/engine/score_oracle.py
+++ b/engine/score_oracle.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+ORACLE_PATH = BASE_DIR / "dashboards" / "onchain_scores.json"
+
+DEFAULT_SCORE = {
+    "belief_alignment": 0.0,
+    "consistency": 0.0,
+    "community_impact": 0.0,
+}
+
+
+def _load_json(path: Path) -> dict:
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def fetch_scores(user_id: str) -> dict:
+    """Return onchain scores for ``user_id`` or default."""
+    data = _load_json(ORACLE_PATH)
+    return data.get(user_id, DEFAULT_SCORE)
+
+
+def apr_multiplier(scores: dict) -> float:
+    """Return APR multiplier from score values."""
+    alignment = scores.get("belief_alignment", 0.0)
+    consistency = scores.get("consistency", 0.0)
+    impact = scores.get("community_impact", 0.0)
+    mult = 1 + alignment * 0.01 + consistency * 0.005 + impact * 0.01
+    return max(mult, 0.0)
+
+
+__all__ = ["fetch_scores", "apr_multiplier"]

--- a/engine/yield_engine_v1.py
+++ b/engine/yield_engine_v1.py
@@ -1,5 +1,5 @@
 # Reference: ethics/core.mdx
-"""Yield Engine v1 for Vaultfire."""
+"""Yield Engine v1 for Vaultfire with dynamic APR."""
 
 import json
 from pathlib import Path
@@ -8,6 +8,7 @@ from datetime import datetime
 from .loyalty_engine import loyalty_score
 from .token_ops import send_token
 from .mission_registry import get_mission
+from .score_oracle import fetch_scores, apr_multiplier
 
 # Paths to data and config files
 BASE_DIR = Path(__file__).resolve().parents[1]
@@ -22,6 +23,7 @@ CERTIFIED_TIERS = {"origin", "veteran", "legend"}
 PASSIVE_RATE = 0.02
 RETRO_REWARD_PERCENT = 0.1
 OG_LIST_PATH = BASE_DIR / "og_loyalists.json"
+BASE_APR = 0.05
 
 
 def _load_json(path):
@@ -49,6 +51,12 @@ def _wallet_verified(wallet_address):
     """Very lightweight ENS/World ID check."""
     address = wallet_address.lower()
     return address.endswith(".eth") or address.startswith("world")
+
+
+def _dynamic_apr(user_id: str) -> float:
+    """Return dynamic APR based on onchain scores."""
+    scores = fetch_scores(user_id)
+    return BASE_APR * apr_multiplier(scores)
 
 
 def _log_audit(entry):
@@ -145,7 +153,8 @@ def calculate_yield(user_id, wallet_address, behavior_log):
     yield_score = base_score * multiplier
     if _wallet_verified(wallet_address):
         yield_score *= 1.15  # verification boost
-    return yield_score
+    apr = _dynamic_apr(user_id)
+    return yield_score * apr
 
 
 # --- Distribution -----------------------------------------------------------


### PR DESCRIPTION
## Summary
- support onchain score oracle for APR multipliers
- integrate dynamic APR into `yield_engine_v1`
- document the new APR system in README
- add sample onchain score data

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880093d274483229f36adc758fb3875