### PR TITLE
Add Ghostkey AI Trader plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,17 @@ print(summarize_text("Welcome to Vaultfire")['summary'])
 toggle_public_display(False)  # hide ENS and wallet by default
 ```
 
+`Ghostkey AI Trader v1.0` is available as a sandboxed partner plug-in. It only
+activates after an explicit opt-in and logs every trade for review. Example:
+
+```python
+from partner_plugins import GhostkeyAITrader
+
+trader = GhostkeyAITrader(lambda w: w == "mywallet")
+trader.activate()
+result = trader.execute_trade("mywallet", {"pair": "ETH/USD", "amount": 1})
+```
+
 ## Security Monitor
 Run `python3 security_monitor.py --set-baseline` once to record baseline file hashes.
 Future runs will detect changes and restore originals if needed using `--repair`.

--- a/__tests__/ghostkey_ai_trader.test.js
+++ b/__tests__/ghostkey_ai_trader.test.js
@@ -1,0 +1,6 @@
+const { execFileSync } = require('child_process');
+
+test('ghostkey_ai_trader python tests', () => {
+  const output = execFileSync('python3', ['-m', 'unittest', 'partner_plugins.tests.test_ghostkey_ai_trader'], { encoding: 'utf8' });
+  expect(output.trim()).toMatch(/OK/);
+});

--- a/partner_plugins/ghostkey_ai_trader.py
+++ b/partner_plugins/ghostkey_ai_trader.py
@@ -1,0 +1,91 @@
+"""Ghostkey AI Trader v1.0 plugin.
+
+This module provides a sandboxed trading assistant for the Vaultfire protocol. It
+operates only when explicitly activated by the user and respects the Ghostkey
+Ethics Framework. All activity is recorded in an audit log. The assistant makes
+no profit guarantees and does not constitute financial advice.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+AUDIT_LOG = Path(__file__).resolve().parent.parent / "vaultfire-core" / "ethics" / "ai_trader_audit.json"
+
+
+@dataclass
+class GhostkeyAITrader:
+    """Modular trading assistant sandboxed from core logic."""
+
+    verify_wallet: Callable[[str], bool]
+    opt_in: bool = False
+    paused: bool = False
+    risk_daily: Optional[float] = None
+    risk_weekly: Optional[float] = None
+    audit: List[Dict] = field(default_factory=list)
+    auto_trade: bool = False
+    strategy: Optional[Dict] = None
+
+    def activate(self, confirm: bool = True) -> None:
+        """Opt in to enable trading features."""
+        if confirm:
+            self.opt_in = True
+
+    def pause(self) -> None:
+        """Pause all automated trading."""
+        self.paused = True
+
+    def resume(self) -> None:
+        self.paused = False
+
+    def set_risk_caps(self, daily: Optional[float] = None, weekly: Optional[float] = None) -> None:
+        self.risk_daily = daily
+        self.risk_weekly = weekly
+
+    def deploy_strategy(self, name: str, params: Dict) -> None:
+        """Store user-approved strategy parameters."""
+        self.strategy = {"name": name, "params": params}
+
+    def toggle_auto_trade(self, enabled: bool) -> None:
+        self.auto_trade = enabled
+
+    def analyze_market(self, prices: List[float]) -> Dict:
+        """Return a basic market trend analysis."""
+        if not prices:
+            return {"trend": "neutral"}
+        direction = "up" if prices[-1] > prices[0] else "down"
+        return {"trend": direction, "samples": len(prices)}
+
+    def detect_signals(self, market_data: Dict) -> List[str]:
+        """Placeholder signal detector."""
+        return ["buy"] if market_data.get("trend") == "up" else ["sell"]
+
+    def _write_audit(self) -> None:
+        AUDIT_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with open(AUDIT_LOG, "w") as f:
+            json.dump(self.audit, f, indent=2)
+
+    def execute_trade(self, wallet: str, trade: Dict) -> Dict:
+        """Record trade if wallet verified and trader active."""
+        if not self.opt_in or self.paused:
+            raise RuntimeError("Trader not active")
+        if not self.verify_wallet(wallet):
+            raise RuntimeError("Unverified wallet")
+        record = {
+            "wallet": wallet,
+            "trade": trade,
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+        }
+        self.audit.append(record)
+        self._write_audit()
+        return record
+
+    def get_audit_log(self) -> List[Dict]:
+        return list(self.audit)
+
+
+__all__ = ["GhostkeyAITrader"]

--- a/partner_plugins/tests/test_ghostkey_ai_trader.py
+++ b/partner_plugins/tests/test_ghostkey_ai_trader.py
@@ -1,0 +1,20 @@
+import unittest
+from partner_plugins.ghostkey_ai_trader import GhostkeyAITrader
+
+def verify(wallet: str) -> bool:
+    return wallet == "verified_wallet"
+
+class TraderTest(unittest.TestCase):
+    def test_trade_requires_opt_in_and_verified_wallet(self):
+        trader = GhostkeyAITrader(verify)
+        with self.assertRaises(RuntimeError):
+            trader.execute_trade("verified_wallet", {"pair": "BTC/USD", "amount": 1})
+        trader.activate()
+        with self.assertRaises(RuntimeError):
+            trader.execute_trade("bad_wallet", {"pair": "BTC/USD", "amount": 1})
+        result = trader.execute_trade("verified_wallet", {"pair": "BTC/USD", "amount": 1})
+        self.assertEqual(result["wallet"], "verified_wallet")
+        self.assertEqual(len(trader.get_audit_log()), 1)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create Ghostkey AI Trader partner plugin
- add python tests and jest wrapper
- document plugin usage in README

## Testing
- `npm test`
- `python3 -m unittest partner_plugins.tests.test_ghostkey_ai_trader`

------
https://chatgpt.com/codex/tasks/task_e_6882f24edcac8322b87fc0fbf390dc8c