### PR TITLE
Add Vaultfire FIT layer

### DIFF
--- a/docs/vaultfire_fit_layer.md
+++ b/docs/vaultfire_fit_layer.md
@@ -1,0 +1,17 @@
+# Vaultfire FIT Layer
+
+The FIT layer connects biometric workout tracking with Vaultfire's reward and purpose engines.
+
+## AI Coach logic
+- `record_workout()` stores routine metrics and mirrors progress back to the Purpose Engine.
+- `coach_feedback()` returns short suggestions based on recent activity.
+
+## Fitness Milestone Minter
+When a routine reaches 5, 10 or 25 logged sessions, a progress NFT is automatically minted using `inventory_storage.add_item()`.
+
+## Fit-for-reward
+If a workout entry is marked as verified the user receives one VAULT token via `token_ops.send_token()`.
+
+## VaultWear stub
+`sync_wearable()` is reserved for future wearable device integration.
+

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -99,6 +99,8 @@ from .gamified_yield_layer import (
     quest_card,
     add_streak_protection,
 )
+from .fit_ai_coach import record_workout, coach_feedback
+from .vaultwear import sync_wearable
 
 __all__ = [
     "resolve_identity",
@@ -202,5 +204,8 @@ __all__ = [
     "carbon_offset_status",
     "energy_device_report",
     "pledge_commitment",
+    "record_workout",
+    "coach_feedback",
+    "sync_wearable",
 ]
 

--- a/engine/fit_ai_coach.py
+++ b/engine/fit_ai_coach.py
@@ -1,0 +1,102 @@
+"""Vaultfire FIT layer - AI Coach and progress tracking."""
+from __future__ import annotations
+
+import json
+import hashlib
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .inventory_storage import add_item
+from .token_ops import send_token
+from .purpose_engine import moral_memory_mirror
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+FIT_LOG = BASE_DIR / "logs" / "fitness_log.json"
+MILESTONE_PATH = BASE_DIR / "logs" / "fitness_milestones.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _hash(identifier: str) -> str:
+    return hashlib.sha256(identifier.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# AI Coach logic
+# ---------------------------------------------------------------------------
+
+def record_workout(user_id: str, routine: str, metrics: Dict[str, float], verified: bool = False) -> Dict:
+    """Record a workout session for ``user_id``."""
+    hashed = _hash(user_id)
+    log = _load_json(FIT_LOG, {})
+    entry = log.get(hashed, {})
+    history = entry.setdefault("history", [])
+    history.append({
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "routine": routine,
+        "metrics": metrics,
+        "verified": verified,
+    })
+    log[hashed] = entry
+    _write_json(FIT_LOG, log)
+    _check_milestone(hashed, routine)
+    if verified:
+        send_token(user_id, 1.0, "VAULT")
+    moral_memory_mirror(user_id)
+    return entry
+
+
+def coach_feedback(user_id: str) -> List[str]:
+    """Return simple feedback strings based on recent workouts."""
+    hashed = _hash(user_id)
+    log = _load_json(FIT_LOG, {}).get(hashed, {})
+    history = log.get("history", [])[-5:]
+    feedback: List[str] = []
+    total_mins = 0.0
+    for session in history:
+        metrics = session.get("metrics", {})
+        total_mins += metrics.get("minutes", 0.0)
+    if total_mins < 60:
+        feedback.append("Aim for at least 60 minutes of activity this week.")
+    else:
+        feedback.append("Great job keeping active!")
+    return feedback
+
+
+# ---------------------------------------------------------------------------
+# Milestone handling
+# ---------------------------------------------------------------------------
+
+def _check_milestone(hashed: str, routine: str) -> None:
+    milestones = _load_json(MILESTONE_PATH, {})
+    user = milestones.setdefault(hashed, {})
+    count = user.get(routine, 0) + 1
+    user[routine] = count
+    _write_json(MILESTONE_PATH, milestones)
+    if count in {5, 10, 25}:
+        _mint_milestone_nft(hashed, routine, count)
+
+
+def _mint_milestone_nft(hashed: str, routine: str, count: int) -> None:
+    token_id = f"{routine}-{count}"
+    tx = hashlib.sha256(f"{hashed}:{token_id}".encode()).hexdigest()[:10]
+    add_item(hashed, token_id, tx)
+
+
+__all__ = ["record_workout", "coach_feedback"]
+

--- a/engine/vaultwear.py
+++ b/engine/vaultwear.py
@@ -1,0 +1,13 @@
+"""Stub for future VaultWear wearable sync module."""
+from __future__ import annotations
+
+from typing import Dict
+
+
+def sync_wearable(user_id: str, data: Dict) -> None:
+    """Placeholder to sync data from VaultWear device."""
+    raise NotImplementedError("VaultWear sync not implemented yet")
+
+
+__all__ = ["sync_wearable"]
+


### PR DESCRIPTION
## Summary
- implement `fit_ai_coach` with biometric workout tracking, milestone NFT minting and token rewards
- expose coach helpers and VaultWear stub in engine exports
- document the FIT layer

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68802e7c62288322bf958cafc0d34a47