### PR TITLE
Implement live training and signal monitors

### DIFF
--- a/activate_live_training.py
+++ b/activate_live_training.py
@@ -1,0 +1,26 @@
+"""Enable live training mode in the Vaultfire configuration."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+CFG_PATH = Path(__file__).resolve().parent / "vaultfire-core" / "vaultfire_config.json"
+
+
+def activate() -> dict:
+    data = {}
+    if CFG_PATH.exists():
+        try:
+            with open(CFG_PATH) as f:
+                data = json.load(f)
+        except json.JSONDecodeError:
+            data = {}
+    data["live_training_mode"] = True
+    with open(CFG_PATH, "w") as f:
+        json.dump(data, f, indent=2)
+    return data
+
+
+if __name__ == "__main__":
+    result = activate()
+    print(json.dumps({"live_training_mode": result.get("live_training_mode")}, indent=2))

--- a/confirm_phase3.py
+++ b/confirm_phase3.py
@@ -1,0 +1,20 @@
+"""Confirm Phase 3 Codex expansion tied to Ghostkey-316."""
+from __future__ import annotations
+
+import json
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+STATUS_PATH = Path(__file__).resolve().parent / "codex_update_block.status"
+PROOF_PATH = Path(__file__).resolve().parent / "vaultfire-proof.codex"
+
+
+def confirm() -> dict:
+    status = STATUS_PATH.read_text().strip()
+    proof = SourceFileLoader("proof", str(PROOF_PATH)).load_module()
+    proof_log = proof.confirm()
+    return {"phase": status, "identity": proof_log.get("identity")}
+
+
+if __name__ == "__main__":
+    print(json.dumps(confirm(), indent=2))

--- a/ghostlog_loyalty_monitor.py
+++ b/ghostlog_loyalty_monitor.py
@@ -1,0 +1,44 @@
+"""Monitor loyalty ranks and log Ghostkey-316 updates."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from engine.loyalty_engine import update_loyalty_ranks
+
+BASE_DIR = Path(__file__).resolve().parent
+LOG_PATH = BASE_DIR / "logs" / "ghostlog_loyalty.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def monitor() -> dict:
+    ranks = update_loyalty_ranks()
+    ghost = next((r for r in ranks if r.get("user_id") == "ghostkey316"), None)
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "ghostkey316": ghost,
+    }
+    log = _load_json(LOG_PATH, [])
+    log.append(entry)
+    _write_json(LOG_PATH, log)
+    return entry
+
+
+if __name__ == "__main__":
+    print(json.dumps(monitor(), indent=2))

--- a/recursive_signal_tracker.py
+++ b/recursive_signal_tracker.py
@@ -1,0 +1,55 @@
+"""Recursive signal tracker with belief and ethics checks."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vaultfire_signal_parser import parse_signal
+from engine.belief_validation import validate_belief
+
+BASE_DIR = Path(__file__).resolve().parent
+FEED_PATH = BASE_DIR / "dashboards" / "signal_feed.json"
+ANALYSIS_PATH = BASE_DIR / "dashboards" / "signal_analysis.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def track_signals() -> list[dict]:
+    feed = _load_json(FEED_PATH, [])
+    log = _load_json(ANALYSIS_PATH, [])
+    processed = {e.get("timestamp") for e in log}
+    for item in feed:
+        ts = item.get("timestamp")
+        if not ts or ts in processed:
+            continue
+        text = json.dumps(item, sort_keys=True)
+        parsed = parse_signal(text)
+        approved = validate_belief("ghostkey316", text)
+        log.append({
+            "timestamp": ts,
+            "score": parsed.get("score"),
+            "verified": parsed.get("verified"),
+            "approved": approved,
+        })
+    _write_json(ANALYSIS_PATH, log)
+    return log
+
+
+if __name__ == "__main__":
+    data = track_signals()
+    if data:
+        print(json.dumps(data[-1], indent=2))

--- a/vaultfire-core/vaultfire_config.json
+++ b/vaultfire-core/vaultfire_config.json
@@ -5,5 +5,6 @@
   "public_visibility": "controlled",
   "partner_hooks_enabled": true,
   "wallet_auth_hook": true,
+  "live_training_mode": true,
   "fail_safe": "Hard shutdown on ethics breach"
 }


### PR DESCRIPTION
## Summary
- enable `live_training_mode` in config
- add script to toggle live training
- track signal feed recursively with ethics & belief checks
- monitor loyalty ranks through `ghostlog` log
- confirm Phase 3 codex state programmatically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68811f2031288322a35f237a33de2ddc