### PR TITLE
Implement squad layer with XP and multipliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Vaultfire Init represents the first development signal from **Ghostkey-316** (Br
 - `engine/wellness_companion.py` – journaling and mood tracking with coping suggestions tied to the companion.
 - `engine/life_xp_module.py` – rewards growth activities and syncs with Vaultlink.
 - `engine/planetkeeper.py` – records eco-positive behavior for optional yield multipliers.
+- `engine/squad_layer.py` – tracks squad XP, quests and multipliers.
 - `engine/mirror_room.py` – topic-based spaces that sync with memory and loop history.
 - `logs/` – location for generated log files (ignored by Git). This now includes
   `token_ledger.json` which tracks token rewards when partnerships enable direct

--- a/docs/squad_layer.md
+++ b/docs/squad_layer.md
@@ -1,0 +1,14 @@
+# Squad Layer
+
+This module lets contributors build purpose-driven squads that accumulate XP through shared quests. Multipliers grow as members maintain loyalty and work together.
+
+```python
+from engine.squad_layer import issue_squad_quest, complete_squad_quest, squad_multiplier
+issue_squad_quest("alpha", "q1", "Finish onboarding", xp=20)
+complete_squad_quest("alpha", "alice", "q1")
+bonus = squad_multiplier("alpha")
+```
+
+## Disclaimers
+- Records live under `logs/squad_layer/` and may be cleared at any time.
+- Multipliers do not represent guaranteed financial rewards.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -131,6 +131,12 @@ from .social_layer import (
     create_competition,
     record_result,
 )
+from .squad_layer import (
+    record_xp,
+    issue_squad_quest,
+    complete_squad_quest,
+    squad_multiplier,
+)
 from .belief_graph import (
     build_belief_graph,
     graph_similarity,
@@ -271,5 +277,9 @@ __all__ = [
     "graph_similarity",
     "match_users",
     "trust_metric",
+    "record_xp",
+    "issue_squad_quest",
+    "complete_squad_quest",
+    "squad_multiplier",
 ]
 

--- a/engine/squad_layer.py
+++ b/engine/squad_layer.py
@@ -1,0 +1,125 @@
+"""Squad Layer for Vaultfire.
+
+This module builds on the social layer so contributors can form
+purpose-driven squads, earn squad XP and complete squad quests.
+Yield or status multipliers grow as squads maintain loyalty and
+synergy among members.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+from .social_layer import create_squad, add_member, remove_member
+from .loyalty_multiplier import loyalty_multiplier
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+SQUAD_DIR = BASE_DIR / "logs" / "squad_layer"
+XP_PATH = SQUAD_DIR / "xp.json"
+QUEST_PATH = SQUAD_DIR / "quests.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Squad XP tracking
+# ---------------------------------------------------------------------------
+
+def _xp_state() -> Dict:
+    return _load_json(XP_PATH, {})
+
+
+def _save_xp(state: Dict) -> None:
+    _write_json(XP_PATH, state)
+
+
+def record_xp(squad_id: str, user_id: str, amount: int) -> None:
+    """Add ``amount`` XP to ``squad_id`` and ``user_id``."""
+    state = _xp_state()
+    squad = state.setdefault(squad_id, {"total": 0, "members": {}, "log": []})
+    squad["total"] += amount
+    squad["members"][user_id] = squad["members"].get(user_id, 0) + amount
+    squad["log"].append({
+        "user": user_id,
+        "xp": amount,
+        "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    })
+    state[squad_id] = squad
+    _save_xp(state)
+
+
+# ---------------------------------------------------------------------------
+# Quests
+# ---------------------------------------------------------------------------
+
+def issue_squad_quest(squad_id: str, quest_id: str, desc: str, xp: int = 10) -> Dict:
+    """Create a new quest for ``squad_id``."""
+    quests = _load_json(QUEST_PATH, {})
+    squad_q = quests.setdefault(squad_id, {})
+    if quest_id in squad_q:
+        return {"message": "exists"}
+    entry = {"desc": desc, "xp": xp, "completions": []}
+    squad_q[quest_id] = entry
+    _write_json(QUEST_PATH, quests)
+    return entry
+
+
+def complete_squad_quest(squad_id: str, user_id: str, quest_id: str) -> Optional[Dict]:
+    """Mark ``quest_id`` complete for ``user_id``."""
+    quests = _load_json(QUEST_PATH, {})
+    squad_q = quests.get(squad_id, {})
+    quest = squad_q.get(quest_id)
+    if not quest:
+        return None
+    quest.setdefault("completions", []).append({
+        "user": user_id,
+        "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    })
+    _write_json(QUEST_PATH, quests)
+    xp = quest.get("xp", 0)
+    record_xp(squad_id, user_id, xp)
+    return {"squad": squad_id, "quest": quest_id, "xp": xp}
+
+
+# ---------------------------------------------------------------------------
+# Multipliers
+# ---------------------------------------------------------------------------
+
+def squad_multiplier(squad_id: str) -> float:
+    """Return yield/status multiplier for ``squad_id``."""
+    state = _xp_state()
+    info = state.get(squad_id)
+    if not info:
+        return 1.0
+    base = 1.0 + min(info.get("total", 0), 1000) / 1000.0
+    members = info.get("members", {})
+    if not members:
+        return round(base, 3)
+    mults = [loyalty_multiplier(u) for u in members]
+    synergy = sum(mults) / len(mults)
+    return round(base * synergy, 3)
+
+
+__all__ = [
+    "record_xp",
+    "issue_squad_quest",
+    "complete_squad_quest",
+    "squad_multiplier",
+]


### PR DESCRIPTION
## Summary
- add squad layer module to track squad XP and quests
- export squad helpers via `engine.__init__`
- document the new layer
- mention the new module in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68805d6836b88322ad89f296b54bbc61