### PR TITLE
Add data purge tool and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,14 @@ Run `python3 system_watchdog.py` to continuously log CPU, memory, and disk usage
 while also checking the security baseline. Use `--no-repair` to disable automatic
 restoration when corruption is detected.
 
+## Data Removal
+Participants may request deletion of their local records. Use
+`purge_user_data.py` to wipe references from common logs:
+
+```bash
+python3 tools/purge_user_data.py <user_id> --wallet mywallet.eth
+```
+
 ## Disclaimers
 - This repository is experimental software provided for learning and discussion.
 - Nothing here constitutes financial or legal advice.
@@ -625,3 +633,4 @@ restoration when corruption is detected.
 - Learn2Earn module is experimental; quiz rewards depend on local records and
   do not guarantee any asset transfer.
 - `vaultfire-cli` manages local protocol files and never stores private keys.
+- Contributors may purge their local data using `tools/purge_user_data.py`.

--- a/tools/purge_user_data.py
+++ b/tools/purge_user_data.py
@@ -1,0 +1,74 @@
+"""Utility to purge local user data across Vaultfire logs."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+
+FILES: dict[Path, str] = {
+    BASE_DIR / "user_scorecard.json": "dict",
+    BASE_DIR / "user_goals.json": "dict",
+    BASE_DIR / "user_list.json": "list",
+    BASE_DIR / "ghostscores.json": "dict",
+    BASE_DIR / "logs" / "alignment_feedback.json": "entries",
+    BASE_DIR / "immutable_log.jsonl": "jsonl",
+}
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def purge_user(user_id: str, wallet: str | None = None) -> None:
+    """Remove ``user_id`` and optional ``wallet`` from local logs."""
+    for path, kind in FILES.items():
+        if not path.exists():
+            continue
+        if kind == "dict":
+            data = _load_json(path, {})
+            if user_id in data:
+                del data[user_id]
+                _write_json(path, data)
+        elif kind == "list":
+            data = _load_json(path, [])
+            new_data = [x for x in data if x != user_id]
+            if data != new_data:
+                _write_json(path, new_data)
+        elif kind == "entries":
+            data = _load_json(path, [])
+            new_data = [e for e in data if e.get("user_id") != user_id and (wallet is None or e.get("wallet") != wallet)]
+            if data != new_data:
+                _write_json(path, new_data)
+        elif kind == "jsonl":
+            lines = path.read_text().splitlines()
+            new_lines = [line for line in lines if user_id not in line and (wallet is None or wallet not in line)]
+            if lines != new_lines:
+                path.write_text("\n".join(new_lines) + ("\n" if new_lines else ""))
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="Purge local data for a user")
+    parser.add_argument("user_id", help="User identifier to remove")
+    parser.add_argument("--wallet", help="Wallet or ENS to match", default=None)
+    args = parser.parse_args()
+    purge_user(args.user_id, args.wallet)
+    print(f"Purged data for {args.user_id}")
+
+
+if __name__ == "__main__":
+    _cli()


### PR DESCRIPTION
## Summary
- add `purge_user_data.py` utility for removing user data from local logs
- document optional data removal in README with instructions
- note the purge tool in the disclaimers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881997598908322bd3490999bb4e62b