### PR TITLE
Add fan engagement features to sports CLI

### DIFF
--- a/vaultfire_sports.py
+++ b/vaultfire_sports.py
@@ -11,6 +11,11 @@ import csv
 import json
 from pathlib import Path
 from typing import Any, Dict, List
+from urllib.request import urlopen
+from datetime import datetime
+from uuid import uuid4
+
+from engine import record_belief_action
 
 # Data files
 REGISTRY_PATH = Path("sports_registry.json")
@@ -18,6 +23,11 @@ CRED_LOG_PATH = Path("fan_cred_log.csv")
 RIVALRY_PATH = Path("rivalry_matrix.json")
 NFT_MAP_PATH = Path("sports_nft_map.json")
 ATHLETE_NODE_PATH = Path("athlete_node_log.json")
+TEAM_MAP_PATH = Path("team_fan_map.json")
+CHECKIN_LOG_PATH = Path("event_checkin_log.csv")
+MEMORY_LOG_PATH = Path("fan_story_log.json")
+BATTLE_LOG_PATH = Path("fan_battle_log.csv")
+LOYALTY_TRACKER_PATH = Path("loyalty_bond_tracker.json")
 
 
 # ---------------------------------------------------------------------------
@@ -49,6 +59,21 @@ def _append_csv(path: Path, row: List[str]) -> None:
         if not exists:
             writer.writerow(["timestamp", "identity", "action", "value", "detail"])
         writer.writerow(row)
+
+
+def _sync_schedule(team: str, fallback: str | None = None) -> Dict:
+    """Return schedule data for ``team`` from ESPN API or fallback file."""
+    url = (
+        "https://site.api.espn.com/apis/v2/sports/football/college-football/"
+        f"teams/{team}/schedule"
+    )
+    try:
+        with urlopen(url, timeout=5) as resp:
+            return json.load(resp)
+    except Exception:
+        if fallback:
+            return _load_json(Path(fallback), {})
+    return {}
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +175,103 @@ def cmd_update(args: argparse.Namespace) -> None:
     print("Game data synced")
 
 
