### PR TITLE
Improve identity resolver case handling

### DIFF
--- a/__tests__/vaultfire_partner_onboard.test.js
+++ b/__tests__/vaultfire_partner_onboard.test.js
@@ -36,7 +36,9 @@ beforeEach(() => {
 
 test('resolveIdentity validates ENS and cb.id addresses', () => {
   expect(resolveIdentity('ghostkey316.eth')).toBe('0x9abCDEF1234567890abcdefABCDEF1234567890');
+  expect(resolveIdentity('GhostKey316.ETH')).toBe('0x9abCDEF1234567890abcdefABCDEF1234567890');
   expect(resolveIdentity('bpow20.cb.id')).toBe('cb1qexampleaddress0000000000000000000000');
+  expect(resolveIdentity('BPOW20.CB.ID')).toBe('cb1qexampleaddress0000000000000000000000');
   expect(resolveIdentity('unknown.eth')).toBeNull();
 });
 

--- a/engine/identity_resolver.py
+++ b/engine/identity_resolver.py
@@ -28,8 +28,9 @@ def resolve_cb_id(name: str) -> Optional[str]:
 
 def resolve_identity(identifier: str) -> Optional[str]:
     """Resolve ``identifier`` to a wallet address."""
-    if identifier.endswith(".eth"):
-        return resolve_ens(identifier)
-    if identifier.endswith(".cb.id"):
-        return resolve_cb_id(identifier)
+    ident = identifier.lower()
+    if ident.endswith(".eth"):
+        return resolve_ens(ident)
+    if ident.endswith(".cb.id"):
+        return resolve_cb_id(ident)
     return None

--- a/vaultfire_partner_onboard.js
+++ b/vaultfire_partner_onboard.js
@@ -15,11 +15,12 @@ const CB_ID_MAP = {
 };
 
 function resolveIdentity(identifier) {
-  if (identifier.endsWith('.eth')) {
-    return ENS_MAP[identifier.toLowerCase()] || null;
+  const id = identifier.toLowerCase();
+  if (id.endsWith('.eth')) {
+    return ENS_MAP[id] || null;
   }
-  if (identifier.endsWith('.cb.id')) {
-    return CB_ID_MAP[identifier.toLowerCase()] || null;
+  if (id.endsWith('.cb.id')) {
+    return CB_ID_MAP[id] || null;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- make wallet resolution case-insensitive in `vaultfire_partner_onboard.js`
- update Python identity resolver to handle mixed‑case identifiers
- extend tests to cover new behavior

## Testing
- `npm test`
- `python3 python_system_validate.py`


------
https://chatgpt.com/codex/tasks/task_e_68819742bc608322b0beaaa090dc8428