### PR TITLE
Integrate crypto rewards with social layer

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -128,6 +128,8 @@ from .social_layer import (
     vote_idea,
     post_signal,
     exchange_signal,
+    stake_thread,
+    release_stake,
     create_competition,
     record_result,
 )
@@ -137,6 +139,13 @@ from .squad_layer import (
     complete_squad_quest,
     squad_multiplier,
 )
+from .squad_wallets import (
+    create_squad_wallet,
+    record_earning,
+    mission_reward,
+    squad_wallet,
+)
+from .proof_of_loyalty import record_belief_action
 from .belief_graph import (
     build_belief_graph,
     graph_similarity,
@@ -271,6 +280,8 @@ __all__ = [
     "vote_idea",
     "post_signal",
     "exchange_signal",
+    "stake_thread",
+    "release_stake",
     "create_competition",
     "record_result",
     "build_belief_graph",
@@ -281,5 +292,10 @@ __all__ = [
     "issue_squad_quest",
     "complete_squad_quest",
     "squad_multiplier",
+    "create_squad_wallet",
+    "record_earning",
+    "mission_reward",
+    "squad_wallet",
+    "record_belief_action",
 ]
 

--- a/engine/contributor_identity.py
+++ b/engine/contributor_identity.py
@@ -18,6 +18,7 @@ else:  # pragma: no cover - executed as script
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 IDENTITY_PATH = BASE_DIR / "user_identity.json"
+LEDGER_PATH = BASE_DIR / "logs" / "token_ledger.json"
 
 
 def _load_json(path: Path, default):
@@ -70,7 +71,7 @@ def sync_identity(user_id: str, wallet: Optional[str] = None,
 
     data[user_id] = profile
     _write_json(IDENTITY_PATH, data)
-    return profile
+    return identity_summary(user_id)
 
 
 # ---------------------------------------------------------------------------
@@ -95,12 +96,17 @@ def _access_level(multiplier: float) -> str:
 def identity_summary(user_id: str) -> Dict:
     data = _load_json(IDENTITY_PATH, {})
     profile = data.get(user_id, {"wallets": [], "socials": {}, "behavior_score": 0, "history": [], "verified": []})
+    ledger = _load_json(LEDGER_PATH, [])
+    rewards = {}
+    for w in profile.get("wallets", []):
+        rewards[w] = sum(e.get("amount", 0) for e in ledger if e.get("wallet") == w)
     multiplier = _reputation_multiplier(profile)
     summary = {
         "user_id": user_id,
         "wallets": profile.get("wallets", []),
         "socials": profile.get("socials", {}),
         "behavior_score": profile.get("behavior_score", 0),
+        "rewards": rewards,
         "reputation_multiplier": multiplier,
         "access_level": _access_level(multiplier),
     }

--- a/engine/governance.py
+++ b/engine/governance.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from .soul_journal import has_active_soulprint
+from .contributor_identity import identity_summary
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 GOV_DIR = BASE_DIR / "governance"
@@ -52,7 +53,10 @@ def vote_steward(voter_id: str, candidate_id: str) -> None:
         for rec in cand:
             if rec.get("voter") == voter_id:
                 return  # one vote per voter
-    weight = 2.0 if has_active_soulprint(voter_id) else 1.0
+    rep = identity_summary(voter_id).get("reputation_multiplier", 1.0)
+    weight = rep
+    if has_active_soulprint(voter_id):
+        weight += 1.0
     votes.setdefault(candidate_id, []).append({"voter": voter_id, "weight": weight})
     _write_json(STEWARD_VOTES_PATH, votes)
 

--- a/engine/proof_of_loyalty.py
+++ b/engine/proof_of_loyalty.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Proof-of-Loyalty token issuance for belief-aligned actions."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+from .token_ops import send_token
+from .vaultfire_signal_parser import parse_signal
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LOG_PATH = BASE_DIR / "logs" / "proof_of_loyalty.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def record_belief_action(user_id: str, wallet: str, text: str) -> Dict:
+    """Analyze ``text`` and mint LOYAL tokens if belief-aligned."""
+    result = parse_signal(text)
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "user_id": user_id,
+        "wallet": wallet,
+        "text": text,
+        "score": result.get("score"),
+        "verified": result.get("verified"),
+    }
+    log = _load_json(LOG_PATH, [])
+    log.append(entry)
+    _write_json(LOG_PATH, log)
+
+    if result.get("verified"):
+        try:
+            send_token(wallet, 1, "LOYAL")
+            entry["token_awarded"] = True
+        except Exception:
+            entry["token_awarded"] = False
+    else:
+        entry["token_awarded"] = False
+
+    return entry
+
+
+__all__ = ["record_belief_action"]

--- a/engine/social_layer.py
+++ b/engine/social_layer.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from .token_ops import send_token
+
 BASE_DIR = Path(__file__).resolve().parents[1]
 SOCIAL_DIR = BASE_DIR / "logs" / "social"
 SQUADS_PATH = SOCIAL_DIR / "squads.json"
@@ -14,6 +16,7 @@ IDEAS_PATH = SOCIAL_DIR / "ideas.json"
 SIGNALS_PATH = SOCIAL_DIR / "signals.json"
 SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
 COMPETE_PATH = SOCIAL_DIR / "competitions.json"
+STAKE_PATH = SOCIAL_DIR / "staked_threads.json"
 
 
 def _load_json(path: Path, default):
@@ -30,6 +33,39 @@ def _write_json(path: Path, data) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
+
+
+def _user_wallet(user_id: str) -> Optional[str]:
+    data = _load_json(SCORECARD_PATH, {})
+    return data.get(user_id, {}).get("wallet")
+
+
+def stake_thread(thread_id: str, wallet: str, amount: float) -> None:
+    state = _load_json(STAKE_PATH, {})
+    rec = state.get(thread_id, {"total": 0, "wallet": wallet})
+    rec["total"] += amount
+    state[thread_id] = rec
+    _write_json(STAKE_PATH, state)
+    try:
+        send_token(wallet, -abs(amount), "ASM")
+    except Exception:
+        pass
+
+
+def release_stake(thread_id: str, success: bool = True) -> None:
+    state = _load_json(STAKE_PATH, {})
+    rec = state.get(thread_id)
+    if not rec:
+        return
+    amount = rec.get("total", 0)
+    wallet = rec.get("wallet")
+    if success and wallet:
+        try:
+            send_token(wallet, amount, "ASM")
+        except Exception:
+            pass
+    state.pop(thread_id, None)
+    _write_json(STAKE_PATH, state)
 
 
 def _alignment_tier(user_id: str) -> int:
@@ -132,6 +168,7 @@ def post_signal(
     belief: str,
     mirror_prompt: Optional[str] = None,
     loop: str = "believe",
+    stake: float = 0.0,
 ) -> Dict:
     """Record a structured signal from ``sender`` to ``recipient``."""
     signals: Dict[str, Dict[str, List[Dict]]] = _load_json(SIGNALS_PATH, {})
@@ -147,8 +184,24 @@ def post_signal(
         "tier": tier,
         "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
+    if stake:
+        entry["stake"] = stake
     signals.setdefault(loop, {}).setdefault(f"tier{tier}", []).append(entry)
     _write_json(SIGNALS_PATH, signals)
+
+    if stake:
+        try:
+            w = _user_wallet(sender) or sender
+            send_token(w, -abs(stake), "ASM")
+        except Exception:
+            pass
+
+    rec_wallet = _load_json(SCORECARD_PATH, {}).get(recipient, {}).get("wallet")
+    if rec_wallet:
+        try:
+            send_token(rec_wallet, 0.01, "ASM")
+        except Exception:
+            pass
     return entry
 
 

--- a/engine/squad_wallets.py
+++ b/engine/squad_wallets.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""Squad wallet management for pooled earnings and mission rewards."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+from .token_ops import send_token
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+WALLETS_PATH = BASE_DIR / "logs" / "squad_wallets.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def create_squad_wallet(squad_id: str, wallet: str) -> Dict:
+    data = _load_json(WALLETS_PATH, {})
+    if squad_id in data:
+        return data[squad_id]
+    entry = {"wallet": wallet, "log": []}
+    data[squad_id] = entry
+    _write_json(WALLETS_PATH, data)
+    return entry
+
+
+def record_earning(squad_id: str, amount: float, token: str) -> None:
+    data = _load_json(WALLETS_PATH, {})
+    entry = data.get(squad_id)
+    if not entry:
+        return
+    wallet = entry.get("wallet")
+    try:
+        send_token(wallet, amount, token)
+    except Exception:
+        pass
+    entry.setdefault("log", []).append({
+        "amount": amount,
+        "token": token,
+        "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    })
+    data[squad_id] = entry
+    _write_json(WALLETS_PATH, data)
+
+
+def mission_reward(squad_id: str, mission: str, amount: float, token: str = "ASM") -> None:
+    data = _load_json(WALLETS_PATH, {})
+    entry = data.get(squad_id)
+    if not entry:
+        return
+    wallet = entry.get("wallet")
+    try:
+        send_token(wallet, amount, token)
+    except Exception:
+        pass
+    entry.setdefault("missions", []).append({
+        "mission": mission,
+        "amount": amount,
+        "token": token,
+        "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    })
+    data[squad_id] = entry
+    _write_json(WALLETS_PATH, data)
+
+
+def squad_wallet(squad_id: str) -> Dict | None:
+    return _load_json(WALLETS_PATH, {}).get(squad_id)
+
+
+__all__ = [
+    "create_squad_wallet",
+    "record_earning",
+    "mission_reward",
+    "squad_wallet",
+]

--- a/vaultfire-core/marketplace_config.json
+++ b/vaultfire-core/marketplace_config.json
@@ -5,7 +5,8 @@
   "currency": [
     "ASM",
     "USDC",
-    "ETH"
+    "ETH",
+    "LOYAL"
   ],
   "public_display": [
     "signal_score",


### PR DESCRIPTION
## Summary
- add Proof-of‑Loyalty token reward system
- distribute micro‑payments when posting signals and support staking
- provide squad wallets for pooled mission rewards
- weight governance votes by reputation multiplier
- sync reward history with ENS/cb.id profiles
- allow `LOYAL` token in marketplace

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68805ed0d6f08322a07c4b1f60044dc8