### PR TITLE
Add Forkable Life Path module

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ communities to join. The engine also suggests which Vaultfire modules to
 highlight so the experience adapts to their goals. It now includes a **Moral
 Memory Mirror** that analyzes on‑chain and off‑chain actions, tracks belief
 alignment over time and writes a private behavioral fingerprint to each
-contributor's Vaultfire profile.
+contributor's Vaultfire profile. A new **Forkable Life Path** module lets users
+simulate and commit to themed missions — leader, builder, healer, protector,
+artist and teacher. Each path unlocks unique quests, alliances and long-term
+evolution trees.
 
 # Vaultfire Init – Ghostkey-316
 

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -69,6 +69,8 @@ from .purpose_engine import (
     tailor_experience,
     analyze_actions,
     moral_memory_mirror,
+    simulate_life_path,
+    commit_life_path,
 )
 
 __all__ = [
@@ -148,5 +150,7 @@ __all__ = [
     "tailor_experience",
     "analyze_actions",
     "moral_memory_mirror",
+    "simulate_life_path",
+    "commit_life_path",
 ]
 

--- a/engine/purpose_engine.py
+++ b/engine/purpose_engine.py
@@ -16,6 +16,40 @@ ENGAGEMENT_PATH = BASE_DIR / "logs" / "engagement_data.json"
 EVENT_LOG_PATH = BASE_DIR / "event_log.json"
 MORAL_MEMORY_PATH = BASE_DIR / "logs" / "moral_memory.json"
 FINGERPRINT_PATH = BASE_DIR / "logs" / "behavioral_fingerprint.json"
+LIFE_PATHS_STATE_PATH = BASE_DIR / "logs" / "life_path_state.json"
+
+LIFE_PATHS: Dict[str, Dict[str, List[str]]] = {
+    "leader": {
+        "quests": ["rally a team", "draft a vision"],
+        "alliances": ["governance circle"],
+        "evolution": ["strategist", "visionary", "architect"],
+    },
+    "builder": {
+        "quests": ["prototype a tool", "improve infrastructure"],
+        "alliances": ["makers guild"],
+        "evolution": ["engineer", "architect", "master builder"],
+    },
+    "healer": {
+        "quests": ["share a remedy", "host a wellness check"],
+        "alliances": ["curewatch network"],
+        "evolution": ["mentor", "sage", "lifekeeper"],
+    },
+    "protector": {
+        "quests": ["secure a resource", "safeguard a peer"],
+        "alliances": ["guardian core"],
+        "evolution": ["warden", "shield", "legend"],
+    },
+    "artist": {
+        "quests": ["create a piece", "collaborate on a mural"],
+        "alliances": ["creative collective"],
+        "evolution": ["storyteller", "influencer", "cultural beacon"],
+    },
+    "teacher": {
+        "quests": ["share a lesson", "mentor an apprentice"],
+        "alliances": ["knowledge guild"],
+        "evolution": ["guide", "master", "luminary"],
+    },
+}
 
 
 def _load_json(path: Path, default):
@@ -95,6 +129,26 @@ def tailor_experience(user_id: str) -> Dict:
     return {"user_id": user_id, "features": features}
 
 
+def simulate_life_path(path: str) -> Dict:
+    """Preview quests, alliances and evolution for ``path``."""
+    info = LIFE_PATHS.get(path)
+    if not info:
+        raise ValueError("unknown life path")
+    return {"path": path, **info}
+
+
+def commit_life_path(user_id: str, path: str) -> Dict:
+    """Commit ``user_id`` to a life path and persist the choice."""
+    info = simulate_life_path(path)
+    state = _load_json(LIFE_PATHS_STATE_PATH, {})
+    state[user_id] = {
+        "path": path,
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    _write_json(LIFE_PATHS_STATE_PATH, state)
+    return {"user_id": user_id, **info}
+
+
 def _hash_identifier(identifier: str) -> str:
     return hashlib.sha256(identifier.encode()).hexdigest()
 
@@ -161,4 +215,6 @@ __all__ = [
     "tailor_experience",
     "analyze_actions",
     "moral_memory_mirror",
+    "simulate_life_path",
+    "commit_life_path",
 ]


### PR DESCRIPTION
## Summary
- extend Purpose Engine with forkable life paths
- expose new helpers from engine package
- mention life paths in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688016cec9308322bd7b4f267ad0eecf