### PR TITLE
Implement synergy and module upgrades

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -89,6 +89,8 @@ from .purpose_engine import (
     analyze_actions,
     moral_memory_mirror,
     simulate_life_path,
+    daily_path_trigger,
+    self_alignment_check,
     commit_life_path,
 )
 from .synced_soul_compass import update_soul_compass
@@ -198,6 +200,7 @@ from .twitch_layer import (
 )
 from .ar_missions import register_marker, scan_marker
 from .wager_engine import start_battle, record_result
+from .synergy_manager import record_synergy
 
 __all__ = [
     "resolve_identity",
@@ -287,6 +290,8 @@ __all__ = [
     "simulate_life_path",
     "commit_life_path",
     "update_soul_compass",
+    "daily_path_trigger",
+    "self_alignment_check",
     "train_archetype_guide",
     "get_archetype_guide",
     "update_emotional_state",
@@ -381,5 +386,6 @@ __all__ = [
     "record_result",
     "log_quiz",
     "complete_lesson",
+    "record_synergy",
 ]
 

--- a/engine/gaming_layer.py
+++ b/engine/gaming_layer.py
@@ -29,7 +29,12 @@ def _write_json(path: Path, data) -> None:
         json.dump(data, f, indent=2)
 
 
-def create_session(game_id: str, creator: str, metadata: Optional[Dict] = None) -> Dict:
+def create_session(
+    game_id: str,
+    creator: str,
+    metadata: Optional[Dict] = None,
+    stream_handle: str | None = None,
+) -> Dict:
     """Create a new game session and return the record."""
     sessions: List[Dict] = _load_json(SESSIONS_PATH, [])
     session = {
@@ -40,6 +45,13 @@ def create_session(game_id: str, creator: str, metadata: Optional[Dict] = None) 
         "created": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
         "active": True,
     }
+    if stream_handle:
+        try:
+            from .twitch_layer import start_stream
+            start_stream(stream_handle)
+            session["stream"] = stream_handle
+        except Exception:
+            session["stream"] = stream_handle
     sessions.append(session)
     _write_json(SESSIONS_PATH, sessions)
     return session
@@ -64,6 +76,12 @@ def end_session(game_id: str, reward_per_player: float = 0.0, token: str = "ASM"
         if session.get("game_id") == game_id and session.get("active"):
             session["active"] = False
             session["ended"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            if session.get("stream"):
+                try:
+                    from .twitch_layer import end_stream
+                    end_stream(session["stream"])
+                except Exception:
+                    pass
             _write_json(SESSIONS_PATH, sessions)
             if reward_per_player > 0:
                 for player in session.get("players", []):

--- a/engine/learn2earn.py
+++ b/engine/learn2earn.py
@@ -12,6 +12,7 @@ from .life_yield_engine import record_life_action, calculate_life_yield
 from .token_ops import send_token
 from .social_layer import post_signal
 from .gamified_yield_layer import complete_task
+from .reflection_layer import emotion_trend
 from .fit_sync import record_workout_sync
 from .play2earn import record_session
 
@@ -43,14 +44,36 @@ def _log(user_id: str, key: str, entry: Dict) -> None:
     _write_json(LOG_PATH, data)
 
 
-def log_quiz(user_id: str, quiz_id: str, score: float) -> Dict:
-    """Record quiz result scaled by reputation."""
+def _mood_multiplier(user_id: str, key: str) -> float:
+    """Return multiplier based on recent emotions."""
+    trends = emotion_trend(user_id, key)
+    if not trends:
+        return 1.0
+    joy = trends.get("joy", 0.0)
+    doubt = trends.get("doubt", 0.0)
+    return 1.0 + joy - doubt
+
+
+def _next_difficulty(score: float) -> str:
+    if score > 0.8:
+        return "hard"
+    if score < 0.5:
+        return "easy"
+    return "medium"
+
+
+def log_quiz(user_id: str, quiz_id: str, score: float, key: str | None = None) -> Dict:
+    """Record quiz result scaled by reputation and emotional state."""
     mult = learning_multiplier(user_id)
+    if key:
+        mult *= _mood_multiplier(user_id, key)
     xp = round(score * mult, 2)
+    difficulty = _next_difficulty(score)
     entry = {
         "quiz": quiz_id,
         "score": score,
         "xp": xp,
+        "difficulty": difficulty,
         "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
     _log(user_id, "quizzes", entry)
@@ -93,4 +116,4 @@ def complete_lesson(
     return entry
 
 
-__all__ = ["log_quiz", "complete_lesson"]
+__all__ = ["log_quiz", "complete_lesson", "_next_difficulty"]

--- a/engine/loyalty_engine.py
+++ b/engine/loyalty_engine.py
@@ -4,6 +4,7 @@
 import json
 from pathlib import Path
 from datetime import datetime
+from typing import Optional
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
@@ -68,6 +69,27 @@ def loyalty_score(user_id: str) -> dict:
             pass
     score = base * multiplier * bond_mult
     return {"user_id": user_id, "base": base, "tier": tier, "score": score}
+
+
+def loyalty_enhanced_score(
+    user_id: str,
+    mood: Optional[int] = None,
+    frequency: Optional[int] = None,
+    life_impact: Optional[float] = None,
+) -> dict:
+__all__ = ["loyalty_score", "update_loyalty_ranks", "loyalty_enhanced_score"]
+    """Return loyalty score adjusted by mood and impact metrics."""
+    info = loyalty_score(user_id)
+    bonus = 0.0
+    if mood is not None:
+        bonus += max(min(mood - 3, 2), -2) * 5
+    if frequency is not None:
+        bonus += min(frequency, 30) * 0.2
+    if life_impact is not None:
+        bonus += life_impact * 10
+    info["score"] += bonus
+    info["bonus"] = bonus
+    return info
 
 
 def update_loyalty_ranks() -> list[dict]:

--- a/engine/purpose_engine.py
+++ b/engine/purpose_engine.py
@@ -190,6 +190,26 @@ def commit_life_path(user_id: str, path: str) -> Dict:
     return {"user_id": user_id, **info}
 
 
+def daily_path_trigger(user_id: str) -> str:
+    """Return today's quest suggestion for the user's path."""
+    state = _load_json(LIFE_PATHS_STATE_PATH, {})
+    path = state.get(user_id, {}).get("path")
+    if not path:
+        return generate_purpose_quest(user_id)
+    quests = LIFE_PATHS.get(path, {}).get("quests", [])
+    if not quests:
+        return generate_purpose_quest(user_id)
+    return f"Daily Path Quest: {random.choice(quests)}"
+
+
+def self_alignment_check(user_id: str) -> float:
+    """Return alignment delta between actions and mission."""
+    mission = _load_json(PURPOSE_PATH, {}).get(user_id, {}).get("mission", "")
+    actions = analyze_actions(user_id)
+    alignment = actions.get("offchain_score", 0) - len(mission.split()) * 0.1
+    return round(alignment, 2)
+
+
 def _hash_identifier(identifier: str) -> str:
     return hashlib.sha256(identifier.encode()).hexdigest()
 
@@ -257,6 +277,8 @@ __all__ = [
     "tailor_experience",
     "analyze_actions",
     "moral_memory_mirror",
+    "daily_path_trigger",
+    "self_alignment_check",
     "simulate_life_path",
     "commit_life_path",
     "gene_risk_level",

--- a/engine/social_layer.py
+++ b/engine/social_layer.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from .token_ops import send_token
+from .music_layer import attach_track_to_signal
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 SOCIAL_DIR = BASE_DIR / "logs" / "social"
@@ -214,6 +215,12 @@ def post_signal(
 def exchange_signal(sender: str, recipient: str, signal: str) -> Dict:
     """Backward compatible wrapper for plain text signals."""
     return post_signal(sender, recipient, "general", "neutral", signal)
+
+
+def share_track(sender: str, recipient: str, track_id: str) -> Dict:
+    """Share a music track and sync with the social feed."""
+    attach_track_to_signal(track_id, track_id)
+    return post_signal(sender, recipient, "music", "positive", track_id, track=track_id)
 
 
 # ---------------------------------------------------------------------------

--- a/engine/synergy_manager.py
+++ b/engine/synergy_manager.py
@@ -1,0 +1,51 @@
+
+"""Cross-module synergy utilities."""
+
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Dict
+
+from .gamified_yield_layer import quest_card
+from .music_layer import build_music_identity
+from .wellness_companion import mood_checkin
+from .purpose_engine import moral_memory_mirror
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LOG_PATH = BASE_DIR / "logs" / "synergy_log.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def record_synergy(user_id: str) -> Dict:
+    """Record a simple synergy snapshot across modules."""
+    card = quest_card(user_id)
+    moral_memory_mirror(user_id)
+    mood_checkin(user_id, 3)
+    build_music_identity(user_id, [])
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "user_id": user_id,
+        "tasks": card.get("tasks", {}),
+    }
+    log = _load_json(LOG_PATH, [])
+    log.append(entry)
+    _write_json(LOG_PATH, log)
+    return entry
+
+
+__all__ = ["record_synergy"]

--- a/engine/wellness_companion.py
+++ b/engine/wellness_companion.py
@@ -56,9 +56,21 @@ def coping_suggestions(user_id: str, key: str) -> List[str]:
     return suggestions
 
 
+def evolve_companion(user_id: str) -> str:
+    """Evolve AI companion logic with Morals-First safeguards."""
+    trend = emotion_trend(user_id, "vaultkey")
+    if trend.get("joy", 0) > 0.5:
+        stage = "guide"
+    else:
+        stage = "ally"
+    record_interaction(user_id, stage, "evolve", 1.0, False, "vaultkey")
+    return stage
+
+
 __all__ = [
     "log_journal_entry",
     "mood_checkin",
     "reflection_prompt",
     "coping_suggestions",
+    "evolve_companion",
 ]

--- a/security_monitor.py
+++ b/security_monitor.py
@@ -11,6 +11,11 @@ import json
 from pathlib import Path
 from datetime import datetime
 
+try:
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - optional
+    psutil = None
+
 BASE_DIR = Path(__file__).resolve().parent
 BASELINE_PATH = BASE_DIR / "vaultfire-core" / "security_baseline.json"
 BACKUP_DIR = BASE_DIR / "vaultfire-core" / "baseline_backups"
@@ -36,6 +41,28 @@ def _write_json(path: Path, data) -> None:
 def _hash_file(path: Path) -> str:
     data = path.read_bytes()
     return hashlib.sha256(data).hexdigest()
+
+
+def audit_connections() -> list[dict]:
+    """Return list of active network connections."""
+    results: list[dict] = []
+    if psutil is None:
+        return results
+    for conn in psutil.net_connections(kind="tcp"):
+        if conn.raddr:
+            results.append({
+                "laddr": f"{conn.laddr.ip}:{conn.laddr.port}",
+                "raddr": f"{conn.raddr.ip}:{conn.raddr.port}",
+                "status": conn.status,
+            })
+    if results:
+        log = _load_json(LOG_PATH, [])
+        ts = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        for r in results:
+            r["timestamp"] = ts
+            log.append(r)
+        _write_json(LOG_PATH, log)
+    return results
 
 
 def set_baseline(files: list[Path]) -> None:


### PR DESCRIPTION
## Summary
- add new `synergy_manager` module for cross-module coordination
- integrate synergy export in package
- extend loyalty engine with mood and activity bonuses
- add emotion-aware quiz difficulty to Learn2Earn
- evolve the wellness companion
- provide daily path triggers in Purpose Engine
- sync music sharing in social layer
- hook Twitch streams into gaming layer sessions
- add live connection auditing to security monitor

## Testing
- `pytest -q` *(no tests ran)*
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880fc29415083228cb9f86e9d4f1d8a