### PR TITLE
Add Vaultlink ethical growth engine

### DIFF
--- a/docs/vaultlink_engine.md
+++ b/docs/vaultlink_engine.md
@@ -10,12 +10,21 @@ Vaultlink provides a modular AI companion that evolves with each user. The engin
 - **Synced evolution tree** – new levels unlock coaching and philosophical domains.
 - **Legacy transfer** – states can be cloned for a different user.
 - **Plugin ready** – the engine exposes simple hooks for partner frontends.
+- **Ethical Growth Engine** – moral alignment and belief scores gate all intelligence upgrades.
+- **Moral Mirror System** – each session is logged for user review before growth is applied.
 
 ## API
 - `onboard_companion(user_id, key)` – initialize state for a user.
 - `record_interaction(user_id, text, domain, behavior, milestone, key)` – store an interaction and update level.
 - `fetch_state(user_id, key)` – return decrypted state including memory slots.
 - `transfer_companion_state(from_user, to_user, from_key, to_key)` – clone state for legacy handoff.
+
+### Ethical Growth Engine
+Vaultlink will only ascend to higher levels when the user's alignment score and
+belief level satisfy the Ghostkey Ethics Framework. Learning multipliers are
+weighted by loyalty and trust metrics while harmful behavior stalls progress.
+All session text is stored in a moral mirror log for human feedback. Advanced
+logic tiers require an override file signed by the founding architects.
 
 **Disclaimer**
 - Vaultlink uses basic XOR encryption and should not store highly sensitive data.

--- a/engine/ethical_growth_engine.py
+++ b/engine/ethical_growth_engine.py
@@ -1,0 +1,86 @@
+"""Ethical Growth Engine for Vaultlink.
+
+This module enforces the Ghostkey Ethics Framework during
+Vaultlink's learning process. Intelligence upgrades only occur
+when alignment and belief metrics meet the required threshold.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from datetime import datetime
+
+from .loyalty_multiplier import loyalty_multiplier
+from .signal_engine import calculate_alignment_score
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
+MIRROR_PATH = BASE_DIR / "logs" / "moral_mirror.json"
+OVERRIDE_PATH = BASE_DIR / "vaultfire-core" / "ethics" / "override_consensus.json"
+
+ALIGN_THRESHOLD = 75
+BELIEF_THRESHOLD = 1
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def belief_score(user_id: str) -> float:
+    card = _load_json(SCORECARD_PATH, {})
+    return float(card.get(user_id, {}).get("belief_level", 0))
+
+
+def ethics_passed(user_id: str) -> bool:
+    align = calculate_alignment_score(user_id)
+    belief = belief_score(user_id)
+    return align >= ALIGN_THRESHOLD and belief >= BELIEF_THRESHOLD
+
+
+def learning_multiplier(user_id: str) -> float:
+    mult = loyalty_multiplier(user_id)
+    card = _load_json(SCORECARD_PATH, {})
+    info = card.get(user_id, {})
+    trust = info.get("trust_behavior", 0)
+    if trust < 0:
+        return 0.0
+    return round(mult * (1 + trust / 100.0), 3)
+
+
+def record_mirror_entry(user_id: str, text: str) -> None:
+    """Store interaction text for human reflection."""
+    data = _load_json(MIRROR_PATH, {})
+    history = data.get(user_id, [])
+    history.append({
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "text": text,
+    })
+    data[user_id] = history[-50:]
+    _write_json(MIRROR_PATH, data)
+
+
+def asi_activation_allowed() -> bool:
+    info = _load_json(OVERRIDE_PATH, {})
+    return bool(info.get("asi_override"))
+
+
+__all__ = [
+    "belief_score",
+    "ethics_passed",
+    "learning_multiplier",
+    "record_mirror_entry",
+    "asi_activation_allowed",
+]

--- a/engine/vaultlink.py
+++ b/engine/vaultlink.py
@@ -10,6 +10,12 @@ from typing import Dict, List
 
 from .health_sync_engine import encrypt_data, decrypt_data
 from .reflection_layer import update_emotional_state
+from .ethical_growth_engine import (
+    ethics_passed,
+    learning_multiplier,
+    record_mirror_entry,
+    asi_activation_allowed,
+)
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 STATE_DIR = BASE_DIR / "logs" / "vaultlink"
@@ -120,7 +126,10 @@ def record_interaction(
     milestone: bool,
     key: str,
 ) -> Dict:
-    """Record an interaction and update growth metrics."""
+    """Record a user interaction and update growth metrics.
+
+    XP and level increases require passing the Ethical Growth Engine checks.
+    """
     path = _state_path(user_id)
     state = _load_json(path, None)
     if not state:
@@ -132,20 +141,26 @@ def record_interaction(
     if milestone:
         state["milestones"] += 1
         xp_gain += 2.0
+    xp_gain *= learning_multiplier(user_id)
+    if xp_gain < 0:
+        xp_gain = 0.0
     state["xp"] += xp_gain
     state["interactions"] += 1
     level_before = state["level"]
     level_now = _calc_level(state["xp"])
-    if level_now > level_before:
-        state["level"] = level_now
-        random.seed(state["seed"] + level_now)
-        if level_now <= len(ABILITIES):
-            ability = ABILITIES[level_now - 1]
-            if ability not in state["abilities"]:
-                state["abilities"].append(ability)
-        trait = random.choice(TRAITS)
-        if trait not in state["traits"]:
-            state["traits"].append(trait)
+    if level_now > level_before and ethics_passed(user_id):
+        if level_now >= 5 and not asi_activation_allowed():
+            level_now = level_before
+        else:
+            state["level"] = level_now
+            random.seed(state["seed"] + level_now)
+            if level_now <= len(ABILITIES):
+                ability = ABILITIES[level_now - 1]
+                if ability not in state["abilities"]:
+                    state["abilities"].append(ability)
+            trait = random.choice(TRAITS)
+            if trait not in state["traits"]:
+                state["traits"].append(trait)
     emotions = update_emotional_state(user_id, text, key)
     entry = f"{now.strftime('%Y-%m-%dT%H:%M:%SZ')}|{domain}|{text}"
     full_token = encrypt_data(entry, key)
@@ -153,6 +168,7 @@ def record_interaction(
     mem_limit = 3 + state["level"] * 2
     state.setdefault("memory_history", []).append(full_token)
     state["memory"].append(short_token)
+    record_mirror_entry(user_id, text)
     state["memory"] = state["memory"][-mem_limit:]
     state["last_update"] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
     _write_json(path, state)

--- a/vaultfire-core/ethics/override_consensus.json
+++ b/vaultfire-core/ethics/override_consensus.json
@@ -1,0 +1,3 @@
+{
+  "asi_override": false
+}


### PR DESCRIPTION
## Summary
- introduce `ethical_growth_engine` with belief checks and moral mirror logging
- gate Vaultlink level-ups on ethics alignment
- apply loyalty-weighted XP and mirror logging for every interaction
- add override consensus file
- document new systems in `vaultlink_engine.md`

## Testing
- `python -m py_compile engine/ethical_growth_engine.py engine/vaultlink.py`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68804a8d0170832292bf09c89d9eeea9