### PR TITLE
Fix indentation error in loyalty_engine

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,0 +1,1 @@
+[{"timestamp": "2025-07-23T17:30:06Z", "change": "loyalty engine indentation fix", "update_block": "PENDING_PUSH"}]

--- a/codex_update_block.status
+++ b/codex_update_block.status
@@ -1,0 +1,1 @@
+PENDING_PUSH

--- a/engine/loyalty_engine.py
+++ b/engine/loyalty_engine.py
@@ -77,7 +77,6 @@ def loyalty_enhanced_score(
     frequency: Optional[int] = None,
     life_impact: Optional[float] = None,
 ) -> dict:
-__all__ = ["loyalty_score", "update_loyalty_ranks", "loyalty_enhanced_score"]
     """Return loyalty score adjusted by mood and impact metrics."""
     info = loyalty_score(user_id)
     bonus = 0.0
@@ -99,6 +98,13 @@ def update_loyalty_ranks() -> list[dict]:
     _write_json(LOYALTY_RANKS_PATH, ranks)
     _log({"action": "update_ranks", "count": len(ranks)})
     return ranks
+
+
+__all__ = [
+    "loyalty_score",
+    "update_loyalty_ranks",
+    "loyalty_enhanced_score",
+]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- resolve indentation error in `loyalty_engine.py`
- add `__all__` declaration
- create `codex_update_block.status`
- log update in `changelog.json`

## Testing
- `npm test`
- `python system_integrity_check.py`
- `python engine/feedback_loop.py` *(fails: ModuleNotFoundError: No module named 'vaultfire_signal')*
- `python simulate_partner_activation.py test user --test-mode`
- `python sandbox_belieftech.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688119b45a4c8322a5f70bc74bc19e2e