+def cmd_set_team(args: argparse.Namespace) -> None:
+    """Track favorite team and sync schedule."""
+    team_map: Dict[str, List[str]] = _load_json(TEAM_MAP_PATH, {})
+    fans = team_map.get(args.team, [])
+    if args.identity not in fans:
+        fans.append(args.identity)
+    team_map[args.team] = fans
+    _write_json(TEAM_MAP_PATH, team_map)
+
+    schedule = _sync_schedule(args.team, args.fallback)
+    for event in schedule.get("events", []):
+        comp = event.get("competitions", [{}])[0]
+        status = comp.get("status", {}).get("type", {}).get("description", "")
+        prompt = f"{args.team} {status}"
+        record_belief_action(args.identity, args.identity, prompt)
+    print(f"Favorite team set: {args.team}")
+
+
+def cmd_check_in(args: argparse.Namespace) -> None:
+    """Log event check-in with optional GPS tag."""
+    row = [datetime.utcnow().isoformat(), args.identity, args.team or "", args.gps or ""]
+    exists = CHECKIN_LOG_PATH.exists()
+    with open(CHECKIN_LOG_PATH, "a", newline="") as f:
+        writer = csv.writer(f)
+        if not exists:
+            writer.writerow(["timestamp", "identity", "team", "gps"])
+        writer.writerow(row)
+    print("Check-in recorded")
+
+
+def cmd_memory(args: argparse.Namespace) -> None:
+    """Capture a fan memory for the chain."""
+    memory = input("Share your memory: ").strip()
+    if not memory:
+        print("No memory entered")
+        return
+    log: List[Dict[str, Any]] = _load_json(MEMORY_LOG_PATH, [])
+    log.append({
+        "timestamp": datetime.utcnow().isoformat(),
+        "identity": args.identity,
+        "team": args.team,
+        "memory": memory,
+    })
+    _write_json(MEMORY_LOG_PATH, log)
+    record_belief_action(args.identity, args.identity, memory)
+    print("Memory saved")
+
+
+def cmd_battle(args: argparse.Namespace) -> None:
+    """Start a fan battle prediction."""
+    result = args.result or ""
+    if not result and args.resolve:
+        schedule = _sync_schedule(args.team, None)
+        result = schedule.get("status", "") if isinstance(schedule, dict) else ""
+    row = [
+        datetime.utcnow().isoformat(),
+        args.identity,
+        args.rival,
+        args.prediction,
+        args.stakes,
+        result,
+    ]
+    exists = BATTLE_LOG_PATH.exists()
+    with open(BATTLE_LOG_PATH, "a", newline="") as f:
+        writer = csv.writer(f)
+        if not exists:
+            writer.writerow(["timestamp", "identity", "rival", "prediction", "stakes", "result"])
+        writer.writerow(row)
+    if result:
+        record_belief_action(args.identity, args.identity, result)
+    print("Battle logged")
+
+
+def cmd_challenge(args: argparse.Namespace) -> None:
+    """Manage long-term prediction challenges."""
+    tracker: List[Dict[str, Any]] = _load_json(LOYALTY_TRACKER_PATH, [])
+    if args.accept:
+        for entry in tracker:
+            if entry.get("id") == args.accept and args.identity not in entry.get("accepted_by", []):
+                entry.setdefault("accepted_by", []).append(args.identity)
+        _write_json(LOYALTY_TRACKER_PATH, tracker)
+        print("Challenge accepted")
+        return
+
+    entry = {
+        "id": str(uuid4()),
+        "identity": args.identity,
+        "team": args.team,
+        "description": args.description,
+        "due": args.due,
+        "accepted_by": [],
+    }
+    tracker.append(entry)
+    _write_json(LOYALTY_TRACKER_PATH, tracker)
+    print("Challenge created")
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -194,6 +316,41 @@ def main(argv: List[str] | None = None) -> int:
     p_update = sub.add_parser("update", help="Sync game data")
     p_update.add_argument("identity")
     p_update.set_defaults(func=cmd_update)
+
+    p_set_team = sub.add_parser("set-team", help="Set favorite team")
+    p_set_team.add_argument("identity")
+    p_set_team.add_argument("team")
+    p_set_team.add_argument("--fallback")
+    p_set_team.set_defaults(func=cmd_set_team)
+
+    p_checkin = sub.add_parser("check-in", help="Event check-in")
+    p_checkin.add_argument("identity")
+    p_checkin.add_argument("--team")
+    p_checkin.add_argument("--gps")
+    p_checkin.set_defaults(func=cmd_check_in)
+
+    p_memory = sub.add_parser("memory", help="Log a fan memory")
+    p_memory.add_argument("identity")
+    p_memory.add_argument("--team", default="")
+    p_memory.set_defaults(func=cmd_memory)
+
+    p_battle = sub.add_parser("battle", help="Start fan battle")
+    p_battle.add_argument("identity")
+    p_battle.add_argument("team")
+    p_battle.add_argument("rival")
+    p_battle.add_argument("prediction")
+    p_battle.add_argument("stakes")
+    p_battle.add_argument("--resolve", action="store_true")
+    p_battle.add_argument("--result")
+    p_battle.set_defaults(func=cmd_battle)
+
+    p_challenge = sub.add_parser("challenge", help="Long term challenge")
+    p_challenge.add_argument("identity")
+    p_challenge.add_argument("team")
+    p_challenge.add_argument("description")
+    p_challenge.add_argument("--due", default="")
+    p_challenge.add_argument("--accept")
+    p_challenge.set_defaults(func=cmd_challenge)
 
     args = parser.parse_args(argv)
     args.func(args)


### PR DESCRIPTION
## Summary
- add new log paths for tracking teams and memories
- include schedule sync helper
- implement set-team, check-in, memory, battle, and challenge commands
- expose new CLI options for fan activities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68817b7d86088322839ac3c0e197a776