### PR TITLE
Add Vaultcore mission scheduler and dashboard

### DIFF
--- a/engine/mission_scheduler.py
+++ b/engine/mission_scheduler.py
@@ -1,0 +1,110 @@
+"""Vaultcore mission scheduler and reward aggregator."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+from .purpose_engine import generate_purpose_quest
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+SCHEDULE_PATH = BASE_DIR / "logs" / "daily_missions.json"
+SETTINGS_PATH = BASE_DIR / "logs" / "mission_settings.json"
+POINTS_PATH = BASE_DIR / "logs" / "vault_points.json"
+GOALS_PATH = BASE_DIR / "user_goals.json"
+
+MISSION_TYPES: Dict[str, list[str]] = {
+    "health": ["hydrate", "stretch", "log_nutrition"],
+    "finance": ["review_budget", "track_expenses"],
+    "creativity": ["journal", "sketch"],
+    "rest": ["meditate", "sleep_early"],
+    "relationship": ["check_in", "offer_help"],
+}
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _today() -> str:
+    return datetime.utcnow().strftime("%Y-%m-%d")
+
+
+def sync_mode(user_id: str) -> bool:
+    settings = _load_json(SETTINGS_PATH, {})
+    return bool(settings.get(user_id, {}).get("sync_enabled", True))
+
+
+def set_sync_mode(user_id: str, enabled: bool) -> None:
+    settings = _load_json(SETTINGS_PATH, {})
+    entry = settings.get(user_id, {})
+    entry["sync_enabled"] = bool(enabled)
+    settings[user_id] = entry
+    _write_json(SETTINGS_PATH, settings)
+
+
+def _user_schedule(data: Dict, user_id: str) -> Dict:
+    entry = data.get(user_id)
+    if not entry:
+        entry = {}
+        data[user_id] = entry
+    return entry
+
+
+def assign_daily_mission(user_id: str) -> Optional[Dict]:
+    if not sync_mode(user_id):
+        return None
+    data = _load_json(SCHEDULE_PATH, {})
+    entry = _user_schedule(data, user_id)
+    today = _today()
+    if entry.get("day") == today:
+        return entry
+    mission = generate_purpose_quest(user_id)
+    entry.update({"day": today, "mission": mission})
+    _write_json(SCHEDULE_PATH, data)
+    return entry
+
+
+def record_reward(user_id: str, domain: str, amount: int) -> None:
+    points = _load_json(POINTS_PATH, {})
+    entry = points.get(user_id, {})
+    entry[domain] = entry.get(domain, 0) + int(amount)
+    points[user_id] = entry
+    _write_json(POINTS_PATH, points)
+
+
+def aggregated_points(user_id: str) -> int:
+    points = _load_json(POINTS_PATH, {})
+    return sum(points.get(user_id, {}).values())
+
+
+def dashboard_snapshot(user_id: str) -> Dict:
+    mission = assign_daily_mission(user_id) or {}
+    return {
+        "user_id": user_id,
+        "mission": mission,
+        "vault_points": aggregated_points(user_id),
+    }
+
+__all__ = [
+    "assign_daily_mission",
+    "record_reward",
+    "aggregated_points",
+    "dashboard_snapshot",
+    "set_sync_mode",
+    "sync_mode",
+    "MISSION_TYPES",
+]

--- a/frontend/pages/mission_dashboard.html
+++ b/frontend/pages/mission_dashboard.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Vaultcore Mission Dashboard</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: 'Courier New', monospace;
+      background: #000;
+      color: #0ff;
+    }
+    .theme-dark {
+      background: #001;
+      color: #0ff;
+    }
+    header {
+      background: #222;
+      color: #0ff;
+      padding: 20px;
+      text-align: center;
+      border-bottom: 2px solid #0ff;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      padding: 6px 10px;
+      border: 1px solid #0ff;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Mission Tracker</h1>
+    <button id="themeToggle">Toggle Theme</button>
+  </header>
+
+  <section id="missions">
+    <h3>Daily Missions</h3>
+    <table id="missionTable">
+      <thead><tr><th>User</th><th>Mission</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
+  <section id="points">
+    <h3>Vault Points</h3>
+    <table id="pointsTable">
+      <thead><tr><th>User</th><th>Total Points</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
+  <script src="mission_dashboard.js"></script>
+</body>
+</html>

--- a/frontend/pages/mission_dashboard.js
+++ b/frontend/pages/mission_dashboard.js
@@ -1,0 +1,56 @@
+// Reference: ethics/core.mdx
+async function loadMissions() {
+  const res = await fetch('../../logs/daily_missions.json').catch(() => null);
+  if (!res || !res.ok) return {};
+  try { return await res.json(); } catch { return {}; }
+}
+
+async function loadPoints() {
+  const res = await fetch('../../logs/vault_points.json').catch(() => null);
+  if (!res || !res.ok) return {};
+  try { return await res.json(); } catch { return {}; }
+}
+
+function displayMissions(data) {
+  const tbody = document.querySelector('#missionTable tbody');
+  tbody.innerHTML = '';
+  Object.entries(data || {}).forEach(([user, info]) => {
+    const tr = document.createElement('tr');
+    const u = document.createElement('td');
+    u.textContent = user;
+    const m = document.createElement('td');
+    m.textContent = (info.mission || '').slice(0, 80);
+    tr.appendChild(u);
+    tr.appendChild(m);
+    tbody.appendChild(tr);
+  });
+}
+
+function displayPoints(data) {
+  const tbody = document.querySelector('#pointsTable tbody');
+  tbody.innerHTML = '';
+  Object.entries(data || {}).forEach(([user, domains]) => {
+    const tr = document.createElement('tr');
+    const u = document.createElement('td');
+    u.textContent = user;
+    const t = document.createElement('td');
+    const total = Object.values(domains || {}).reduce((a, b) => a + b, 0);
+    t.textContent = total;
+    tr.appendChild(u);
+    tr.appendChild(t);
+    tbody.appendChild(tr);
+  });
+}
+
+async function init() {
+  const missions = await loadMissions();
+  displayMissions(missions);
+  const points = await loadPoints();
+  displayPoints(points);
+}
+
+document.getElementById('themeToggle').addEventListener('click', () => {
+  document.body.classList.toggle('theme-dark');
+});
+
+init();

--- a/user_goals.json
+++ b/user_goals.json
@@ -1,0 +1,4 @@
+{
+  "ghostkey316": ["health", "creativity"],
+  "sample_user": ["finance", "rest"]
+}


### PR DESCRIPTION
## Summary
- add `mission_scheduler` module for assigning daily missions, tracking rewards, and toggling sync
- create mission dashboard HTML/JS for centralized mission tracking
- include example `user_goals.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68802eaec8d08322b5a9e5158da26941