### PR TITLE
Add SparkStarter initiation layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Vaultfire Init represents the first development signal from **Ghostkey-316** (Br
 - `engine/gamified_yield_layer.py` – tracks quest streaks and converts XP into vault points.
 - `engine/vaultlink.py` – modular AI companion that evolves with each user.
 - `engine/wellness_companion.py` – journaling and mood tracking with coping suggestions tied to the companion.
+- `engine/sparkstarter_layer.py` – proactive AI-ping module integrating the SparkStarter Initiation Layer.
 - `engine/fit_sync.py` – logs workouts and team challenges with Proof of Sweat.
 - `engine/music_layer.py` – builds music identity profiles and AI‑curated playlists.
 - `engine/life_xp_module.py` – rewards growth activities and syncs with Vaultlink.

--- a/docs/sparkstarter_layer.md
+++ b/docs/sparkstarter_layer.md
@@ -1,0 +1,22 @@
+# SparkStarter Initiation Layer
+
+This module extends the Vaultlink companion with a proactive AI‑ping behavior layer. Messages are generated during key engagement windows and can provide reminders, motivational stats or quick fact drops from protocol memory.
+
+## Modes
+- **Silent Mode** – AI listens only.
+- **Check-In Mode** – minimal interaction.
+- **Companion Mode** – full active support.
+
+Pings mirror the user's tone and timing preferences and pull in context from the loyalty engine, belief score and milestone logs.
+
+## Usage
+```python
+from engine.sparkstarter_layer import set_mode, set_preferences, next_ping
+set_mode("alice", "companion")
+set_preferences("alice", "friendly", 2)
+entry = next_ping("alice", "Keep moving forward!", "secret-key")
+```
+
+## Disclaimers
+- SparkStarter is not a medical or therapeutic system.
+- Ping data is stored locally and may be cleared at any time.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -129,6 +129,7 @@ from .wellness_companion import (
     reflection_prompt,
     coping_suggestions,
 )
+from .sparkstarter_layer import set_mode, set_preferences, next_ping
 from .music_layer import (
     connect_service,
     pull_top_tracks,
@@ -394,6 +395,9 @@ __all__ = [
     "coping_suggestions",
     "reward_engagement",
     "reward_microtask",
+    "set_mode",
+    "set_preferences",
+    "next_ping",
     "reward_idea",
     "reward_layer_build",
     "record_life_action",

--- a/engine/sparkstarter_layer.py
+++ b/engine/sparkstarter_layer.py
@@ -1,0 +1,104 @@
+"""SparkStarter Initiation Layer for Vaultfire."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, Optional
+
+from .vaultlink import record_interaction
+from .loyalty_engine import loyalty_score
+from .ethical_growth_engine import belief_score
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+PREF_PATH = BASE_DIR / "logs" / "sparkstarter_prefs.json"
+PING_LOG_PATH = BASE_DIR / "logs" / "sparkstarter_log.json"
+
+MODES = {"silent", "check-in", "companion"}
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def set_mode(user_id: str, mode: str) -> None:
+    """Set engagement ``mode`` for ``user_id``."""
+    if mode not in MODES:
+        raise ValueError("invalid mode")
+    prefs = _load_json(PREF_PATH, {})
+    info = prefs.get(user_id, {})
+    info["mode"] = mode
+    prefs[user_id] = info
+    _write_json(PREF_PATH, prefs)
+
+
+def set_preferences(user_id: str, tone: str, window_hours: int = 4) -> None:
+    """Store tone and ping window for ``user_id``."""
+    prefs = _load_json(PREF_PATH, {})
+    info = prefs.get(user_id, {})
+    info["tone"] = tone
+    info["window"] = int(window_hours)
+    prefs[user_id] = info
+    _write_json(PREF_PATH, prefs)
+
+
+def _should_ping(last: Optional[str], window: int) -> bool:
+    if not last:
+        return True
+    try:
+        prev = datetime.strptime(last, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return True
+    return datetime.utcnow() - prev >= timedelta(hours=window)
+
+
+def next_ping(user_id: str, message: str, key: str) -> Optional[Dict]:
+    """Record a ping if allowed and return the log entry."""
+    prefs = _load_json(PREF_PATH, {})
+    info = prefs.get(user_id, {})
+    mode = info.get("mode", "check-in")
+    if mode == "silent":
+        return None
+    window = int(info.get("window", 4))
+    last = info.get("last_ping")
+    if not _should_ping(last, window):
+        return None
+
+    loyalty = loyalty_score(user_id)
+    belief = belief_score(user_id)
+    tone = info.get("tone", "neutral")
+    record_interaction(user_id, message, "spark", 0.5, False, key)
+
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "user_id": user_id,
+        "mode": mode,
+        "tone": tone,
+        "loyalty": loyalty.get("tier"),
+        "belief": belief,
+        "message": message,
+    }
+    log = _load_json(PING_LOG_PATH, [])
+    log.append(entry)
+    _write_json(PING_LOG_PATH, log)
+
+    info["last_ping"] = entry["timestamp"]
+    prefs[user_id] = info
+    _write_json(PREF_PATH, prefs)
+    return entry
+
+
+__all__ = ["set_mode", "set_preferences", "next_ping", "MODES"]


### PR DESCRIPTION
## Summary
- integrate SparkStarter as a modular AI-ping layer
- export sparkstarter functions from `engine.__init__`
- document SparkStarter module
- mention SparkStarter in README

## Testing
- `npm test`
- `python3 python_system_validate.py`


------
https://chatgpt.com/codex/tasks/task_e_6882c825bcd883228de004a01bbff084