### PR TITLE
Add Retail Revival Mode feature layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ The Partner Port layer for third-party games is documented in `docs/partner_port
 Optional modules expand partner capabilities while respecting privacy and ethics. See `docs/partner_addons_v1.1.md` for details.
 
 Additional production-ready features are outlined in `docs/codex_overdrive_v2.md`.
+Retail experiences can enable `docs/retail_revival_mode.md` for offline-friendly storytelling and loyalty syncing.
 Run `vaultfire_codex_overdrive_activate_all` to initialize the Overdrive
 modules with wallet `bpow20.cb.id` and ENS `ghostkey316.eth`.
 

--- a/changelog.json
+++ b/changelog.json
@@ -13,10 +13,15 @@
     "timestamp": "2025-07-24T15:22:22Z",
     "change": "Partner Modules v1.0",
     "update_block": "PENDING_PUSH"
-  }
-  ,{
+  },
+  {
     "timestamp": "2025-07-24T15:22:23Z",
     "change": "SparkStarter v1.5 Companion Class upgrade",
+    "update_block": "PENDING_PUSH"
+  },
+  {
+    "timestamp": "2025-07-25T02:16:21Z",
+    "change": "vaultfire_module_retail_revival_v1",
     "update_block": "PENDING_PUSH"
   }
 ]

--- a/docs/retail_revival_mode.md
+++ b/docs/retail_revival_mode.md
@@ -1,0 +1,18 @@
+# Retail Revival Mode
+
+`vaultfire_module_retail_revival_v1` introduces an optional layer for hybrid and physical retail experiences. It is disabled by default and can be toggled per partner using `final_modules.retail_revival_mode.set_retail_revival_enabled`.
+
+## Features
+- Offline-friendly prompts returned by `offline_prompt` for analog displays.
+- AI-guided storytelling via `retail_story_snippet(theme, context)`.
+- Loyalty syncing and memory updates when `record_visit` logs a physical check-in.
+- Configurable nostalgia overlays such as `nostalgia_overlay('mall_90s')`.
+- Safe by design – if the mode is disabled, calls fallback without altering core data.
+
+Logs are stored in `final_modules/retail_revival_visits.json` and `final_modules/retail_revival_config.json`.
+
+## Disclaimers
+- Hardware integrations are not included.
+- Loyalty calculations are simulated with local logs.
+- This module does not provide financial or legal advice.
+

--- a/final_modules/__init__.py
+++ b/final_modules/__init__.py
@@ -5,6 +5,15 @@ from .brandkit_portal import generate_brandkit, register_partner_link
 from .smart_contract_audit import audit_contracts
 from .failsafe_recovery import request_recovery, privacy_wipe
 from .alignment_badge import issue_badge
+from .retail_revival_mode import (
+    set_retail_revival_enabled,
+    retail_revival_enabled,
+    offline_prompt,
+    nostalgia_overlay,
+    retail_story_snippet,
+    record_visit,
+    visit_history,
+)
 
 __all__ = [
     "companion_app",
@@ -14,4 +23,11 @@ __all__ = [
     "request_recovery",
     "privacy_wipe",
     "issue_badge",
+    "set_retail_revival_enabled",
+    "retail_revival_enabled",
+    "offline_prompt",
+    "nostalgia_overlay",
+    "retail_story_snippet",
+    "record_visit",
+    "visit_history",
 ]

--- a/final_modules/retail_revival_mode.py
+++ b/final_modules/retail_revival_mode.py
@@ -1,0 +1,101 @@
+"""Retail Revival Mode optional feature layer."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from engine.loyalty_engine import update_loyalty_ranks
+from engine.purpose_engine import moral_memory_mirror
+
+BASE_DIR = Path(__file__).resolve().parent
+CFG_PATH = BASE_DIR / "retail_revival_config.json"
+VISITS_PATH = BASE_DIR / "retail_revival_visits.json"
+
+NOSTALGIA_THEMES = {
+    "mall_90s": {"overlay": "🛍️ Neon lights and food court jams"},
+    "game_shop": {"overlay": "🎮 Cartridge cabinets and pixel art banners"},
+}
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def set_retail_revival_enabled(partner_id: str, enabled: bool) -> None:
+    """Toggle Retail Revival Mode for ``partner_id``."""
+    cfg = _load_json(CFG_PATH, {})
+    cfg[partner_id] = bool(enabled)
+    _write_json(CFG_PATH, cfg)
+
+
+def retail_revival_enabled(partner_id: str) -> bool:
+    """Return True if Retail Revival Mode is active for ``partner_id``."""
+    cfg = _load_json(CFG_PATH, {})
+    return cfg.get(partner_id, False)
+
+
+def offline_prompt(message: str) -> str:
+    """Return a minimal text block for analog-style displays."""
+    border = "-" * 32
+    return f"\n{border}\n{message}\n{border}\n"
+
+
+def nostalgia_overlay(theme: str) -> dict:
+    """Return theme overlay details."""
+    return NOSTALGIA_THEMES.get(theme, {})
+
+
+def retail_story_snippet(theme: str, context: str) -> str:
+    """Generate a short narrative snippet for retail staff."""
+    overlay = nostalgia_overlay(theme).get("overlay", "")
+    return f"{overlay} {context}".strip()
+
+
+def record_visit(user_id: str, partner_id: str, theme: str | None = None) -> dict:
+    """Record a physical visit and sync loyalty and memory."""
+    if not retail_revival_enabled(partner_id):
+        return {"message": "retail revival inactive"}
+    visits = _load_json(VISITS_PATH, {})
+    history = visits.get(user_id, [])
+    entry = {
+        "partner": partner_id,
+        "theme": theme or "default",
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    history.append(entry)
+    visits[user_id] = history
+    _write_json(VISITS_PATH, visits)
+    moral_memory_mirror(user_id)
+    update_loyalty_ranks()
+    return entry
+
+
+def visit_history(user_id: str) -> list:
+    """Return logged visit history."""
+    visits = _load_json(VISITS_PATH, {})
+    return visits.get(user_id, [])
+
+
+__all__ = [
+    "set_retail_revival_enabled",
+    "retail_revival_enabled",
+    "offline_prompt",
+    "nostalgia_overlay",
+    "retail_story_snippet",
+    "record_visit",
+    "visit_history",
+]
+


### PR DESCRIPTION
## Summary
- implement `retail_revival_mode` module as optional layer
- expose new functions from `final_modules`
- document Retail Revival Mode usage
- reference doc from README
- log feature in `changelog.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882e831854083229a71b508037265a9