### PR TITLE
Add attribution layer and royalty logic

### DIFF
--- a/.vaultfire/core/ethics.json
+++ b/.vaultfire/core/ethics.json
@@ -1,0 +1,8 @@
+{
+  "contributor": "Ghostkey-316",
+  "ens": "ghostkey316.eth",
+  "wallet": "bpow20.cb.id",
+  "github": "github.com/Ghostkey316",
+  "attribution_required": true,
+  "default_visibility": "private"
+}

--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ Pass `--save` to persist your choices in `ghostfire_config.json`.
  - Contributor Role: **Spark-tier loyalty / Activation-ready**
 - Created: **June 10, 2025 @ 12:01AM**
 
+### Human Claim Layer
+The `.vaultfire/core/ethics.json` file stores contributor rights and attribution
+rules for Ghostkey-316. By default the dashboard keeps this data private until
+the user enables visibility under **Settings > Protocol Lineage**. Any public
+use of the Ghostkey identity quietly triggers a royalty payout to
+`bpow20.cb.id` via the `GhostkeyAttribution` contract and the Python
+`trigger_royalty()` utility.
+
 ## Wallet Loyalty Tiers
 The protocol tracks how long each wallet avoids major sell-offs. Every week
 without selling 90% or more of the balance unlocks a higher multiplier:

--- a/contracts/GhostkeyAttribution.sol
+++ b/contracts/GhostkeyAttribution.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/**
+ * @title GhostkeyAttribution
+ * @notice Stores permanent contributor metadata and routes royalty shares
+ *         for Ghostkey-316. Future forks must preserve this metadata.
+ */
+contract GhostkeyAttribution {
+    string public constant CONTRIBUTOR = "Ghostkey-316";
+    string public constant ENS = "ghostkey316.eth";
+    string public constant PRIMARY_WALLET = "bpow20.cb.id";
+    string public constant GITHUB = "github.com/Ghostkey316";
+
+    address payable public immutable royaltyRecipient;
+
+    event RoyaltyPaid(address indexed payer, uint256 amount, string token);
+
+    constructor(address payable recipient) {
+        require(recipient != address(0), "recipient zero");
+        royaltyRecipient = recipient;
+    }
+
+    receive() external payable {
+        royaltyRecipient.transfer(msg.value);
+        emit RoyaltyPaid(msg.sender, msg.value, "ETH");
+    }
+
+    function payRoyalty() external payable {
+        require(msg.value > 0, "no value");
+        royaltyRecipient.transfer(msg.value);
+        emit RoyaltyPaid(msg.sender, msg.value, "ETH");
+    }
+}

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -258,6 +258,7 @@ from .worldcoin_layer import (
     wld_bridge,
     run_worldcoin_diagnostics,
 )
+from .royalty_engine import trigger_royalty
 from .connector_resilience_layer import (
     detect_missing_connectors,
     register_endpoint,
@@ -509,5 +510,6 @@ __all__ = [
     "log_fallback_event",
     "set_connector_enabled",
     "connector_enabled",
+    "trigger_royalty",
 ]
 

--- a/engine/royalty_engine.py
+++ b/engine/royalty_engine.py
@@ -1,0 +1,43 @@
+"""Ghostkey attribution and royalty utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .token_ops import send_token
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LOG_PATH = BASE_DIR / "logs" / "royalty_log.json"
+ROYALTY_WALLET = "bpow20.cb.id"
+DEFAULT_AMOUNT = 0.1
+DEFAULT_TOKEN = "ASM"
+
+
+def _load_log() -> list:
+    if LOG_PATH.exists():
+        try:
+            with open(LOG_PATH) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return []
+    return []
+
+
+def _write_log(entries: list) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(LOG_PATH, "w") as f:
+        json.dump(entries, f, indent=2)
+
+
+def trigger_royalty(event: str, amount: float = DEFAULT_AMOUNT, token: str = DEFAULT_TOKEN) -> dict:
+    """Send a royalty payout and record the event."""
+    send_token(ROYALTY_WALLET, amount, token)
+    log = _load_log()
+    entry = {"event": event, "amount": amount, "token": token}
+    log.append(entry)
+    _write_log(log)
+    return entry
+
+
+__all__ = ["trigger_royalty"]

--- a/frontend/pages/settings_lineage.html
+++ b/frontend/pages/settings_lineage.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Protocol Lineage Settings</title>
+  <style>
+    body { font-family: Arial, sans-serif; background: #111; color: #eee; margin: 0; padding: 20px; }
+    h1 { margin-top: 0; }
+    pre { background: #222; padding: 10px; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Protocol Lineage</h1>
+  <label><input type="checkbox" id="toggle"> Public Attribution</label>
+  <pre id="lineage">Loading...</pre>
+  <script src="settings_lineage.js"></script>
+</body>
+</html>

--- a/frontend/pages/settings_lineage.js
+++ b/frontend/pages/settings_lineage.js
@@ -1,0 +1,20 @@
+async function loadLineage() {
+  const res = await fetch('../../.vaultfire/core/ethics.json').catch(() => null);
+  if (!res || !res.ok) return null;
+  try { return await res.json(); } catch { return null; }
+}
+
+function display(data, visible) {
+  const pre = document.getElementById('lineage');
+  if (!data) { pre.textContent = 'Unavailable'; return; }
+  pre.textContent = visible ? JSON.stringify(data, null, 2) : 'Attribution cloaked';
+}
+
+async function init() {
+  const data = await loadLineage();
+  const toggle = document.getElementById('toggle');
+  toggle.addEventListener('change', () => display(data, toggle.checked));
+  display(data, false);
+}
+
+init();


### PR DESCRIPTION
## Summary
- embed Ghostkey contributor metadata in `.vaultfire/core/ethics.json`
- implement `GhostkeyAttribution` contract for future forks
- provide Python `trigger_royalty` helper
- expose royalty util via `engine/__init__`
- add Protocol Lineage settings page
- document Human Claim Layer in README

## Testing
- `npm test`
- `python3 python_system_validate.py`


------
https://chatgpt.com/codex/tasks/task_e_68829c1c17f88322974f0a5ee8f42823