### PR TITLE
Add partner plug-in framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,22 @@ Run these steps to verify your local instance is ready for partner plugins:
 
 If all commands succeed without errors, the protocol is ready for activation.
 
+## Public Partner Plug-in Interface
+Partner integrations can extend Vaultfire without modifying core files. Place
+modules in the new `partner_plugins` directory and they will load automatically
+alongside built-in partner modules. Default plugins provide optional helpers for
+OpenAI, Assemble AI, Worldcoin biometric sync and an ENS cloak toggle.
+
+Example usage:
+
+```python
+from partner_plugins import summarize_text, transcribe_audio, verify_worldcoin,
+    toggle_public_display
+
+print(summarize_text("Welcome to Vaultfire")['summary'])
+toggle_public_display(False)  # hide ENS and wallet by default
+```
+
 ## Security Monitor
 Run `python3 security_monitor.py --set-baseline` once to record baseline file hashes.
 Future runs will detect changes and restore originals if needed using `--repair`.

--- a/compatibility_shim.py
+++ b/compatibility_shim.py
@@ -1,0 +1,42 @@
+"""Compatibility shim for optional partner APIs."""
+
+from __future__ import annotations
+
+
+class _OpenAI:
+    def chat_completion(self, prompt: str) -> dict:
+        try:
+            import openai  # type: ignore
+            resp = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=60,
+            )
+            return resp
+        except Exception:
+            return {"choices": [{"message": {"content": "unavailable"}}]}
+
+
+class _NS3:
+    def fetch_quiz(self, user_id: str) -> dict:
+        try:
+            import ns3  # type: ignore
+            return ns3.fetch_quiz(user_id)  # type: ignore
+        except Exception:
+            return {"score": 0, "loyalty_points": 0}
+
+
+class _Worldcoin:
+    def verify(self, user_id: str, world_id: str) -> bool:
+        try:
+            import worldcoin  # type: ignore
+            return bool(worldcoin.verify(user_id, world_id))  # type: ignore
+        except Exception:
+            return False
+
+
+openai_api = _OpenAI()
+ns3_api = _NS3()
+worldcoin_api = _Worldcoin()
+
+__all__ = ["openai_api", "ns3_api", "worldcoin_api"]

--- a/partner_api_shim.ts
+++ b/partner_api_shim.ts
@@ -1,0 +1,32 @@
+/** Compatibility shim for partner APIs */
+export async function openaiChat(prompt: string): Promise<string> {
+  try {
+    const openai = await import('openai');
+    const resp = await openai.ChatCompletion.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 60
+    });
+    return resp.choices[0].message.content;
+  } catch (err) {
+    return 'openai unavailable';
+  }
+}
+
+export async function ns3Quiz(user: string): Promise<{ score: number }> {
+  try {
+    const ns3 = await import('ns3');
+    return await ns3.fetchQuiz(user);
+  } catch (err) {
+    return { score: 0 };
+  }
+}
+
+export async function worldcoinVerify(user: string, worldId: string): Promise<boolean> {
+  try {
+    const worldcoin = await import('worldcoin');
+    return await worldcoin.verify(user, worldId);
+  } catch (err) {
+    return false;
+  }
+}

