### PR TITLE
Add visual shell and multiplayer sync modules

### DIFF
--- a/belief_sync_engine.js
+++ b/belief_sync_engine.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const EventEmitter = require('events');
+
+const GLOBAL_BUS = new EventEmitter();
+
+const LOG_PATH = path.join(__dirname, 'fork_log.json');
+
+function _loadLog() {
+  if (!fs.existsSync(LOG_PATH)) return [];
+  try {
+    const raw = fs.readFileSync(LOG_PATH, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+}
+
+function _writeLog(data) {
+  fs.writeFileSync(LOG_PATH, JSON.stringify(data, null, 2));
+}
+
+class BeliefSyncEngine extends EventEmitter {
+  constructor(session_id, ghost_id) {
+    super();
+    this.session_id = session_id;
+    this.ghost_id = ghost_id;
+    GLOBAL_BUS.on('sync', e => {
+      if (e.session_id === this.session_id && e.ghost_id !== this.ghost_id) {
+        this.emit('sync', e);
+      }
+    });
+  }
+
+  syncChoice(belief_fork_id, choice) {
+    const entry = {
+      session_id: this.session_id,
+      ghost_id: this.ghost_id,
+      belief_fork_id,
+      choice,
+      timestamp: Date.now()
+    };
+    const log = _loadLog();
+    log.push(entry);
+    _writeLog(log);
+    GLOBAL_BUS.emit('sync', entry);
+    return entry;
+  }
+
+  getStats() {
+    const log = _loadLog();
+    const counts = {};
+    for (const entry of log) {
+      counts[entry.choice] = (counts[entry.choice] || 0) + 1;
+    }
+    return counts;
+  }
+}
+
+module.exports = { BeliefSyncEngine };

--- a/entry_log.json
+++ b/entry_log.json
@@ -1,0 +1,8 @@
+[
+  {
+    "user": "tester",
+    "role": "dev",
+    "session_role": "dev",
+    "time": "2025-07-25T21:22:25.481Z"
+  }
+]

--- a/fork_log.json
+++ b/fork_log.json
@@ -1,0 +1,9 @@
+[
+  {
+    "session_id": "s1",
+    "ghost_id": "g1",
+    "belief_fork_id": "fork1",
+    "choice": "A",
+    "timestamp": 1753478557764
+  }
+]

--- a/tests/test_entry_gate.py
+++ b/tests/test_entry_gate.py
@@ -1,0 +1,19 @@
+import json
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+class EntryGateTest(unittest.TestCase):
+    def test_login_records_entry(self):
+        log_path = Path('entry_log.json')
+        if log_path.exists():
+            log_path.unlink()
+        output = subprocess.check_output(['node', 'vault_entry.js', 'tester', 'dev'])
+        data = json.loads(output)
+        self.assertEqual(data['session_role'], 'dev')
+        log = json.loads(log_path.read_text())
+        self.assertEqual(log[-1]['user'], 'tester')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_multiplayer_sync.js
+++ b/tests/test_multiplayer_sync.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const { BeliefSyncEngine } = require('../belief_sync_engine');
+const { createIframe } = require('../web_mirror_viewer');
+
+function resetLog() {
+  const p = path.join(__dirname, '..', 'fork_log.json');
+  fs.writeFileSync(p, '[]');
+}
+
+function testSync() {
+  resetLog();
+  const a = new BeliefSyncEngine('s1', 'g1');
+  const b = new BeliefSyncEngine('s1', 'g2');
+  let received = null;
+  b.on('sync', e => { received = e; });
+  a.syncChoice('fork1', 'A');
+  assert(received && received.choice === 'A');
+  const log = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'fork_log.json')));
+  assert(log.length === 1);
+}
+
+function testViewerConfig() {
+  const cfgPath = path.join(__dirname, '..', 'embed_config.json');
+  const cfg = { width: 500, height: 300, visual_shell: true };
+  fs.writeFileSync(cfgPath, JSON.stringify(cfg));
+  const html = createIframe('https://example.com');
+  assert(html.includes('?visual_shell=1'));
+  assert(html.includes('width="500"'));
+  fs.writeFileSync(cfgPath, JSON.stringify({ width: 640, height: 480 }));
+}
+
+try {
+  testSync();
+  testViewerConfig();
+  console.log('OK');
+} catch (err) {
+  console.error('FAIL', err);
+  process.exit(1);
+}

