### PR TITLE
Add memory and reward simulation modules

### DIFF
--- a/agent_memory.js
+++ b/agent_memory.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+
+const LOG_PATH = path.join(__dirname, 'memory_log.json');
+const ETHICS_WORDS = ['truth', 'loyalty', 'wisdom', 'service', 'humanity'];
+
+function _loadJSON(p, def) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return def;
+  }
+}
+
+function _writeJSON(p, data) {
+  fs.writeFileSync(p, JSON.stringify(data, null, 2));
+}
+
+function logAction(ghostId, sessionId, action, details = {}) {
+  const log = _loadJSON(LOG_PATH, []);
+  const entry = {
+    ghost_id: ghostId,
+    session_id: sessionId,
+    action,
+    details,
+    timestamp: Date.now(),
+  };
+  log.push(entry);
+  _writeJSON(LOG_PATH, log);
+  return entry;
+}
+
+function _vectorize(text, words) {
+  const tokens = text.toLowerCase().split(/[^a-z0-9]+/);
+  return words.map(w => tokens.filter(t => t === w).length);
+}
+
+function _cosine(a, b) {
+  const dot = a.reduce((s, v, i) => s + v * b[i], 0);
+  const magA = Math.sqrt(a.reduce((s, v) => s + v * v, 0));
+  const magB = Math.sqrt(b.reduce((s, v) => s + v * v, 0));
+  if (!magA || !magB) return 0;
+  return dot / (magA * magB);
+}
+
+function alignmentScore(ghostId) {
+  const log = _loadJSON(LOG_PATH, []);
+  const text = log
+    .filter(e => e.ghost_id === ghostId)
+    .map(e => `${e.action} ${JSON.stringify(e.details)}`)
+    .join(' ');
+  const vec = _vectorize(text, ETHICS_WORDS);
+  const ref = ETHICS_WORDS.map(() => 1);
+  return _cosine(vec, ref);
+}
+
+module.exports = {
+  logAction,
+  alignmentScore,
+  _loadJSON,
+  _writeJSON,
+};

--- a/memory_log.json
+++ b/memory_log.json
@@ -1,0 +1,1 @@
+[{"ghost_id": "g1", "session_id": "s1", "action": "belief_milestone", "details": {}, "timestamp": 0}]

