### PR TITLE
Add gamified yield quest layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Vaultfire Init represents the first development signal from **Ghostkey-316** (Br
 - `engine/cure_locker.py` – stores community-sourced healing methods with on-chain vote logs.
 - `engine/archetype_mirror.py` – trains an AI guide from actions, beliefs and journal style.
 - `engine/reflection_layer.py` – tracks encrypted emotion tags and trends.
+- `engine/gamified_yield_layer.py` – tracks quest streaks and converts XP into vault points.
 - `logs/` – location for generated log files (ignored by Git). This now includes
   `token_ledger.json` which tracks token rewards when partnerships enable direct
   payouts.

--- a/docs/gamified_yield_layer.md
+++ b/docs/gamified_yield_layer.md
@@ -1,0 +1,23 @@
+# Gamified Yield Layer
+
+This module introduces streak-based quests and XP rewards across four domains:
+Health, Crypto, Growth and Gaming. Each completed quest grants XP. Every 100 XP
+automatically converts into a vault point, which may trigger a yield boost via
+the existing `mark_yield_boost` hook.
+
+Quests refresh daily and scale by belief alignment. Higher alignment scores
+unlock tier‑1 quests for bigger rewards. Streaks track consecutive days of
+quest completion and include optional protection to avoid losing progress after
+an occasional missed day.
+
+Frontend components consume the `quest_card()` output to display Quest Cards,
+Daily Tasks and Level Unlocks. XP and streak data are stored in
+`logs/yield_quests.json`.
+
+Cooldowns prevent repeating the same quest within 24 hours. When XP increases
+a full level, `mark_yield_boost()` records the user for a potential yield
+increase.
+
+**Disclaimers**
+- This gamified layer stores progress locally and does not guarantee any
+  financial return.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -76,6 +76,12 @@ from .purpose_engine import (
 from .synced_soul_compass import update_soul_compass
 from .archetype_mirror import train_archetype_guide, get_archetype_guide
 from .reflection_layer import update_emotional_state, emotion_trend
+from .gamified_yield_layer import (
+    get_daily_tasks,
+    complete_task,
+    quest_card,
+    add_streak_protection,
+)
 
 __all__ = [
     "resolve_identity",
@@ -162,5 +168,9 @@ __all__ = [
     "get_archetype_guide",
     "update_emotional_state",
     "emotion_trend",
+    "get_daily_tasks",
+    "complete_task",
+    "quest_card",
+    "add_streak_protection",
 ]
 

--- a/engine/gamified_yield_layer.py
+++ b/engine/gamified_yield_layer.py
@@ -1,0 +1,195 @@
+"""Gamified Yield Layer for Vaultfire.
+
+This module links real-world quest completion to protocol rewards. It
+keeps track of daily tasks, streaks, cooldowns and level progress for
+multiple domains. XP converts to vault points and can trigger yield
+boosts via existing modules.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .purpose_engine import moral_memory_mirror
+from .yield_engine_v1 import mark_yield_boost
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+PROGRESS_PATH = BASE_DIR / "logs" / "yield_quests.json"
+SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
+
+Quest = Dict[str, object]
+
+# Simple quest definitions. "tier" gates quests based on belief milestones.
+QUESTS: Dict[str, List[Quest]] = {
+    "health": [
+        {"id": "hydrate", "desc": "Drink 2L of water", "xp": 10, "tier": 0},
+        {"id": "move", "desc": "Log 30 minutes of movement", "xp": 15, "tier": 0},
+        {"id": "share_tip", "desc": "Share a wellness tip", "xp": 20, "tier": 1},
+    ],
+    "crypto": [
+        {"id": "read_update", "desc": "Read a crypto security update", "xp": 10, "tier": 0},
+        {"id": "practice_tx", "desc": "Run a test transaction", "xp": 15, "tier": 0},
+        {"id": "teach_wallet", "desc": "Teach someone wallet safety", "xp": 25, "tier": 1},
+    ],
+    "growth": [
+        {"id": "journal", "desc": "Write a short reflection", "xp": 10, "tier": 0},
+        {"id": "learn", "desc": "Study a new skill for 20m", "xp": 15, "tier": 0},
+        {"id": "mentor", "desc": "Mentor a newcomer", "xp": 25, "tier": 1},
+    ],
+    "gaming": [
+        {"id": "daily_match", "desc": "Play a quick match", "xp": 10, "tier": 0},
+        {"id": "review_replay", "desc": "Review yesterday's game", "xp": 15, "tier": 0},
+        {"id": "create_mod", "desc": "Submit a mod idea", "xp": 25, "tier": 1},
+    ],
+}
+
+DEFAULT_STREAK = {"count": 0, "last_day": "", "protection": 0}
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _belief_tier(user_id: str) -> int:
+    """Return quest tier based on alignment score."""
+    card = _load_json(SCORECARD_PATH, {})
+    score = card.get(user_id, {}).get("alignment_score", 0)
+    if score >= 200:
+        return 1
+    return 0
+
+
+def _today() -> str:
+    return datetime.utcnow().strftime("%Y-%m-%d")
+
+
+def _record_progress(data: Dict, user_id: str) -> None:
+    _write_json(PROGRESS_PATH, data)
+    # update purpose engine memory for context
+    moral_memory_mirror(user_id)
+
+
+def _user_entry(data: Dict, user_id: str) -> Dict:
+    entry = data.get(user_id)
+    if not entry:
+        entry = {
+            "xp": 0,
+            "vault_points": 0,
+            "streaks": {},
+            "tasks": {},
+        }
+    data[user_id] = entry
+    return entry
+
+
+def _assign_daily_tasks(entry: Dict, tier: int) -> None:
+    today = _today()
+    if entry.get("tasks", {}).get("day") == today:
+        return
+    entry["tasks"] = {"day": today, "domains": {}}
+    for domain, quests in QUESTS.items():
+        available = [q for q in quests if q.get("tier", 0) <= tier]
+        entry["tasks"]["domains"][domain] = [q["id"] for q in available]
+
+
+def get_daily_tasks(user_id: str) -> Dict:
+    """Return today's task list for ``user_id``."""
+    data = _load_json(PROGRESS_PATH, {})
+    entry = _user_entry(data, user_id)
+    tier = _belief_tier(user_id)
+    _assign_daily_tasks(entry, tier)
+    _record_progress(data, user_id)
+    return entry["tasks"]
+
+
+def _cooldown_ok(entry: Dict, domain: str, quest_id: str) -> bool:
+    last = entry.get("last_complete", {}).get(domain, {}).get(quest_id)
+    if not last:
+        return True
+    prev = datetime.fromisoformat(last)
+    return datetime.utcnow() - prev >= timedelta(hours=24)
+
+
+def complete_task(user_id: str, domain: str, quest_id: str) -> Optional[Dict]:
+    """Mark ``quest_id`` complete for ``domain`` if cooldown allows."""
+    data = _load_json(PROGRESS_PATH, {})
+    entry = _user_entry(data, user_id)
+    if domain not in QUESTS:
+        return None
+    all_ids = {q["id"]: q for q in QUESTS[domain]}
+    quest = all_ids.get(quest_id)
+    if not quest:
+        return None
+    tier = _belief_tier(user_id)
+    if quest.get("tier", 0) > tier:
+        return None
+    if not _cooldown_ok(entry, domain, quest_id):
+        return None
+
+    entry.setdefault("last_complete", {}).setdefault(domain, {})[quest_id] = datetime.utcnow().isoformat()
+    entry["xp"] += quest.get("xp", 0)
+    streak = entry.setdefault("streaks", {}).setdefault(domain, DEFAULT_STREAK.copy())
+    today = _today()
+    if streak["last_day"] == today:
+        pass
+    elif streak["last_day"] and datetime.strptime(today, "%Y-%m-%d") - datetime.strptime(streak["last_day"], "%Y-%m-%d") > timedelta(days=1):
+        if streak.get("protection", 0) > 0:
+            streak["protection"] -= 1
+        else:
+            streak["count"] = 0
+    else:
+        streak["count"] += 1
+    streak["last_day"] = today
+    if entry["xp"] // 100 > entry.get("vault_points", 0):
+        entry["vault_points"] = entry["xp"] // 100
+        mark_yield_boost(user_id)
+    _record_progress(data, user_id)
+    return {"quest": quest_id, "domain": domain, "xp": entry["xp"], "streak": streak["count"]}
+
+
+def quest_card(user_id: str) -> Dict:
+    """Return a summary for the frontend."""
+    data = _load_json(PROGRESS_PATH, {})
+    entry = _user_entry(data, user_id)
+    tier = _belief_tier(user_id)
+    _assign_daily_tasks(entry, tier)
+    level = entry["xp"] // 100
+    return {
+        "user_id": user_id,
+        "xp": entry["xp"],
+        "vault_points": entry.get("vault_points", 0),
+        "level": level,
+        "tasks": entry["tasks"],
+        "streaks": entry.get("streaks", {}),
+    }
+
+
+def add_streak_protection(user_id: str, domain: str, amount: int = 1) -> None:
+    data = _load_json(PROGRESS_PATH, {})
+    entry = _user_entry(data, user_id)
+    streak = entry.setdefault("streaks", {}).setdefault(domain, DEFAULT_STREAK.copy())
+    streak["protection"] += amount
+    _record_progress(data, user_id)
+
+
+__all__ = [
+    "get_daily_tasks",
+    "complete_task",
+    "quest_card",
+    "add_streak_protection",
+]


### PR DESCRIPTION
## Summary
- implement `gamified_yield_layer` with streaks, XP and level rewards
- expose quest APIs from `engine.__init__`
- document gamified yield layer
- mention new module in repository structure

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68802384d9c8832283b86534bef438f1