--- a/tests/test_visual_shell_render.py
+++ b/tests/test_visual_shell_render.py
@@ -1,0 +1,25 @@
+import subprocess
+import unittest
+import json
+
+class VisualShellRenderTest(unittest.TestCase):
+    def test_render_includes_metadata(self):
+        record = {
+            "object_id": "obj1",
+            "file": "model.gltf",
+            "watermark": True,
+            "timed_reveal": True,
+            "partner_lock": False,
+        }
+        script = (
+            "const vs=require('./visual_shell');"
+            f"process.stdout.write(vs.renderModel({json.dumps(record)}))"
+        )
+        output = subprocess.check_output(['node', '-e', script])
+        html = output.decode()
+        self.assertIn('model.gltf', html)
+        self.assertIn('watermark', html)
+        self.assertIn('timed_reveal', html)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vault_entry.js
+++ b/vault_entry.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+const LOG_PATH = path.join(__dirname, 'entry_log.json');
+const PARTNERS_PATH = path.join(__dirname, 'partners.json');
+
+function _loadJSON(p, def) {
+  if (!fs.existsSync(p)) return def;
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return def;
+  }
+}
+
+function _writeJSON(p, data) {
+  fs.writeFileSync(p, JSON.stringify(data, null, 2));
+}
+
+function login(user, role = 'player') {
+  const allowed = ['player', 'dev', 'admin', 'AI'];
+  if (!allowed.includes(role)) throw new Error('invalid role');
+  const entry = {
+    user,
+    role,
+    session_role: role,
+    time: new Date().toISOString()
+  };
+  const log = _loadJSON(LOG_PATH, []);
+  log.push(entry);
+  _writeJSON(LOG_PATH, log);
+  const forks = _loadJSON(PARTNERS_PATH, []).map(p => p.partner_id);
+  return { session_role: role, forks };
+}
+
+if (require.main === module) {
+  const user = process.argv[2] || 'guest';
+  const role = process.argv[3] || 'player';
+  try {
+    const out = login(user, role);
+    console.log(JSON.stringify(out, null, 2));
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { login };

--- a/visual_config.json
+++ b/visual_config.json
@@ -1,0 +1,5 @@
+{
+  "engine": "three",
+  "width": 640,
+  "height": 480
+}

--- a/visual_shell.js
+++ b/visual_shell.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_PATH = path.join(__dirname, 'visual_config.json');
+
+function loadConfig() {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { engine: 'three', width: 800, height: 600 };
+  }
+}
+
+function renderModel(record) {
+  const cfg = loadConfig();
+  const engine = cfg.engine === 'babylon' ? 'babylon' : 'three';
+  const meta = [];
+  if (record.watermark) meta.push('watermark');
+  if (record.timed_reveal) meta.push('timed_reveal');
+  if (record.partner_lock) meta.push('partner_lock');
+  const overlay = meta.map(m => `<span class="meta">${m}</span>`).join(' ');
+  const script = engine === 'babylon'
+    ? '<script src="https://cdn.babylonjs.com/babylon.js"></script>'
+    : '<script src="https://cdn.jsdelivr.net/npm/three@0.157/build/three.min.js"></script>';
+  return [
+    script,
+    `<canvas id="${record.object_id}" width="${cfg.width}" height="${cfg.height}" data-model="${record.file}"></canvas>`,
+    `<div class="overlay">${overlay}</div>`
+  ].join('\n');
+}
+
+module.exports = { loadConfig, renderModel };

--- a/web_mirror_viewer.js
+++ b/web_mirror_viewer.js
@@ -16,7 +16,8 @@ function createIframe(url) {
   const cfg = loadConfig();
   const w = cfg.width || 600;
   const h = cfg.height || 400;
-  return `<iframe src="${url}" width="${w}" height="${h}" frameborder="0" allowfullscreen></iframe>`;
+  const vs = cfg.visual_shell ? '?visual_shell=1' : '';
+  return `<iframe src="${url}${vs}" width="${w}" height="${h}" frameborder="0" allowfullscreen></iframe>`;
 }
 
 module.exports = { createIframe, loadConfig };


### PR DESCRIPTION
## Summary
- implement `visual_shell` with config-driven Three.js/Babylon placeholder renderer
- implement `belief_sync_engine` for cross-user fork synchronization
- create `vault_entry.js` access gateway
- enhance `web_mirror_viewer` to respect visual_shell setting
- provide config & log stubs
- add integration tests for rendering, sync, and entry logging

## Testing
- `npm test`
- `python3 -m unittest tests.test_visual_shell_render tests.test_entry_gate`
- `node tests/test_multiplayer_sync.js`


------
https://chatgpt.com/codex/tasks/task_e_6883f47719b48322a0c7764943371bec