### PR TITLE
Add ghostkey trader notification engine

### DIFF
--- a/__tests__/ghostkey_trader_notifications.test.js
+++ b/__tests__/ghostkey_trader_notifications.test.js
@@ -1,0 +1,6 @@
+const { execFileSync } = require('child_process');
+
+test('ghostkey_trader_notifications python tests', () => {
+  const output = execFileSync('python3', ['-m', 'unittest', 'partner_plugins.tests.test_ghostkey_trader_notifications'], { encoding: 'utf8' });
+  expect(output.trim()).toMatch(/OK/);
+});

--- a/ghostkey_trader_notifications.py
+++ b/ghostkey_trader_notifications.py
@@ -1,0 +1,97 @@
+"""Opt-in notification engine for Ghostkey AI Trader.
+
+This module listens for trader events via ``vaultfire_core.protocol_notify``.
+Notifications are filtered based on ``vaultfire_user_settings.json`` and can be
+sent to different channels: terminal log, email log, or mobile webhook.
+All alerts include the Ghostkey ID and use a belief-based message format.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+BASE_DIR = Path(__file__).resolve().parent
+SETTINGS_PATH = Path(
+    os.environ.get("VF_USER_SETTINGS_PATH", str(BASE_DIR / "vaultfire_user_settings.json"))
+)
+LOG_PATH = BASE_DIR / "logs" / "trader_notify_log.json"
+EMAIL_LOG_PATH = BASE_DIR / "logs" / "trader_email_log.json"
+DEFAULT_SETTINGS = {
+    "notify_trader_activity": False,
+    "notification_channel": "log_to_terminal",
+    "webhook_url": "http://localhost:8060/notify",
+}
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _format_message(event: str, payload: Dict) -> str:
+    base = f"Ghostkey-316 {event.replace('_', ' ')}"
+    detail = payload.get("symbol") or payload.get("signals") or payload.get("error")
+    if detail:
+        return f"{base}: {detail}"
+    return base
+
+
+def _send_email(message: str) -> None:
+    log = _load_json(EMAIL_LOG_PATH, [])
+    log.append({"timestamp": datetime.utcnow().isoformat() + "Z", "message": message})
+    _write_json(EMAIL_LOG_PATH, log)
+
+
+def _send_webhook(url: str, payload: Dict) -> None:
+    if not url:
+        return
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    try:
+        urllib.request.urlopen(req, timeout=2)
+    except Exception:
+        pass
+
+
+def notify_event(event: str, payload: Dict) -> Dict:
+    settings = _load_json(SETTINGS_PATH, DEFAULT_SETTINGS)
+    if not settings.get("notify_trader_activity"):
+        return {"sent": False}
+    channel = settings.get("notification_channel", "log_to_terminal")
+    message = _format_message(event, payload)
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "event": event,
+        "payload": payload,
+        "channel": channel,
+        "message": message,
+        "id": "Ghostkey-316",
+    }
+    if channel == "log_to_terminal":
+        print(message)
+    elif channel == "email":
+        _send_email(message)
+    elif channel == "mobile_webhook":
+        _send_webhook(settings.get("webhook_url", ""), entry)
+    log = _load_json(LOG_PATH, [])
+    log.append(entry)
+    _write_json(LOG_PATH, log)
+    return entry
+
+
+__all__ = ["notify_event"]

--- a/partner_plugins/ghostkey_ai_trader.py
+++ b/partner_plugins/ghostkey_ai_trader.py
@@ -62,7 +62,14 @@ class GhostkeyAITrader:
 
     def detect_signals(self, market_data: Dict) -> List[str]:
         """Placeholder signal detector."""
-        return ["buy"] if market_data.get("trend") == "up" else ["sell"]
+        signals = ["buy"] if market_data.get("trend") == "up" else ["sell"]
+        try:  # optional core integration
+            import vaultfire_core
+            if hasattr(vaultfire_core, "protocol_notify"):
+                vaultfire_core.protocol_notify("trade_signal", {"signals": signals})
+        except Exception:
+            pass
+        return signals
 
     def _write_audit(self) -> None:
         AUDIT_LOG.parent.mkdir(parents=True, exist_ok=True)
@@ -71,18 +78,33 @@ class GhostkeyAITrader:
 
     def execute_trade(self, wallet: str, trade: Dict) -> Dict:
         """Record trade if wallet verified and trader active."""
-        if not self.opt_in or self.paused:
-            raise RuntimeError("Trader not active")
-        if not self.verify_wallet(wallet):
-            raise RuntimeError("Unverified wallet")
-        record = {
-            "wallet": wallet,
-            "trade": trade,
-            "timestamp": datetime.utcnow().isoformat() + "Z",
-        }
-        self.audit.append(record)
-        self._write_audit()
-        return record
+        try:
+            if not self.opt_in or self.paused:
+                raise RuntimeError("Trader not active")
+            if not self.verify_wallet(wallet):
+                raise RuntimeError("Unverified wallet")
+            record = {
+                "wallet": wallet,
+                "trade": trade,
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+            }
+            self.audit.append(record)
+            self._write_audit()
+            try:
+                import vaultfire_core
+                if hasattr(vaultfire_core, "protocol_notify"):
+                    vaultfire_core.protocol_notify("trade_executed", record)
+            except Exception:
+                pass
+            return record
+        except Exception as e:
+            try:
+                import vaultfire_core
+                if hasattr(vaultfire_core, "protocol_notify"):
+                    vaultfire_core.protocol_notify("error", {"error": str(e)})
+            except Exception:
+                pass
+            raise
 
     def get_audit_log(self) -> List[Dict]:
         return list(self.audit)

--- a/partner_plugins/tests/test_ghostkey_trader_notifications.py
+++ b/partner_plugins/tests/test_ghostkey_trader_notifications.py
@@ -1,0 +1,51 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import ghostkey_trader_notifications as gtn
+
+class NotifyTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.settings = Path(self.tmp.name) / "user.json"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write_settings(self, data):
+        self.settings.write_text(json.dumps(data))
+
+    def test_trade_triggers_log(self):
+        self.write_settings({"notify_trader_activity": True, "notification_channel": "log_to_terminal"})
+        with patch.dict(os.environ, {"VF_USER_SETTINGS_PATH": str(self.settings)}):
+            with patch("builtins.print") as mock_print:
+                gtn.notify_event("trade_executed", {"symbol": "ASM"})
+                self.assertTrue(mock_print.called)
+
+    def test_opt_out_sends_nothing(self):
+        self.write_settings({"notify_trader_activity": False})
+        with patch.dict(os.environ, {"VF_USER_SETTINGS_PATH": str(self.settings)}):
+            with patch("builtins.print") as mock_print:
+                gtn.notify_event("trade_executed", {"symbol": "ASM"})
+                self.assertFalse(mock_print.called)
+
+    def test_mobile_webhook_payload(self):
+        self.write_settings({
+            "notify_trader_activity": True,
+            "notification_channel": "mobile_webhook",
+            "webhook_url": "http://localhost/test",
+        })
+        with patch.dict(os.environ, {"VF_USER_SETTINGS_PATH": str(self.settings)}):
+            with patch("urllib.request.urlopen") as mock_open:
+                gtn.notify_event("trade_executed", {"symbol": "ASM"})
+                self.assertTrue(mock_open.called)
+                req = mock_open.call_args[0][0]
+                payload = json.loads(req.data.decode())
+                self.assertEqual(req.full_url, "http://localhost/test")
+                self.assertEqual(payload["id"], "Ghostkey-316")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vaultfire_core.py
+++ b/vaultfire_core.py
@@ -1,0 +1,44 @@
+"""Vaultfire Core utilities."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from engine.proof_of_loyalty import record_belief_action
+
+PURPOSE_MAP_PATH = Path('purpose_map.json')
+
+
+def sync_purpose(domain: str, trait: str, role: str) -> dict:
+    record = {
+        'domain': domain,
+        'trait': trait,
+        'role': role,
+        'timestamp': datetime.utcnow().isoformat()
+    }
+    try:
+        data = json.loads(PURPOSE_MAP_PATH.read_text())
+    except Exception:
+        data = {'records': []}
+    data.setdefault('records', []).append(record)
+    PURPOSE_MAP_PATH.write_text(json.dumps(data, indent=2))
+    return record
+
+
+def cli_belief(identity: str, wallet: str, text: str) -> dict:
+    result = record_belief_action(identity, wallet, text)
+    sync_purpose('cli', 'belief', 'record')
+    return result
+
+
+def protocol_notify(event: str, payload: dict) -> None:
+    """Proxy event notifications to the Ghostkey trader channel."""
+    try:
+        from ghostkey_trader_notifications import notify_event
+    except Exception:
+        return
+    try:
+        notify_event(event, payload)
+    except Exception:
+        pass

--- a/vaultfire_user_settings.json
+++ b/vaultfire_user_settings.json
@@ -1,0 +1,5 @@
+{
+  "notify_trader_activity": true,
+  "notification_channel": "log_to_terminal",
+  "webhook_url": "http://localhost:8060/notify"
+}


### PR DESCRIPTION
## Summary
- create `vaultfire_core.protocol_notify` to route notifications
- add `ghostkey_trader_notifications` module with opt-in settings
- integrate notifications with `GhostkeyAITrader`
- define default user settings
- provide unit tests for notification logic and JS wrapper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882f40e96f08322a5a7fc3af45befba