### PR TITLE
Add earning module with reputation-based rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,16 @@ python3 engine/vaultfire_credits.py ghostkey316
 The onboarding API exposes `/vaultfire_credits/<id>` to query these totals.
 
 
+## Earning Module
+`engine/earning_module.py` rewards contributors for meaningful engagement,
+microtask completion, idea contributions and building new layers. Rewards are
+sent to the contributor's resolved wallet and scaled by on-chain reputation.
+
+```python
+from engine.earning_module import reward_microtask
+reward_microtask("alice", "alice.eth", "task-1")
+```
+
 ## Design DNA
 The project includes a short guide in `docs/design_culture.md` detailing the 90s-inspired look and our ethics-first approach to branding. It also covers simple UX principles and how to write human messages throughout the interface.
 

--- a/docs/earning_module.md
+++ b/docs/earning_module.md
@@ -1,0 +1,15 @@
+# Earning Module
+
+This component rewards contributors for meaningful engagement and completed work.
+Each action multiplies a base reward by the contributor's on-chain reputation.
+Wallet addresses are resolved through ENS or Coinbase IDs before payouts.
+
+Example usage:
+```python
+from engine.earning_module import reward_engagement
+reward_engagement("alice", "alice.eth", score=2.5)
+```
+
+**Disclaimers**
+- Rewards are recorded locally in `logs/earning_log.json` and may be purged.
+- On-chain scores come from an experimental oracle and may be inaccurate.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -108,6 +108,12 @@ from .vaultlink import (
     fetch_state as fetch_vaultlink_state,
 )
 from .immutable_log import append_entry as log_immutable
+from .earning_module import (
+    reward_engagement,
+    reward_microtask,
+    reward_idea,
+    reward_layer_build,
+)
 
 __all__ = [
     "resolve_identity",
@@ -220,6 +226,10 @@ __all__ = [
     "onboard_companion",
     "record_interaction",
     "fetch_vaultlink_state",
+    "reward_engagement",
+    "reward_microtask",
+    "reward_idea",
+    "reward_layer_build",
     "log_immutable",
 ]
 

--- a/engine/earning_module.py
+++ b/engine/earning_module.py
@@ -1,0 +1,110 @@
+# Reference: ethics/core.mdx
+"""Earning module rewarding positive contributions.
+
+This module issues token rewards for meaningful engagement, completing
+microtasks, submitting new ideas and building layers. Reward amounts
+scale with the contributor's on-chain reputation.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from .identity_resolver import resolve_identity
+from .score_oracle import fetch_scores, apr_multiplier
+from .token_ops import send_token
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LOG_PATH = BASE_DIR / "logs" / "earning_log.json"
+
+BASE_REWARDS = {
+    "engagement": 0.5,
+    "microtask": 1.0,
+    "idea": 2.0,
+    "layer": 3.0,
+}
+
+SUPPORTED_TOKENS = {"ASM", "ETH", "USDC"}
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _resolve_wallet(wallet_or_ens: str) -> str:
+    return resolve_identity(wallet_or_ens) or wallet_or_ens
+
+
+def _reward_multiplier(user_id: str) -> float:
+    scores = fetch_scores(user_id)
+    return apr_multiplier(scores)
+
+
+def _log_entry(entry: dict) -> None:
+    log = _load_json(LOG_PATH, [])
+    entry["timestamp"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    log.append(entry)
+    _write_json(LOG_PATH, log)
+
+
+def _reward_user(user_id: str, wallet: str, action: str, extra: Optional[dict], token: str) -> dict:
+    if token not in SUPPORTED_TOKENS:
+        raise ValueError(f"Unsupported token {token}")
+    wallet_addr = _resolve_wallet(wallet)
+    multiplier = _reward_multiplier(user_id)
+    amount = BASE_REWARDS.get(action, 0) * multiplier
+    if amount <= 0:
+        return {}
+    send_token(wallet_addr, amount, token)
+    entry = {
+        "user_id": user_id,
+        "wallet": wallet_addr,
+        "action": action,
+        "amount": amount,
+        "token": token,
+    }
+    if extra:
+        entry.update(extra)
+    _log_entry(entry)
+    return entry
+
+
+def reward_engagement(user_id: str, wallet: str, score: float = 1.0, token: str = "ASM") -> dict:
+    extra = {"score": score}
+    return _reward_user(user_id, wallet, "engagement", extra, token)
+
+
+def reward_microtask(user_id: str, wallet: str, task_id: str, token: str = "ASM") -> dict:
+    extra = {"task_id": task_id}
+    return _reward_user(user_id, wallet, "microtask", extra, token)
+
+
+def reward_idea(user_id: str, wallet: str, idea_id: str, token: str = "ASM") -> dict:
+    extra = {"idea_id": idea_id}
+    return _reward_user(user_id, wallet, "idea", extra, token)
+
+
+def reward_layer_build(user_id: str, wallet: str, layer: str, token: str = "ASM") -> dict:
+    extra = {"layer": layer}
+    return _reward_user(user_id, wallet, "layer", extra, token)
+
+
+__all__ = [
+    "reward_engagement",
+    "reward_microtask",
+    "reward_idea",
+    "reward_layer_build",
+]


### PR DESCRIPTION
## Summary
- add new earning_module to reward microtasks and engagement
- expose reward helpers through engine package
- document the earning module and update README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68805462aa9883228869f3201ebf89bd