### PR TITLE
Add full system validation runner

### DIFF
--- a/run_full_system_validation.py
+++ b/run_full_system_validation.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Aggregate Vaultfire validation runner."""
+from __future__ import annotations
+
+import importlib
+import json
+from datetime import datetime
+from typing import Any, Dict
+
+from python_system_validate import gather_python_files, build_graph, detect_cycles
+from system_integrity_check import run_integrity_check, ALIGNMENT_PHRASE
+from engine.worldcoin_layer import run_worldcoin_diagnostics
+from simulate_partner_activation import activation_hook
+
+try:
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    psutil = None  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+def python_validation() -> Dict[str, Any]:
+    files = gather_python_files()
+    graph, syntax_errors, suspicious = build_graph(files)
+    cycles = detect_cycles(graph)
+    issues = syntax_errors or suspicious or cycles
+    return {
+        "modules_checked": len(files),
+        "syntax_errors": syntax_errors,
+        "suspicious_ops": suspicious,
+        "cycles": cycles,
+        "status": "PASS" if not issues else "FAIL",
+    }
+
+
+def plugin_check(name: str) -> str:
+    try:
+        importlib.import_module(name)
+        return "available"
+    except Exception as e:  # pragma: no cover - environment variance
+        return f"error: {e}"
+
+
+def performance_metrics() -> Dict[str, Any]:
+    if psutil is None:
+        return {}
+    return {
+        "cpu": psutil.cpu_percent(interval=0.1),
+        "memory": psutil.virtual_memory().percent,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main routine
+# ---------------------------------------------------------------------------
+
+def run_checks() -> Dict[str, Any]:
+    python_report = python_validation()
+    integrity = run_integrity_check()
+    privacy = run_worldcoin_diagnostics()
+    plugins = {
+        "openai_tools": plugin_check("partner_plugins.openai_tools"),
+        "assemble_ai_services": plugin_check("partner_plugins.assemble_ai_services"),
+        "worldcoin_biometric": plugin_check("partner_plugins.worldcoin_biometric"),
+        "ens_cloak": plugin_check("partner_plugins.ens_cloak"),
+    }
+    activation = activation_hook(
+        "diag_test",
+        ["ghostkey316.eth"],
+        ALIGNMENT_PHRASE,
+        silent=True,
+        test_mode=True,
+    )
+    result = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "python": python_report,
+        "integrity": integrity,
+        "privacy": privacy,
+        "plugins": plugins,
+        "activation": activation["status"],
+        "performance": performance_metrics(),
+    }
+    ok = (
+        python_report["status"] == "PASS"
+        and not any(integrity.values())
+        and not privacy.get("issues")
+        and activation["status"] == "PASS"
+    )
+    result["status"] = "PASS" if ok else "FAIL"
+    return result
+
+
+def main() -> int:
+    report = run_checks()
+    print(json.dumps(report, indent=2))
+    if report["status"] == "PASS":
+        print("Vaultfire is Activation Ready")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `run_full_system_validation.py` that aggregates python checks, integrity validation, plugin availability, privacy diagnostics, and activation simulation

## Testing
- `npm test`
- `python3 python_system_validate.py`
- `python3 system_integrity_check.py --silent`
- `python3 run_full_system_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_6882c53c8bf48322a79cb688d719bdef