--- a/partner_modules/__init__.py
+++ b/partner_modules/__init__.py
@@ -1,4 +1,7 @@
-"""Partner onboarding modules."""
+"""Partner onboarding modules with optional plugin support."""
+
+from importlib import import_module
+from pathlib import Path
 
 from .verifiability_console import (
     record_audit_log,
@@ -85,3 +88,19 @@ __all__ = [
     "set_addon_enabled",
     "addon_enabled",
 ]
+
+# -----------------------------------------------------
+# Optional partner plugins
+# -----------------------------------------------------
+PLUGIN_DIR = Path(__file__).resolve().parents[1] / "partner_plugins"
+if PLUGIN_DIR.exists():
+    for path in PLUGIN_DIR.glob("*.py"):
+        if path.stem == "__init__":
+            continue
+        try:
+            mod = import_module(f"partner_plugins.{path.stem}")
+            for name in getattr(mod, "__all__", []):
+                globals()[name] = getattr(mod, name)
+                __all__.append(name)
+        except Exception:
+            continue

--- a/partner_plugins/__init__.py
+++ b/partner_plugins/__init__.py
@@ -1,0 +1,23 @@
+from importlib import import_module
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+
+__all__ = []
+plugins = {}
+
+for path in PLUGIN_DIR.glob('*.py'):
+    if path.stem == '__init__':
+        continue
+    try:
+        module = import_module(f'partner_plugins.{path.stem}')
+        plugins[path.stem] = module
+        for name in getattr(module, '__all__', []):
+            globals()[name] = getattr(module, name)
+            __all__.append(name)
+    except Exception:
+        continue
+
+def load_plugins():
+    """Return loaded plugin modules."""
+    return plugins

--- a/partner_plugins/assemble_ai_services.py
+++ b/partner_plugins/assemble_ai_services.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from typing import Dict
+
+try:
+    import assemblyai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    assemblyai = None  # type: ignore
+
+
+def transcribe_audio(path: str) -> Dict:
+    """Return transcription for ``path`` using AssemblyAI if available."""
+    if assemblyai is None:
+        return {"text": "", "provider": "fallback"}
+    client = assemblyai.Client()
+    with open(path, "rb") as f:
+        transcript = client.transcribe(f)
+    return {"text": getattr(transcript, "text", ""), "provider": "assemblyai"}
+
+
+__all__ = ["transcribe_audio"]

--- a/partner_plugins/ens_cloak.py
+++ b/partner_plugins/ens_cloak.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+
+CONFIG_PATH = Path('ghostfire_config.json')
+
+
+def toggle_public_display(show: bool) -> None:
+    """Show or hide ENS and wallet identifiers."""
+    cfg = {}
+    if CONFIG_PATH.exists():
+        try:
+            cfg = json.loads(CONFIG_PATH.read_text())
+        except Exception:
+            cfg = {}
+    cfg['hide_ens'] = not show
+    cfg['hide_wallet'] = not show
+    CONFIG_PATH.write_text(json.dumps(cfg, indent=2))
+
+
+__all__ = ["toggle_public_display"]

--- a/partner_plugins/openai_tools.py
+++ b/partner_plugins/openai_tools.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from typing import Dict
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore
+
+
+def summarize_text(text: str) -> Dict:
+    """Return a short summary of ``text`` using OpenAI if available."""
+    if openai is None:
+        return {"summary": text[:100], "provider": "fallback"}
+    resp = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": text}],
+        max_tokens=60,
+    )
+    summary = resp["choices"][0]["message"]["content"]
+    return {"summary": summary, "provider": "openai"}
+
+
+__all__ = ["summarize_text"]

--- a/partner_plugins/worldcoin_biometric.py
+++ b/partner_plugins/worldcoin_biometric.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+from typing import Dict
+
+from engine.worldcoin_layer import sync_orb_identity
+
+
+def verify_worldcoin(user_id: str, world_id: str) -> Dict:
+    """Verify Worldcoin identity via built-in worldcoin_layer."""
+    return sync_orb_identity(user_id, world_id, True)
+
+
+__all__ = ["verify_worldcoin"]


### PR DESCRIPTION
## Summary
- add public `partner_plugins` package with OpenAI, AssemblyAI, Worldcoin and ENS cloak modules
- load partner plugins automatically from `partner_modules`
- provide compatibility shim modules in Python and TypeScript
- document plug‑in usage in README

## Testing
- `python3 python_system_validate.py`
- `npm test`
- `python3 system_integrity_check.py --silent`


------
https://chatgpt.com/codex/tasks/task_e_68829b9c948c83229873baacc20037e0