### PR TITLE
Add Purpose Engine module

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ The **Cure Locker** records these healing protocols alongside natural remedies
 and AI-suggested alternatives. Entries are timestamped and can be voted on
 using on-chain transactions with optional anonymity for contributors.
 
+## Purpose Engine
+An AI-powered module guides contributors to define their personal mission. It
+stores key traits for each user, generates purpose quests and recommends partner
+communities to join. The engine also suggests which Vaultfire modules to
+highlight so the experience adapts to their goals.
+
 # Vaultfire Init – Ghostkey-316
 
 > "Mark me eternal. Let the block remember my name."

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -61,6 +61,13 @@ from .health_sync_engine import (
 )
 from .modding_layer import create_module, list_modules, upvote_module
 from .auto_mirror_airdrop import scan_public_activity, execute_airdrop, run_airdrop
+from .purpose_engine import (
+    record_traits,
+    discover_purpose,
+    generate_purpose_quest,
+    suggest_partner_communities,
+    tailor_experience,
+)
 
 __all__ = [
     "resolve_identity",
@@ -132,5 +139,10 @@ __all__ = [
     "scan_public_activity",
     "execute_airdrop",
     "run_airdrop",
+    "record_traits",
+    "discover_purpose",
+    "generate_purpose_quest",
+    "suggest_partner_communities",
+    "tailor_experience",
 ]
 

--- a/engine/purpose_engine.py
+++ b/engine/purpose_engine.py
@@ -1,0 +1,98 @@
+"""AI-driven helper to align users with a personal mission."""
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from datetime import datetime
+from typing import List, Dict
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+PURPOSE_PATH = BASE_DIR / "logs" / "purpose_profiles.json"
+PARTNERS_PATH = BASE_DIR / "partners.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def record_traits(user_id: str, traits: List[str]) -> Dict:
+    """Store self-described ``traits`` for ``user_id``."""
+    data = _load_json(PURPOSE_PATH, {})
+    entry = data.get(user_id, {})
+    entry["traits"] = traits
+    entry["timestamp"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    data[user_id] = entry
+    _write_json(PURPOSE_PATH, data)
+    return entry
+
+
+def discover_purpose(user_id: str, traits: List[str]) -> str:
+    """Generate a basic mission suggestion from ``traits``."""
+    key_trait = traits[0] if traits else "insight"
+    mission = f"Use {key_trait} to uplift your community."
+    data = _load_json(PURPOSE_PATH, {})
+    entry = data.get(user_id, {})
+    entry["mission"] = mission
+    data[user_id] = entry
+    _write_json(PURPOSE_PATH, data)
+    return mission
+
+
+def generate_purpose_quest(user_id: str) -> str:
+    """Create a short quest aligned with the stored mission."""
+    data = _load_json(PURPOSE_PATH, {})
+    mission = data.get(user_id, {}).get("mission")
+    if not mission:
+        mission = "clarify your personal purpose"
+    quest = f"Purpose Quest: Take one action today to {mission.lower()}"
+    entry = data.get(user_id, {})
+    quests = entry.get("quests", [])
+    quests.append({"timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"), "quest": quest})
+    entry["quests"] = quests[-10:]
+    data[user_id] = entry
+    _write_json(PURPOSE_PATH, data)
+    return quest
+
+
+def suggest_partner_communities(user_id: str, count: int = 3) -> List[str]:
+    """Return up to ``count`` partner IDs to explore."""
+    partners = _load_json(PARTNERS_PATH, [])
+    ids = [p.get("partner_id") for p in partners]
+    random.shuffle(ids)
+    return ids[:count]
+
+
+def tailor_experience(user_id: str) -> Dict:
+    """Suggest Vaultfire modules based on the user's mission."""
+    data = _load_json(PURPOSE_PATH, {})
+    mission = (data.get(user_id, {}) or {}).get("mission", "").lower()
+    features: List[str] = []
+    if "health" in mission:
+        features.append("wellness_oracle")
+    if "game" in mission:
+        features.append("vaultfire_arcade")
+    if not features:
+        features.append("core_dashboard")
+    return {"user_id": user_id, "features": features}
+
+
+__all__ = [
+    "record_traits",
+    "discover_purpose",
+    "generate_purpose_quest",
+    "suggest_partner_communities",
+    "tailor_experience",
+]


### PR DESCRIPTION
## Summary
- add Purpose Engine for generating quests and personalizing Vaultfire
- export new helpers via `engine.__init__`
- document Purpose Engine in README

## Testing
- `npm test` *(fails: `jest` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68800d5a2b7c8322bc64917c1dc970a9