### PR TITLE
Add Planetkeeper eco-yield module

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ crypto stewardship to adjust guidance and unlock context-specific quests or
 reflection prompts.
 An additional **Reflection Layer** tags the emotional tone of journal entries
 and interactions, storing private patterns that influence future quests.
+The optional **Planetkeeper Module** tracks eco-friendly actions and links them
+to yield bonuses. Users who opt in can log carbon offsets, efficient device
+usage or sustainability pledges. Completing eco-positive tasks adds
+multipliers inside the Purpose Engine, unlocks a Planetkeeper badge and may
+publish their impact to an optional public dashboard.
 
 # Vaultfire Init – Ghostkey-316
 
@@ -77,6 +82,7 @@ Vaultfire Init represents the first development signal from **Ghostkey-316** (Br
 - `engine/archetype_mirror.py` – trains an AI guide from actions, beliefs and journal style.
 - `engine/reflection_layer.py` – tracks encrypted emotion tags and trends.
 - `engine/gamified_yield_layer.py` – tracks quest streaks and converts XP into vault points.
+- `engine/planetkeeper.py` – records eco-positive behavior for optional yield multipliers.
 - `logs/` – location for generated log files (ignored by Git). This now includes
   `token_ledger.json` which tracks token rewards when partnerships enable direct
   payouts.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -61,6 +61,17 @@ from .health_sync_engine import (
 )
 from .modding_layer import create_module, list_modules, upvote_module
 from .auto_mirror_airdrop import scan_public_activity, execute_airdrop, run_airdrop
+from .planetkeeper import (
+    opt_in as planetkeeper_opt_in,
+    is_opted_in as planetkeeper_enabled,
+    record_eco_action,
+    eco_multiplier,
+    award_planetkeeper_badge,
+    public_impact as planetkeeper_public,
+    carbon_offset_status,
+    energy_device_report,
+    pledge_commitment,
+)
 from .purpose_engine import (
     record_traits,
     discover_purpose,
@@ -172,5 +183,14 @@ __all__ = [
     "complete_task",
     "quest_card",
     "add_streak_protection",
+    "planetkeeper_opt_in",
+    "planetkeeper_enabled",
+    "record_eco_action",
+    "eco_multiplier",
+    "award_planetkeeper_badge",
+    "planetkeeper_public",
+    "carbon_offset_status",
+    "energy_device_report",
+    "pledge_commitment",
 ]
 

--- a/engine/planetkeeper.py
+++ b/engine/planetkeeper.py
@@ -1,0 +1,142 @@
+"""Planetkeeper Module for eco-linked rewards."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import Dict, Optional
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DATA_DIR = BASE_DIR / "logs" / "planetkeeper"
+SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
+OPT_IN_PATH = DATA_DIR / "opt_in.json"
+ACTION_PATH = DATA_DIR / "eco_actions.json"
+IMPACT_PATH = BASE_DIR / "dashboards" / "planetkeeper_public.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Opt-in management
+# ---------------------------------------------------------------------------
+
+def opt_in(user_id: str) -> None:
+    """Enable Planetkeeper tracking for ``user_id``."""
+    data = _load_json(OPT_IN_PATH, [])
+    if user_id not in data:
+        data.append(user_id)
+        _write_json(OPT_IN_PATH, data)
+
+
+def is_opted_in(user_id: str) -> bool:
+    """Return ``True`` if ``user_id`` opted in."""
+    return user_id in _load_json(OPT_IN_PATH, [])
+
+
+# ---------------------------------------------------------------------------
+# Action logging and multipliers
+# ---------------------------------------------------------------------------
+
+def record_eco_action(user_id: str, action: str, details: Optional[Dict] = None) -> None:
+    """Record an eco-positive ``action`` for ``user_id``."""
+    if not is_opted_in(user_id):
+        return
+    data = _load_json(ACTION_PATH, {})
+    log = data.get(user_id, [])
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "action": action,
+    }
+    if details:
+        entry["details"] = details
+    log.append(entry)
+    data[user_id] = log[-50:]
+    _write_json(ACTION_PATH, data)
+    _update_public(user_id)
+
+
+def _update_public(user_id: str) -> None:
+    dash = _load_json(IMPACT_PATH, {})
+    dash[user_id] = dash.get(user_id, 0) + 1
+    _write_json(IMPACT_PATH, dash)
+
+
+def eco_score(user_id: str) -> int:
+    """Return raw eco action count for ``user_id``."""
+    return len(_load_json(ACTION_PATH, {}).get(user_id, []))
+
+
+def eco_multiplier(user_id: str) -> float:
+    """Return yield multiplier based on eco score."""
+    score = eco_score(user_id)
+    mult = 1.0 + min(score, 100) / 100.0
+    return round(mult, 2)
+
+
+# ---------------------------------------------------------------------------
+# Badges and public impact
+# ---------------------------------------------------------------------------
+
+def award_planetkeeper_badge(user_id: str) -> None:
+    """Add Planetkeeper badge to ``user_id`` if opted in."""
+    if not is_opted_in(user_id):
+        return
+    scorecard = _load_json(SCORECARD_PATH, {})
+    user = scorecard.get(user_id, {})
+    badges = set(user.get("badges", []))
+    badges.add("planetkeeper")
+    user["badges"] = sorted(badges)
+    scorecard[user_id] = user
+    _write_json(SCORECARD_PATH, scorecard)
+
+
+def public_impact() -> Dict[str, int]:
+    """Return summarized eco actions per user."""
+    return _load_json(IMPACT_PATH, {})
+
+
+# ---------------------------------------------------------------------------
+# Optional external API stubs
+# ---------------------------------------------------------------------------
+
+def carbon_offset_status(user_id: str) -> Dict:
+    """Placeholder for carbon offset API integration."""
+    return {"user_id": user_id, "offset_tons": 0.0}
+
+
+def energy_device_report(user_id: str) -> Dict:
+    """Placeholder for efficient device detection API."""
+    return {"user_id": user_id, "efficient_devices": []}
+
+
+def pledge_commitment(user_id: str, pledge: str) -> None:
+    """Record sustainability pledge text."""
+    record_eco_action(user_id, "pledge", {"pledge": pledge})
+
+
+__all__ = [
+    "opt_in",
+    "is_opted_in",
+    "record_eco_action",
+    "eco_score",
+    "eco_multiplier",
+    "award_planetkeeper_badge",
+    "public_impact",
+    "carbon_offset_status",
+    "energy_device_report",
+    "pledge_commitment",
+]

--- a/engine/purpose_engine.py
+++ b/engine/purpose_engine.py
@@ -10,6 +10,18 @@ from typing import List, Dict
 
 from .reflection_layer import emotion_trend
 
+try:
+    from .planetkeeper import eco_multiplier, is_opted_in, award_planetkeeper_badge
+except Exception:  # module is optional
+    def eco_multiplier(user_id: str) -> float:
+        return 1.0
+
+    def is_opted_in(user_id: str) -> bool:
+        return False
+
+    def award_planetkeeper_badge(user_id: str) -> None:
+        return None
+
 BASE_DIR = Path(__file__).resolve().parents[1]
 PURPOSE_PATH = BASE_DIR / "logs" / "purpose_profiles.json"
 PARTNERS_PATH = BASE_DIR / "partners.json"
@@ -100,6 +112,12 @@ def generate_purpose_quest(user_id: str) -> str:
     if not mission:
         mission = "clarify your personal purpose"
     quest = f"Purpose Quest: Take one action today to {mission.lower()}"
+    if is_opted_in(user_id):
+        mult = eco_multiplier(user_id)
+        if mult > 1.0:
+            quest += f" (Planetkeeper x{mult:.2f})"
+        if mult >= 1.5:
+            award_planetkeeper_badge(user_id)
     entry = data.get(user_id, {})
     quests = entry.get("quests", [])
     quests.append({"timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"), "quest": quest})


### PR DESCRIPTION
## Summary
- add new `planetkeeper` module for eco-positive behavior tracking
- integrate Planetkeeper multipliers in `purpose_engine`
- export Planetkeeper helpers in `engine.__init__`
- document Planetkeeper in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688024e35a0083229ee0cb93ab393281