### PR TITLE
Implement Reflection Layer with adaptive quests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ evolution trees.
 The new **Synced Soul Compass** layers in wellness stats, game behavior and
 crypto stewardship to adjust guidance and unlock context-specific quests or
 reflection prompts.
+An additional **Reflection Layer** tags the emotional tone of journal entries
+and interactions, storing private patterns that influence future quests.
 
 # Vaultfire Init – Ghostkey-316
 
@@ -73,6 +75,7 @@ Vaultfire Init represents the first development signal from **Ghostkey-316** (Br
 - `engine/curewatch.py` – flags recurring high-effectiveness treatments as `CureWatch` for governance review.
 - `engine/cure_locker.py` – stores community-sourced healing methods with on-chain vote logs.
 - `engine/archetype_mirror.py` – trains an AI guide from actions, beliefs and journal style.
+- `engine/reflection_layer.py` – tracks encrypted emotion tags and trends.
 - `logs/` – location for generated log files (ignored by Git). This now includes
   `token_ledger.json` which tracks token rewards when partnerships enable direct
   payouts.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -65,6 +65,7 @@ from .purpose_engine import (
     record_traits,
     discover_purpose,
     generate_purpose_quest,
+    adaptive_purpose_quest,
     suggest_partner_communities,
     tailor_experience,
     analyze_actions,
@@ -74,6 +75,7 @@ from .purpose_engine import (
 )
 from .synced_soul_compass import update_soul_compass
 from .archetype_mirror import train_archetype_guide, get_archetype_guide
+from .reflection_layer import update_emotional_state, emotion_trend
 
 __all__ = [
     "resolve_identity",
@@ -148,6 +150,7 @@ __all__ = [
     "record_traits",
     "discover_purpose",
     "generate_purpose_quest",
+    "adaptive_purpose_quest",
     "suggest_partner_communities",
     "tailor_experience",
     "analyze_actions",
@@ -157,5 +160,7 @@ __all__ = [
     "update_soul_compass",
     "train_archetype_guide",
     "get_archetype_guide",
+    "update_emotional_state",
+    "emotion_trend",
 ]
 

--- a/engine/purpose_engine.py
+++ b/engine/purpose_engine.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from datetime import datetime
 from typing import List, Dict
 
+from .reflection_layer import emotion_trend
+
 BASE_DIR = Path(__file__).resolve().parents[1]
 PURPOSE_PATH = BASE_DIR / "logs" / "purpose_profiles.json"
 PARTNERS_PATH = BASE_DIR / "partners.json"
@@ -105,6 +107,20 @@ def generate_purpose_quest(user_id: str) -> str:
     data[user_id] = entry
     _write_json(PURPOSE_PATH, data)
     return quest
+
+
+def adaptive_purpose_quest(user_id: str, key: str) -> str:
+    """Generate a quest influenced by the user's recent emotions."""
+    base = generate_purpose_quest(user_id)
+    trends = emotion_trend(user_id, key)
+    if not trends:
+        return base
+    dominant = max(trends, key=trends.get)
+    if dominant in {"fear", "doubt"}:
+        return base + " Reflect on your concerns and take a small supportive step."
+    if dominant in {"joy", "confidence"}:
+        return base + " Your optimism is a strength—share it with a peer."
+    return base
 
 
 def suggest_partner_communities(user_id: str, count: int = 3) -> List[str]:
@@ -211,6 +227,7 @@ __all__ = [
     "record_traits",
     "discover_purpose",
     "generate_purpose_quest",
+    "adaptive_purpose_quest",
     "suggest_partner_communities",
     "tailor_experience",
     "analyze_actions",

--- a/engine/reflection_layer.py
+++ b/engine/reflection_layer.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Reflection layer for tracking user emotions over time."""
+
+import json
+import hashlib
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from .health_sync_engine import encrypt_data, decrypt_data
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+EMOTION_DIR = BASE_DIR / "logs" / "emotion_state"
+
+# simple keyword mapping for lightweight emotion tagging
+EMOTION_KEYWORDS: Dict[str, set[str]] = {
+    "joy": {"joy", "happy", "glad", "delighted", "grateful"},
+    "fear": {"afraid", "fear", "scared", "terrified"},
+    "doubt": {"doubt", "unsure", "uncertain", "confused"},
+    "confidence": {"confident", "assured", "certain", "bold"},
+}
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _hash_id(identifier: str) -> str:
+    return hashlib.sha256(identifier.encode()).hexdigest()
+
+
+def tag_emotion(text: str) -> str:
+    """Return a basic emotion label from ``text``."""
+    text = text.lower()
+    scores: Dict[str, int] = {}
+    for label, words in EMOTION_KEYWORDS.items():
+        scores[label] = sum(1 for w in words if w in text)
+    if not scores:
+        return "neutral"
+    label = max(scores, key=scores.get)
+    return label if scores[label] > 0 else "neutral"
+
+
+def update_emotional_state(user_id: str, text: str, key: str) -> List[Dict]:
+    """Analyze ``text`` and append encrypted emotion record."""
+    hashed = _hash_id(user_id)
+    path = EMOTION_DIR / f"{hashed}.json"
+    data = _load_json(path, {"entries": []})
+    entries_enc = data.get("entries", [])
+    entries: List[Dict] = []
+    for token in entries_enc:
+        try:
+            entry_text = decrypt_data(token, key)
+            ts, emo = entry_text.split("|", 1)
+            entries.append({"timestamp": ts, "emotion": emo})
+        except Exception:
+            continue
+    emotion = tag_emotion(text)
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    token = encrypt_data(f"{timestamp}|{emotion}", key)
+    entries_enc.append(token)
+    _write_json(path, {"entries": entries_enc})
+    entries.append({"timestamp": timestamp, "emotion": emotion})
+    return entries
+
+
+def emotion_trend(user_id: str, key: str, window: int = 10) -> Dict[str, float]:
+    """Return distribution of emotions for ``user_id``."""
+    hashed = _hash_id(user_id)
+    path = EMOTION_DIR / f"{hashed}.json"
+    data = _load_json(path, {"entries": []})
+    counts: Counter[str] = Counter()
+    for token in data.get("entries", [])[-window:]:
+        try:
+            entry_text = decrypt_data(token, key)
+            _, emo = entry_text.split("|", 1)
+            counts[emo] += 1
+        except Exception:
+            continue
+    total = sum(counts.values())
+    if total == 0:
+        return {}
+    return {e: counts[e] / total for e in counts}
+
+
+__all__ = ["update_emotional_state", "emotion_trend", "tag_emotion"]


### PR DESCRIPTION
## Summary
- add Reflection Layer to tag journal emotions privately
- adjust Purpose Engine quests using emotion trends
- expose emotion functions in package
- document reflection layer in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880221b6ac083228e8e2598448bca11