### PR TITLE
Add Twitch and AR gaming extensions

### DIFF
--- a/docs/gaming_extensions.md
+++ b/docs/gaming_extensions.md
@@ -1,0 +1,13 @@
+# Gaming Extensions
+
+These optional modules enhance the core gaming layer with livestream and AR features.
+
+## Features
+- **Twitch integration** – Link handles using `engine.twitch_layer.connect_twitch_account`. Streams recorded via `start_stream` allow belief challenges and tipping in Vault Points or tokens.
+- **AR belief missions** – `engine.ar_missions` registers real-world markers and rewards users who scan them with the mobile camera.
+- **Wager battles** – `engine.wager_engine` lets players create 1v1 or squad wagers. Winners earn Vault Points or tokens and badges.
+
+## Disclaimers
+- Twitch detection is simulated with local JSON logs and does not connect to the official API.
+- AR scanning uses placeholder markers with no security guarantees.
+- Wager battles are demos only and offer no monetary value.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -175,6 +175,16 @@ from .play2earn import (
     belief_mission,
     leaderboard as play2earn_leaderboard,
 )
+from .twitch_layer import (
+    connect_twitch_account,
+    start_stream,
+    end_stream,
+    overlay_challenge,
+    tip_streamer,
+    loyalty_board,
+)
+from .ar_missions import register_marker, scan_marker
+from .wager_engine import start_battle, record_result
 
 __all__ = [
     "resolve_identity",
@@ -337,5 +347,15 @@ __all__ = [
     "record_session",
     "belief_mission",
     "play2earn_leaderboard",
+    "connect_twitch_account",
+    "start_stream",
+    "end_stream",
+    "overlay_challenge",
+    "tip_streamer",
+    "loyalty_board",
+    "register_marker",
+    "scan_marker",
+    "start_battle",
+    "record_result",
 ]
 

--- a/engine/ar_missions.py
+++ b/engine/ar_missions.py
@@ -1,0 +1,63 @@
+"""AR mission utilities for belief-based scanning."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+from .mission_scheduler import record_reward
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+MARKERS_PATH = BASE_DIR / "logs" / "ar_markers.json"
+SCANS_PATH = BASE_DIR / "logs" / "ar_scans.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Marker Registry
+# ---------------------------------------------------------------------------
+
+def register_marker(marker_id: str, belief_text: str, reward: int = 1) -> Dict:
+    """Register a real-world marker with optional reward."""
+    markers = _load_json(MARKERS_PATH, {})
+    markers[marker_id] = {"belief": belief_text, "reward": reward}
+    _write_json(MARKERS_PATH, markers)
+    return markers[marker_id]
+
+
+def scan_marker(user_id: str, marker_id: str) -> Optional[Dict]:
+    """Record that ``user_id`` scanned ``marker_id``."""
+    markers = _load_json(MARKERS_PATH, {})
+    marker = markers.get(marker_id)
+    if not marker:
+        return None
+    scans = _load_json(SCANS_PATH, [])
+    entry = {
+        "user": user_id,
+        "marker": marker_id,
+        "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    scans.append(entry)
+    _write_json(SCANS_PATH, scans)
+    record_reward(user_id, "ar_mission", marker.get("reward", 1))
+    return entry
+
+
+__all__ = ["register_marker", "scan_marker"]

--- a/engine/twitch_layer.py
+++ b/engine/twitch_layer.py
@@ -1,0 +1,139 @@
+"""Twitch integration helpers for Vaultfire gaming."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .loyalty_engine import update_loyalty_ranks
+from .mission_scheduler import record_reward
+from .token_ops import send_token
+from .contributor_identity import identity_summary
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+ACCOUNTS_PATH = BASE_DIR / "logs" / "twitch_accounts.json"
+STREAMS_PATH = BASE_DIR / "logs" / "twitch_streams.json"
+OVERLAYS_PATH = BASE_DIR / "logs" / "twitch_overlays.json"
+TIPS_PATH = BASE_DIR / "logs" / "twitch_tips.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Account Linking
+# ---------------------------------------------------------------------------
+
+def connect_twitch_account(user_id: str, handle: str) -> Dict:
+    """Associate a Twitch ``handle`` with ``user_id``."""
+    accounts = _load_json(ACCOUNTS_PATH, {})
+    accounts[user_id] = handle
+    _write_json(ACCOUNTS_PATH, accounts)
+    return {"user_id": user_id, "handle": handle}
+
+
+# ---------------------------------------------------------------------------
+# Streaming Events
+# ---------------------------------------------------------------------------
+
+def start_stream(handle: str) -> Dict:
+    """Record that ``handle`` went live."""
+    streams = _load_json(STREAMS_PATH, [])
+    entry = {
+        "handle": handle,
+        "event": "start",
+        "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    streams.append(entry)
+    _write_json(STREAMS_PATH, streams)
+    return entry
+
+
+def end_stream(handle: str) -> Dict:
+    """Record that ``handle`` ended a stream."""
+    streams = _load_json(STREAMS_PATH, [])
+    entry = {
+        "handle": handle,
+        "event": "end",
+        "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    streams.append(entry)
+    _write_json(STREAMS_PATH, streams)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Belief Challenges
+# ---------------------------------------------------------------------------
+
+def overlay_challenge(stream_id: str, text: str) -> Dict:
+    """Overlay a belief challenge on a stream."""
+    overlays = _load_json(OVERLAYS_PATH, [])
+    entry = {
+        "stream": stream_id,
+        "text": text,
+        "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    overlays.append(entry)
+    _write_json(OVERLAYS_PATH, overlays)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Tips and Leaderboards
+# ---------------------------------------------------------------------------
+
+def tip_streamer(from_user: str, to_user: str, amount: float, token: str = "LOYAL") -> Dict:
+    """Send a tip from ``from_user`` to ``to_user``."""
+    summary = identity_summary(to_user)
+    wallet = summary.get("wallets", [None])[0] if summary.get("wallets") else None
+    success = False
+    if wallet:
+        try:
+            send_token(wallet, amount, token)
+            success = True
+        except Exception:
+            success = False
+    tips = _load_json(TIPS_PATH, [])
+    entry = {
+        "from": from_user,
+        "to": to_user,
+        "amount": amount,
+        "token": token,
+        "success": success,
+        "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    tips.append(entry)
+    _write_json(TIPS_PATH, tips)
+    record_reward(to_user, "twitch_tip", int(amount))
+    return entry
+
+
+def loyalty_board(top_n: int = 10) -> List[Dict]:
+    """Return the latest loyalty ranks."""
+    return update_loyalty_ranks()[:top_n]
+
+
+__all__ = [
+    "connect_twitch_account",
+    "start_stream",
+    "end_stream",
+    "overlay_challenge",
+    "tip_streamer",
+    "loyalty_board",
+]

--- a/engine/wager_engine.py
+++ b/engine/wager_engine.py
@@ -1,0 +1,82 @@
+"""Real-time wager battles using Vault Points or tokens."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+from .mission_scheduler import record_reward
+from .token_ops import send_token
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+WAGER_PATH = BASE_DIR / "logs" / "wager_battles.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _battles() -> Dict:
+    return _load_json(WAGER_PATH, {})
+
+
+def _save(battles: Dict) -> None:
+    _write_json(WAGER_PATH, battles)
+
+
+# ---------------------------------------------------------------------------
+# Battle Lifecycle
+# ---------------------------------------------------------------------------
+
+def start_battle(game_id: str, players: List[str], amount: float, token: str = "LOYAL") -> Dict:
+    """Create a new wager battle."""
+    battles = _battles()
+    bid = f"battle-{uuid4().hex}"
+    entry = {
+        "id": bid,
+        "game_id": game_id,
+        "players": players,
+        "amount": amount,
+        "token": token,
+        "start": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "active": True,
+    }
+    battles[bid] = entry
+    _save(battles)
+    return entry
+
+
+def record_result(battle_id: str, winner: str) -> Optional[Dict]:
+    """Finalize a battle and reward ``winner``."""
+    battles = _battles()
+    entry = battles.get(battle_id)
+    if not entry or not entry.get("active"):
+        return None
+    entry["active"] = False
+    entry["winner"] = winner
+    entry["end"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    _save(battles)
+    record_reward(winner, "wager", int(entry.get("amount", 0)))
+    try:
+        send_token(winner, entry.get("amount", 0), entry.get("token", "LOYAL"))
+    except Exception:
+        pass
+    return entry
+
+
+__all__ = ["start_battle", "record_result"]

--- a/vaultfire_gaming/__init__.py
+++ b/vaultfire_gaming/__init__.py
@@ -13,6 +13,16 @@ from engine.play2earn import (
     belief_mission,
     leaderboard as p2e_leaderboard,
 )
+from engine.twitch_layer import (
+    connect_twitch_account,
+    start_stream,
+    end_stream,
+    overlay_challenge,
+    tip_streamer,
+    loyalty_board,
+)
+from engine.ar_missions import register_marker, scan_marker
+from engine.wager_engine import start_battle, record_result
 from vaultfire_arcade.guest_progress import merge_guest_progress
 
 __all__ = [
@@ -34,6 +44,16 @@ __all__ = [
     "record_session",
     "belief_mission",
     "p2e_leaderboard",
+    "connect_twitch_account",
+    "start_stream",
+    "end_stream",
+    "overlay_challenge",
+    "tip_streamer",
+    "loyalty_board",
+    "register_marker",
+    "scan_marker",
+    "start_battle",
+    "record_result",
 ]
 
 class VaultfireGameSDK:
@@ -116,3 +136,39 @@ class VaultfireGameSDK:
 
     def leaderboard(self, top_n: int = 10):
         return p2e_leaderboard(top_n)
+
+    # --- Twitch helpers -----------------------------------------------------
+
+    def connect_twitch(self, user_id: str, handle: str):
+        return connect_twitch_account(user_id, handle)
+
+    def start_stream(self, handle: str):
+        return start_stream(handle)
+
+    def end_stream(self, handle: str):
+        return end_stream(handle)
+
+    def overlay_challenge(self, stream_id: str, text: str):
+        return overlay_challenge(stream_id, text)
+
+    def tip_streamer(self, from_user: str, to_user: str, amount: float, token: str = "LOYAL"):
+        return tip_streamer(from_user, to_user, amount, token)
+
+    def loyalty_board(self, top_n: int = 10):
+        return loyalty_board(top_n)
+
+    # --- AR missions --------------------------------------------------------
+
+    def register_marker(self, marker_id: str, belief_text: str, reward: int = 1):
+        return register_marker(marker_id, belief_text, reward)
+
+    def scan_marker(self, user_id: str, marker_id: str):
+        return scan_marker(user_id, marker_id)
+
+    # --- Wager battles ------------------------------------------------------
+
+    def start_battle(self, game_id: str, players: list[str], amount: float, token: str = "LOYAL"):
+        return start_battle(game_id, players, amount, token)
+
+    def record_battle(self, battle_id: str, winner: str):
+        return record_result(battle_id, winner)


### PR DESCRIPTION
## Summary
- add Twitch integration helpers
- add AR mission utilities and wager engine
- expose new features via `VaultfireGameSDK`
- document gaming extensions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688063be3de083229d4df4aa1979b11d