### PR TITLE
Implement Global Path Atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,12 @@ python3 engine/contributor_protocol.py
 
 Results are written to `dashboards/contributor_scores.json` and merged into `user_scorecard.json`.
 
+## Global Path Atlas
+Run `python3 generate_path_atlas.py` to build `dashboards/path_atlas.json` summarizing
+each contributor's chosen life path. Open `frontend/pages/global_path_atlas.html`
+in a browser to visualize how participants align around common purpose arcs and
+connect with peers to co-build missions.
+
 ## Disclaimers
 - This repository is experimental software provided for learning and discussion.
 - Nothing here constitutes financial or legal advice.

--- a/dashboards/path_atlas.json
+++ b/dashboards/path_atlas.json
@@ -1,0 +1,4 @@
+{
+  "participants": [],
+  "summary": {}
+}

--- a/frontend/pages/global_path_atlas.html
+++ b/frontend/pages/global_path_atlas.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Global Path Atlas</title>
+  <style>
+    body { background:#111; color:#0ff; font-family: Arial, sans-serif; margin:0; }
+    header { background:#000; padding:20px; text-align:center; }
+    .container { display:flex; flex-wrap:wrap; padding:20px; }
+    .arc { border:1px solid #0ff; border-radius:8px; margin:10px; padding:10px; flex:1; min-width:160px; }
+    .arc h3 { margin-top:0; }
+    .participant { padding:2px 0; cursor:pointer; }
+    .central { text-align:center; margin:20px 0; font-size:1.2em; }
+    #connect { margin:20px; font-style:italic; }
+  </style>
+</head>
+<body>
+  <header><h1>Global Path Atlas</h1></header>
+  <div class="central">Community Mission Hub</div>
+  <div id="atlas" class="container"></div>
+  <div id="connect"></div>
+  <script src="global_path_atlas.js"></script>
+</body>
+</html>

--- a/frontend/pages/global_path_atlas.js
+++ b/frontend/pages/global_path_atlas.js
@@ -1,0 +1,43 @@
+async function loadJSON(path) {
+  const res = await fetch(path).catch(() => null);
+  if (!res || !res.ok) return null;
+  try { return await res.json(); } catch { return null; }
+}
+
+function displayAtlas(data) {
+  const container = document.getElementById('atlas');
+  container.innerHTML = '';
+  if (!data) return;
+  const groups = {};
+  (data.participants || []).forEach(p => {
+    const list = groups[p.path] = groups[p.path] || [];
+    list.push(p);
+  });
+  Object.entries(groups).forEach(([path, list]) => {
+    const div = document.createElement('div');
+    div.className = 'arc';
+    const h = document.createElement('h3');
+    h.textContent = path;
+    div.appendChild(h);
+    list.forEach(u => {
+      const d = document.createElement('div');
+      d.className = 'participant';
+      d.textContent = u.user;
+      d.addEventListener('click', () => connectTo(u.user));
+      div.appendChild(d);
+    });
+    container.appendChild(div);
+  });
+}
+
+function connectTo(user) {
+  const box = document.getElementById('connect');
+  box.textContent = `Connect with ${user} to co-build a mission.`;
+}
+
+async function init() {
+  const data = await loadJSON('../../dashboards/path_atlas.json');
+  displayAtlas(data);
+}
+
+init();

--- a/generate_path_atlas.py
+++ b/generate_path_atlas.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+STATE_PATH = BASE_DIR / "logs" / "life_path_state.json"
+SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
+ATLAS_PATH = BASE_DIR / "dashboards" / "path_atlas.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def build_atlas() -> dict:
+    life_state = _load_json(STATE_PATH, {})
+    scorecard = _load_json(SCORECARD_PATH, {})
+
+    participants = []
+    summary = {}
+    for user, info in life_state.items():
+        path_arc = info.get("path", "unknown")
+        summary[path_arc] = summary.get(path_arc, 0) + 1
+        participants.append({
+            "user": user,
+            "path": path_arc,
+            "score": scorecard.get(user, {}).get("contributor_score", 0),
+            "timestamp": info.get("timestamp"),
+        })
+
+    atlas = {"participants": participants, "summary": summary}
+    _write_json(ATLAS_PATH, atlas)
+    return atlas
+
+
+if __name__ == "__main__":
+    data = build_atlas()
+    print(json.dumps(data, indent=2))


### PR DESCRIPTION
## Summary
- add `generate_path_atlas.py` to build an atlas of participant life paths
- store atlas data in `dashboards/path_atlas.json`
- add new frontend page for visualizing paths
- document usage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68801c02d734832283be13daf00a2f6c