### PR TITLE
Add GeneSync health layer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,10 @@ soulprint receive a weight bonus during steward elections.
 entries to a contributor's profile. Data is stored locally using a user-supplied
 key and grants small wellness point rewards.
 
+`engine/genesync.py` extends the health layer with an opt-in GeneSync module for
+importing anonymized genetic metrics. The data is encrypted and used only to
+personalize health quests and tips.
+
 
 ## Wallet Bonding
 Two contributors can bond their wallets together. While bonded, each member's yield and loyalty multiplier grows with their shared time-in and combined trust behavior. If either wallet exits or breaks a rule, the bond ends and both loyalty timers reset.
@@ -502,6 +506,9 @@ connect with peers to co-build missions.
 - Biofeedback integrations do not store raw data and respect device permissions.
 - Case study submissions are anonymized and stored publicly for research.
 - Health sync data is locally encrypted with user keys and has not undergone security review.
+- GeneSync integration is optional and stores only anonymized metrics off-chain.
+- No genetic data is ever recorded on-chain.
+- Genetic insights do not replace professional medical or genetic counseling.
 - Modding modules are stored locally and not reviewed for security or content.
 - Loyalty boosts from upvotes carry no monetary value.
 - The SwapGate contract is a demo only and does not provide production-grade liquidity or bridging.

--- a/docs/genesync_overview.md
+++ b/docs/genesync_overview.md
@@ -1,0 +1,8 @@
+# GeneSync Overview
+
+GeneSync is an optional privacy-focused layer that lets contributors sync anonymized genetic or biometric metrics with Vaultfire. Data is encrypted locally using the same lightweight scheme as `health_sync_engine.py` and is never stored on-chain. Metrics can be uploaded from wearable providers or DNA reports to personalize health quests and tips.
+
+**Ethical Warning**
+- GeneSync is experimental and should not be used to diagnose or treat conditions without consulting a professional.
+- Participation is entirely opt-in and genetic metrics remain off-chain.
+

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -59,6 +59,12 @@ from .health_sync_engine import (
     link_journal_entry,
     get_journal_entries,
 )
+from .genesync import (
+    link_gene_metrics,
+    get_gene_metrics,
+    gene_risk_level,
+    GENESYNC_WARNING,
+)
 from .modding_layer import create_module, list_modules, upvote_module
 from .auto_mirror_airdrop import scan_public_activity, execute_airdrop, run_airdrop
 from .purpose_engine import (
@@ -147,6 +153,10 @@ __all__ = [
     "get_wearable_data",
     "link_journal_entry",
     "get_journal_entries",
+    "link_gene_metrics",
+    "get_gene_metrics",
+    "gene_risk_level",
+    "GENESYNC_WARNING",
     "create_module",
     "list_modules",
     "upvote_module",

--- a/engine/genesync.py
+++ b/engine/genesync.py
@@ -1,0 +1,82 @@
+"""Opt-in GeneSync integration for anonymized biometric data."""
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+from typing import Dict, Optional
+
+from .health_sync_engine import encrypt_data, decrypt_data
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+GENE_DIR = BASE_DIR / "logs" / "gene_sync"
+
+GENESYNC_WARNING = (
+    "GeneSync is experimental. Handle genetic data responsibly and consult a "
+    "professional before acting on any recommendation."
+)
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _hash_id(identifier: str) -> str:
+    return hashlib.sha256(identifier.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+
+def link_gene_metrics(user_id: str, metrics: Dict[str, float], key: str) -> Dict[str, float]:
+    """Store encrypted GeneSync metrics for ``user_id``."""
+    hashed = _hash_id(user_id)
+    path = GENE_DIR / f"{hashed}_metrics.json"
+    token = encrypt_data(json.dumps(metrics), key)
+    _write_json(path, {"token": token})
+    return metrics
+
+
+def get_gene_metrics(user_id: str, key: str) -> Optional[Dict[str, float]]:
+    """Return decrypted GeneSync metrics for ``user_id`` if available."""
+    hashed = _hash_id(user_id)
+    path = GENE_DIR / f"{hashed}_metrics.json"
+    data = _load_json(path, {})
+    token = data.get("token")
+    if not token:
+        return None
+    try:
+        plain = decrypt_data(token, key)
+        return json.loads(plain)
+    except Exception:
+        return None
+
+
+def gene_risk_level(user_id: str, key: str) -> str:
+    """Return risk level based on GeneSync metrics."""
+    metrics = get_gene_metrics(user_id, key) or {}
+    score = metrics.get("risk_score", 0.0)
+    if score >= 0.7:
+        return "high"
+    if score >= 0.3:
+        return "medium"
+    return "low"
+
+
+__all__ = [
+    "link_gene_metrics",
+    "get_gene_metrics",
+    "gene_risk_level",
+    "GENESYNC_WARNING",
+]

--- a/engine/purpose_engine.py
+++ b/engine/purpose_engine.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import List, Dict
 
 from .reflection_layer import emotion_trend
+from .genesync import gene_risk_level
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 PURPOSE_PATH = BASE_DIR / "logs" / "purpose_profiles.json"
@@ -113,13 +114,19 @@ def adaptive_purpose_quest(user_id: str, key: str) -> str:
     """Generate a quest influenced by the user's recent emotions."""
     base = generate_purpose_quest(user_id)
     trends = emotion_trend(user_id, key)
-    if not trends:
-        return base
-    dominant = max(trends, key=trends.get)
-    if dominant in {"fear", "doubt"}:
-        return base + " Reflect on your concerns and take a small supportive step."
-    if dominant in {"joy", "confidence"}:
-        return base + " Your optimism is a strength—share it with a peer."
+    if trends:
+        dominant = max(trends, key=trends.get)
+        if dominant in {"fear", "doubt"}:
+            base += " Reflect on your concerns and take a small supportive step."
+        elif dominant in {"joy", "confidence"}:
+            base += " Your optimism is a strength—share it with a peer."
+
+    risk = gene_risk_level(user_id, key)
+    if risk == "high":
+        base += " GeneSync alert: schedule a check-up and prioritize rest."
+    elif risk == "medium":
+        base += " GeneSync note: maintain balanced nutrition this week."
+
     return base
 
 
@@ -234,4 +241,5 @@ __all__ = [
     "moral_memory_mirror",
     "simulate_life_path",
     "commit_life_path",
+    "gene_risk_level",
 ]


### PR DESCRIPTION
## Summary
- add new `genesync.py` module for opt-in genetic data sync
- integrate GeneSync risk checks into `adaptive_purpose_quest`
- export GeneSync helpers in `engine/__init__.py`
- document feature and add ethics warnings
- update README disclaimers

## Testing
- `python3 -m py_compile engine/genesync.py engine/purpose_engine.py engine/__init__.py`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688024c513f0832280f00d24b50462ff