### PR TITLE
Add protocol snapshot utility

### DIFF
--- a/codex_manifest.py
+++ b/codex_manifest.py
@@ -1,0 +1,43 @@
+"""Codex manifest snapshot utility."""
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+from typing import Any, Dict, List
+
+BASE_DIR = Path(__file__).resolve().parent
+SNAPSHOT_PATH = BASE_DIR / "dashboards" / "protocol_snapshot.json"
+
+
+def snapshot_protocol(
+    version: str,
+    description: str,
+    modules: List[str],
+    test_status: Dict[str, Any],
+    forks_enabled: bool,
+    partner_mode: bool,
+    ghostkey_id: str,
+    wallet: str,
+    timestamp: str,
+) -> Dict[str, Any]:
+    """Write a protocol snapshot and return the data."""
+    snapshot = {
+        "version": version,
+        "description": description,
+        "modules": modules,
+        "test_status": test_status,
+        "forks_enabled": forks_enabled,
+        "partner_mode": partner_mode,
+        "ghostkey_id": ghostkey_id,
+        "wallet": wallet,
+        "timestamp": timestamp,
+    }
+    checksum_src = json.dumps(snapshot, sort_keys=True).encode()
+    snapshot["checksum"] = hashlib.sha256(checksum_src).hexdigest()
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(SNAPSHOT_PATH, "w") as f:
+        json.dump(snapshot, f, indent=2)
+    return snapshot
+
+__all__ = ["snapshot_protocol"]

--- a/dashboards/protocol_snapshot.json
+++ b/dashboards/protocol_snapshot.json
@@ -1,0 +1,23 @@
+{
+  "version": "vaultfire_v1.0.3",
+  "description": "Stable build with MirrorForge 3D output, belief_fork_customizer, and partner-level iframe/lock controls.",
+  "modules": [
+    "vaultfire_core",
+    "ns3_bridge_sync",
+    "ghostkey_ai_trader",
+    "mirrorforge",
+    "belief_fork_customizer",
+    "partner_plugins",
+    "web_mirror_viewer"
+  ],
+  "test_status": {
+    "python": "\u2705 all unit tests passed",
+    "js": "\ud83d\udfe1 fallback sim used (jest not installed)"
+  },
+  "forks_enabled": true,
+  "partner_mode": true,
+  "ghostkey_id": "ghostkey316.eth",
+  "wallet": "bpow20.cb.id",
+  "timestamp": "2025-07-25T13:01:00-04:00",
+  "checksum": "d11fcabf72d2eea2e77b6efb19a0990623edb377f5528c429d9024652f5eef28"
+}

--- a/snapshot_vaultfire_protocol.py
+++ b/snapshot_vaultfire_protocol.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from codex_manifest import snapshot_protocol
+
+if __name__ == "__main__":
+    snapshot_protocol(
+        version="vaultfire_v1.0.3",
+        description="Stable build with MirrorForge 3D output, belief_fork_customizer, and partner-level iframe/lock controls.",
+        modules=[
+            "vaultfire_core",
+            "ns3_bridge_sync",
+            "ghostkey_ai_trader",
+            "mirrorforge",
+            "belief_fork_customizer",
+            "partner_plugins",
+            "web_mirror_viewer",
+        ],
+        test_status={
+            "python": "✅ all unit tests passed",
+            "js": "🟡 fallback sim used (jest not installed)",
+        },
+        forks_enabled=True,
+        partner_mode=True,
+        ghostkey_id="ghostkey316.eth",
+        wallet="bpow20.cb.id",
+        timestamp="2025-07-25T13:01:00-04:00",
+    )


### PR DESCRIPTION
## Summary
- add `codex_manifest.py` module with `snapshot_protocol`
- create script `snapshot_vaultfire_protocol.py` that records Vaultfire protocol state
- store resulting data in `dashboards/protocol_snapshot.json`

## Testing
- `npm test`
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688310009cdc8322a17b8c55ff275b03