### PR TITLE
Add Vaultfire Media CLI module

### DIFF
--- a/__tests__/vaultfire_media.test.js
+++ b/__tests__/vaultfire_media.test.js
@@ -1,0 +1,6 @@
+const { execFileSync } = require('child_process');
+
+test('vaultfire_media python tests', () => {
+  const output = execFileSync('python3', ['final_modules/tests/test_vaultfire_media.py'], { encoding: 'utf8' });
+  expect(output.trim()).toMatch(/OK/);
+});

--- a/final_modules/__init__.py
+++ b/final_modules/__init__.py
@@ -14,6 +14,13 @@ from .retail_revival_mode import (
     record_visit,
     visit_history,
 )
+from .vaultfire_media import (
+    generate_image,
+    transcribe_audio,
+    voice_response,
+    analyze_video,
+    build_avatar,
+)
 
 __all__ = [
     "companion_app",
@@ -30,4 +37,9 @@ __all__ = [
     "retail_story_snippet",
     "record_visit",
     "visit_history",
+    "generate_image",
+    "transcribe_audio",
+    "voice_response",
+    "analyze_video",
+    "build_avatar",
 ]

--- a/final_modules/tests/test_vaultfire_media.py
+++ b/final_modules/tests/test_vaultfire_media.py
@@ -1,0 +1,36 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import importlib.util
+import sys
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "vaultfire_media.py"
+spec = importlib.util.spec_from_file_location("vaultfire_media", MODULE_PATH)
+vm = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(vm)
+
+
+class VaultfireMediaTest(unittest.TestCase):
+    def test_generate_image_writes_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            result = vm.generate_image("test", "user.eth", out_dir=tmp_path)
+            img = tmp_path / f"{result['output_id']}.png"
+            meta = tmp_path / f"{result['output_id']}.json"
+            self.assertTrue(meta.exists())
+            # image file only written if Pillow available
+            if img.exists():
+                self.assertTrue(img.is_file())
+            data = json.loads(meta.read_text())
+            self.assertEqual(data["wallet"], "user.eth")
+
+    def test_build_avatar_returns_id(self):
+        result = vm.build_avatar("user.eth")
+        self.assertIn("avatar_id", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/final_modules/vaultfire_media.py
+++ b/final_modules/vaultfire_media.py
@@ -1,0 +1,85 @@
+"""Vaultfire Media v1.0 - simplified placeholder module."""
+from __future__ import annotations
+
+import json
+import random
+import string
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+try:
+    from PIL import Image, ImageDraw  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Image = None  # type: ignore
+    ImageDraw = None  # type: ignore
+
+BASE_DIR = Path(__file__).resolve().parent
+DEFAULT_MEDIA_DIR = BASE_DIR / "media_cache"
+DEFAULT_MEDIA_DIR.mkdir(exist_ok=True)
+
+
+def _random_id(prefix: str) -> str:
+    rand = ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
+    return f"{prefix}{rand}"
+
+
+def generate_image(prompt: str, wallet: str, out_dir: Path | None = None) -> Dict[str, Any]:
+    """Generate a placeholder image and return metadata."""
+    out_dir = out_dir or DEFAULT_MEDIA_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    output_id = _random_id("vaultfire_media_")
+    path = out_dir / f"{output_id}.png"
+    if Image is not None:
+        img = Image.new("RGB", (1024, 1024), color=(73, 109, 137))
+        draw = ImageDraw.Draw(img)
+        draw.text((10, 10), prompt, fill=(255, 255, 0))
+        img.save(path)
+    metadata = {
+        "wallet": wallet,
+        "type": "imagegen",
+        "input": prompt,
+        "output_id": output_id,
+        "render_time": "0s",
+        "tags": ["ghost-tier"],
+        "loyalty_linked": True,
+        "ns3_behavior_id": "default",
+        "verified_by": "vaultfire_core",
+    }
+    with open(out_dir / f"{output_id}.json", "w") as f:
+        json.dump(metadata, f, indent=2)
+    return metadata
+
+
+def transcribe_audio(_: str) -> str:
+    """Return fake transcription for the demo."""
+    return "transcribed speech"
+
+
+def voice_response(text: str) -> str:
+    """Return a simple text response."""
+    return f"Voice response to: {text}"
+
+
+def analyze_video(_: str) -> Dict[str, Any]:
+    """Return a dummy video analysis result."""
+    return {
+        "summary": "video summary",
+        "sentiment": "neutral",
+        "loyalty_bonus": False,
+    }
+
+
+def build_avatar(wallet: str) -> Dict[str, Any]:
+    """Return placeholder avatar details."""
+    avatar_id = _random_id("avatar_")
+    return {"wallet": wallet, "avatar_id": avatar_id}
+
+
+__all__ = [
+    "generate_image",
+    "transcribe_audio",
+    "voice_response",
+    "analyze_video",
+    "build_avatar",
+]

--- a/vaultfire_cli.py
+++ b/vaultfire_cli.py
@@ -141,6 +141,30 @@ def _encrypt_file(path: Path, key: str) -> Path:
     return enc_path
 
 
+def cmd_media(args: argparse.Namespace) -> None:
+    """Run media generation subcommands."""
+    from final_modules import vaultfire_media as vm
+
+    if args.image:
+        result = vm.generate_image(args.image, args.wallet)
+        print(json.dumps(result, indent=2))
+    elif args.voice:
+        text = vm.transcribe_audio(args.voice)
+        if args.respond:
+            output = {"response": vm.voice_response(text)}
+        elif args.visualize:
+            output = vm.generate_image(text, args.wallet)
+        else:
+            output = {"transcript": text}
+        print(json.dumps(output, indent=2))
+    elif args.video:
+        result = vm.analyze_video(args.video)
+        print(json.dumps(result, indent=2))
+    elif args.ai_avatar:
+        result = vm.build_avatar(args.wallet)
+        print(json.dumps(result, indent=2))
+
+
 def cmd_unlock_access(args: argparse.Namespace) -> None:
     """Verify NFT ownership and enable access hooks."""
     if Web3 is None:
@@ -209,6 +233,16 @@ def main(argv: list[str] | None = None) -> int:
     p_unlock.add_argument("abi", help="Path to contract ABI JSON")
     p_unlock.add_argument("wallet", help="Wallet address to check")
     p_unlock.set_defaults(func=cmd_unlock_access)
+
+    p_media = sub.add_parser("media", help="Vaultfire media tools")
+    p_media.add_argument("--wallet", default="bpow20.cb.id", help="Wallet")
+    p_media.add_argument("--image")
+    p_media.add_argument("--voice")
+    p_media.add_argument("--respond", action="store_true")
+    p_media.add_argument("--visualize", action="store_true")
+    p_media.add_argument("--video")
+    p_media.add_argument("--ai-avatar", action="store_true")
+    p_media.set_defaults(func=cmd_media)
 
     args = parser.parse_args(argv)
     args.func(args)


### PR DESCRIPTION
## Summary
- implement placeholder media module with image, audio, and video helpers
- expose media functions via `final_modules`
- add `media` command to `vaultfire_cli.py`
- test media helpers in Python and call them from Node tests

## Testing
- `npm test`
- `python3 final_modules/tests/test_vaultfire_media.py`


------
https://chatgpt.com/codex/tasks/task_e_6883d82fbd6883228dc96e43b5eae3b6