### PR TITLE
Add immutable ledger with hashed entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Vaultfire Init represents the first development signal from **Ghostkey-316** (Br
 - `logs/` – location for generated log files (ignored by Git). This now includes
   `token_ledger.json` which tracks token rewards when partnerships enable direct
   payouts.
+- `immutable_log.jsonl` – append-only ledger that links each entry by hash. If
+  IPFS is available, entries are pinned for decentralized verification.
 - `generate_partner_dashboard.py` – builds `dashboards/partner_earnings.json` summarizing contributor earnings.
 - `ens_sync_status.py` – reads `logs/sync_audit.json` for the latest sync entry of an ENS name. Optional flags allow resync simulation and belief logging.
 - `README.md` – project overview and usage notes.
@@ -113,6 +115,9 @@ log with `ghostkey316.eth` or `bpow20.cb.id`, the script records the underlying
 wallet address alongside the identifier.
 
 The script creates `logs/vaultfire_log.txt` automatically if it does not exist.
+Each activation also appends a signed record to `immutable_log.jsonl`. This
+ledger links entries by cryptographic hash and optionally stores them on IPFS
+when the client library is available.
 
 Run `python3 generate_partner_dashboard.py` to refresh partner earnings.
 

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -106,6 +106,7 @@ from .vaultlink import (
     record_interaction,
     fetch_state as fetch_vaultlink_state,
 )
+from .immutable_log import append_entry as log_immutable
 
 __all__ = [
     "resolve_identity",
@@ -215,5 +216,6 @@ __all__ = [
     "onboard_companion",
     "record_interaction",
     "fetch_vaultlink_state",
+    "log_immutable",
 ]
 

--- a/engine/feedback_loop.py
+++ b/engine/feedback_loop.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from vaultfire_signal import log_vaultfire_status
 from .yield_engine_v1 import mark_yield_boost
 from .belief_validation import validate_belief
+from .immutable_log import append_entry
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 EVENT_LOG_PATH = BASE_DIR / "event_log.json"
@@ -122,6 +123,7 @@ def _log_audit(entry):
     entry_with_time = {"timestamp": timestamp, **entry}
     log.append(entry_with_time)
     _write_json(AUDIT_PATH, log)
+    append_entry("audit_event", entry_with_time)
 
 
 def belief_pulse(user_id):

--- a/engine/immutable_log.py
+++ b/engine/immutable_log.py
@@ -1,0 +1,61 @@
+import json
+import hashlib
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LOG_PATH = BASE_DIR / "immutable_log.jsonl"
+
+
+def _get_last_hash() -> str:
+    if not LOG_PATH.exists():
+        return "0" * 64
+    try:
+        with open(LOG_PATH, "rb") as f:
+            f.seek(0, 2)
+            if f.tell() == 0:
+                return "0" * 64
+            # read last line
+            f.seek(-2, 2)
+            while f.tell() > 0 and f.read(1) != b"\n":
+                f.seek(-2, 1)
+            last_line = f.readline().decode()
+        last_entry = json.loads(last_line)
+        return last_entry.get("hash", "0" * 64)
+    except Exception:
+        return "0" * 64
+
+
+def _store_ipfs(data: bytes) -> Optional[str]:
+    try:
+        import ipfshttpclient  # type: ignore
+    except Exception:
+        return None
+    try:
+        client = ipfshttpclient.connect()
+        cid = client.add_bytes(data)
+        return cid
+    except Exception:
+        return None
+
+
+def append_entry(entry_type: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    prev_hash = _get_last_hash()
+    entry = {
+        "timestamp": timestamp,
+        "type": entry_type,
+        "data": data,
+        "prev_hash": prev_hash,
+    }
+    entry_json = json.dumps(entry, sort_keys=True).encode()
+    entry_hash = hashlib.sha256(entry_json).hexdigest()
+    entry["hash"] = entry_hash
+    cid = _store_ipfs(entry_json)
+    if cid:
+        entry["ipfs_cid"] = cid
+    with open(LOG_PATH, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry

--- a/engine/partner_hooks.py
+++ b/engine/partner_hooks.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from .token_ops import send_token
 from .activation_gate import enforce_activation
+from .immutable_log import append_entry
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 CONFIG_PATH = BASE_DIR / "vaultfire-core" / "vaultfire_config.json"
@@ -66,6 +67,7 @@ def record_usage(partner_id: str, feature: str, tokens: float, wallet: str,
     _write_json(USAGE_LOG_PATH, log)
     # Deduct tokens by recording a negative ledger entry
     send_token(wallet, -tokens, token)
+    append_entry("partner_usage", entry)
     return entry
 
 
@@ -84,4 +86,5 @@ def grant_reward(partner_id: str, wallet: str, amount: float,
     log = _load_json(USAGE_LOG_PATH, [])
     log.append(entry)
     _write_json(USAGE_LOG_PATH, log)
+    append_entry("partner_reward", entry)
     return entry

--- a/engine/token_ops.py
+++ b/engine/token_ops.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from .marketplace import currency_allowed
 from .wallet_loyalty import update_wallet_loyalty
 from .activation_gate import enforce_activation
+from .immutable_log import append_entry
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 LEDGER_PATH = BASE_DIR / "logs" / "token_ledger.json"
@@ -49,4 +50,5 @@ def send_token(wallet: str, amount: float, token: str) -> None:
         update_wallet_loyalty(wallet, amount)
     except Exception:
         pass
+    append_entry("token_transfer", entry)
     return None

--- a/vaultfire_signal.py
+++ b/vaultfire_signal.py
@@ -5,6 +5,8 @@ from datetime import datetime
 import os
 import argparse
 
+from engine.immutable_log import append_entry
+
 from engine.identity_resolver import resolve_identity
 
 DEFAULT_IDENTITY = "ghostkey316.eth"
@@ -25,6 +27,11 @@ def log_vaultfire_status(identity=DEFAULT_IDENTITY, wallet=DEFAULT_WALLET):
 
     with open("logs/vaultfire_log.txt", "a") as log_file:
         log_file.write(log_entry)
+
+    append_entry(
+        "vaultfire_status",
+        {"identity": identity, "wallet": wallet, "resolved": resolved},
+    )
 
     print(log_entry.strip())
 


### PR DESCRIPTION
## Summary
- create `engine/immutable_log.py` for append-only hash-chained ledger
- record partner hooks, token transfers and audit events in the ledger
- log activation events to the ledger
- expose `log_immutable` in `engine` package
- document immutable log in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68804f75d518832297c034ab7c5ef497