--- a/observer_hub.html
+++ b/observer_hub.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Observer Hub</title>
+  <style>
+    body { background:#000; color:#0f0; font-family:monospace; }
+    table { border-collapse: collapse; width:100%; }
+    th, td { border:1px solid #0f0; padding:4px; }
+    tr.high { background:#040; }
+  </style>
+</head>
+<body>
+  <h1>Global Belief Map</h1>
+  <table id="forkTable">
+    <thead><tr><th>Ghost</th><th>Fork</th><th>Alignment</th></tr></thead>
+    <tbody></tbody>
+  </table>
+  <script>
+    const ETHICS_WORDS = ['truth','loyalty','wisdom','service','humanity'];
+    function vec(text){const t=text.toLowerCase().split(/[^a-z0-9]+/);return ETHICS_WORDS.map(w=>t.filter(x=>x===w).length);} 
+    function cos(a,b){const dot=a.reduce((s,v,i)=>s+v*b[i],0);const ma=Math.sqrt(a.reduce((s,v)=>s+v*v,0));const mb=Math.sqrt(b.reduce((s,v)=>s+v*v,0));return ma&&mb?dot/(ma*mb):0;}
+    async function load(){
+      const mem = await fetch('memory_log.json').then(r=>r.json()).catch(()=>[]);
+      const forks = await fetch('fork_log.json').then(r=>r.json()).catch(()=>[]);
+      const body=document.querySelector('#forkTable tbody');
+      body.innerHTML='';
+      forks.forEach(f=>{
+        const entries=mem.filter(m=>m.ghost_id===f.ghost_id);
+        const text=entries.map(e=>JSON.stringify(e)).join(' ');
+        const score=cos(vec(text),ETHICS_WORDS.map(()=>1));
+        const tr=document.createElement('tr');
+        if(score>0.75) tr.classList.add('high');
+        tr.innerHTML=`<td>${f.ghost_id}</td><td>${f.belief_fork_id}</td><td>${(score*100).toFixed(1)}%</td>`;
+        body.appendChild(tr);
+      });
+    }
+    load();
+  </script>
+</body>
+</html>

--- a/reward_loop.py
+++ b/reward_loop.py
@@ -1,0 +1,96 @@
+"""Simulated reward router for Vaultfire belief forks."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+LOG_PATH = Path('rewards_log.json')
+TX_PATH = Path('simulated_tx.json')
+MEMORY_PATH = Path('memory_log.json')
+
+ETHICS_WORDS = ["truth", "loyalty", "wisdom", "service", "humanity"]
+
+_reward_router: List[Dict[str, Any]] = []
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _append(path: Path, entry: Dict[str, Any]) -> None:
+    data = _load_json(path, [])
+    data.append(entry)
+    _write_json(path, data)
+
+
+def _vectorize(text: str, words: List[str]) -> List[int]:
+    tokens = [t.lower() for t in text.split()]
+    return [tokens.count(w) for w in words]
+
+
+def _cosine(a: List[int], b: List[int]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    mag_a = sum(x * x for x in a) ** 0.5
+    mag_b = sum(x * x for x in b) ** 0.5
+    if not mag_a or not mag_b:
+        return 0.0
+    return dot / (mag_a * mag_b)
+
+
+def _alignment(entries: List[Dict[str, Any]]) -> float:
+    text = " ".join(json.dumps(e) for e in entries)
+    vec = _vectorize(text, ETHICS_WORDS)
+    ref = [1] * len(ETHICS_WORDS)
+    return _cosine(vec, ref)
+
+
+def process_rewards(wallet: str) -> List[Dict[str, Any]]:
+    mem = _load_json(MEMORY_PATH, [])
+    results: List[Dict[str, Any]] = []
+    by_ghost: Dict[str, List[Dict[str, Any]]] = {}
+    for entry in mem:
+        by_ghost.setdefault(entry.get("ghost_id"), []).append(entry)
+    for gid, entries in by_ghost.items():
+        score = _alignment(entries)
+        milestone = any(e.get("action") == "belief_milestone" for e in entries)
+        if score >= 0.75 or milestone:
+            reward = {
+                "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ghost_id": gid,
+                "wallet": wallet,
+                "amount": 1,
+                "score": round(score, 3),
+            }
+            _append(LOG_PATH, reward)
+            tx = {
+                "wallet": wallet,
+                "token": "LOYAL",
+                "amount": 1,
+                "ghost_id": gid,
+                "timestamp": reward["timestamp"],
+            }
+            _append(TX_PATH, tx)
+            _reward_router.append(reward)
+            results.append(reward)
+    return results
+
+
+if __name__ == "__main__":
+    import sys
+
+    wallet = sys.argv[1] if len(sys.argv) > 1 else "demo.cb.id"
+    out = process_rewards(wallet)
+    print(json.dumps(out, indent=2))

--- a/rewards_log.json
+++ b/rewards_log.json
@@ -1,0 +1,9 @@
+[
+  {
+    "timestamp": "2025-07-25T21:31:32Z",
+    "ghost_id": "g1",
+    "wallet": "bpow20.cb.id",
+    "amount": 1,
+    "score": 0.0
+  }
+]

--- a/simulated_tx.json
+++ b/simulated_tx.json
@@ -1,0 +1,9 @@
+[
+  {
+    "wallet": "bpow20.cb.id",
+    "token": "LOYAL",
+    "amount": 1,
+    "ghost_id": "g1",
+    "timestamp": "2025-07-25T21:31:32Z"
+  }
+]

--- a/tests/test_agent_memory.py
+++ b/tests/test_agent_memory.py
@@ -1,0 +1,27 @@
+import json
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+MEM_LOG = Path('memory_log.json')
+
+class AgentMemoryTest(unittest.TestCase):
+    def setUp(self):
+        if MEM_LOG.exists():
+            MEM_LOG.unlink()
+        MEM_LOG.write_text('[]')
+
+    def test_log_and_score(self):
+        script = "const m=require('./agent_memory');\n" \
+                 "m.logAction('g1','s1','belief_milestone',{text:'truth loyalty'});\n" \
+                 "console.log(m.alignmentScore('g1').toFixed(2));"
+        out = subprocess.check_output(['node', '-e', script])
+        score = float(out.decode().strip())
+        self.assertGreaterEqual(score, 0)
+        log = json.loads(MEM_LOG.read_text())
+        self.assertEqual(log[0]['ghost_id'], 'g1')
+        self.assertGreaterEqual(score, 0.3)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_observer_map.js
+++ b/tests/test_observer_map.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const assert = require('assert');
+
+function testHtml() {
+  const html = fs.readFileSync('observer_hub.html', 'utf8');
+  assert(html.includes('Global Belief Map'));
+  assert(html.includes('tr.high'));
+}
+
+try {
+  testHtml();
+  console.log('OK');
+} catch (err) {
+  console.error('FAIL', err);
+  process.exit(1);
+}

--- a/tests/test_reward_loop.py
+++ b/tests/test_reward_loop.py
@@ -1,0 +1,29 @@
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+MEM_LOG = Path('memory_log.json')
+REWARD_LOG = Path('rewards_log.json')
+TX_LOG = Path('simulated_tx.json')
+
+class RewardLoopTest(unittest.TestCase):
+    def setUp(self):
+        for p in (MEM_LOG, REWARD_LOG, TX_LOG):
+            if p.exists():
+                p.unlink()
+        MEM_LOG.write_text(json.dumps([
+            {"ghost_id":"g1","session_id":"s1","action":"belief_milestone","details":{},"timestamp":0}
+        ]))
+        REWARD_LOG.write_text('[]')
+        TX_LOG.write_text('[]')
+
+    def test_reward_emitted(self):
+        subprocess.check_call(['python', 'reward_loop.py', 'bpow20.cb.id'])
+        rewards = json.loads(REWARD_LOG.read_text())
+        self.assertTrue(rewards and rewards[-1]['ghost_id']=='g1')
+        tx = json.loads(TX_LOG.read_text())
+        self.assertEqual(tx[-1]['wallet'], 'bpow20.cb.id')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add agent memory tracking with alignment scoring
- implement reward loop for token simulation
- create observer hub webpage to view global belief map
- log state in new JSON files
- test new modules

## Testing
- `python -m unittest discover -s tests`
- `node tests/test_multiplayer_sync.js && node tests/test_observer_map.js`
- `node scripts/run_tests.js`


------
https://chatgpt.com/codex/tasks/task_e_6883f6c1b8b083229795ce367ae44e71