### PR TITLE
Add partner sync modules

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -28,5 +28,10 @@
     "timestamp": "2025-07-25T23:27:29Z",
     "change": "Vaultfire v1.4.1: Signal Compass emotional cue mapping and Code-of-You overlay",
     "update_block": "PENDING_PUSH"
+  },
+  {
+    "timestamp": "2025-07-25T23:40:00Z",
+    "change": "Vaultfire v1.5: Partner Integration Push",
+    "update_block": "PENDING_PUSH"
   }
 ]

--- a/configs/vaultfire_config.json
+++ b/configs/vaultfire_config.json
@@ -1,0 +1,11 @@
+{
+  "system_name": "Vaultfire Partner",
+  "ethics_anchor": true,
+  "monetization_mode": "Behavioral Yield + Contributor Split",
+  "public_visibility": "controlled",
+  "partner_hooks_enabled": true,
+  "wallet_auth_hook": true,
+  "live_training_mode": true,
+  "fail_safe": "Hard shutdown on ethics breach",
+  "localforge_enabled": true
+}

--- a/core/partner_mirror.py
+++ b/core/partner_mirror.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+MIRROR_DIR = BASE_DIR / "logs" / "partner_mirror"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def mirror_update(partner_id: str, traits: Optional[List[str]] = None,
+                  beliefs: Optional[List[str]] = None) -> Dict:
+    """Mirror trait and belief updates for ``partner_id``."""
+    path = MIRROR_DIR / f"{partner_id}.json"
+    record = _load_json(path, {"traits": [], "beliefs": []})
+    if traits:
+        existing = set(record.get("traits", []))
+        for t in traits:
+            if t not in existing:
+                record.setdefault("traits", []).append(t)
+                existing.add(t)
+    if beliefs:
+        existing = set(record.get("beliefs", []))
+        for b in beliefs:
+            if b not in existing:
+                record.setdefault("beliefs", []).append(b)
+                existing.add(b)
+    record["timestamp"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    _write_json(path, record)
+    return record
+
+
+__all__ = ["mirror_update"]

--- a/hooks/signal_sync.js
+++ b/hooks/signal_sync.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const { detectSignals } = require('../signal_compass');
+
+const FEEDBACK_PATH = path.join(__dirname, '..', 'agent_feedback.json');
+const OUT_PATH = path.join(__dirname, '..', 'partner_signals.json');
+
+function loadJSON(p, def){
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return def; }
+}
+
+function writeJSON(p, data){
+  fs.writeFileSync(p, JSON.stringify(data, null, 2));
+}
+
+function syncSignals(){
+  const compass = detectSignals();
+  const feedback = loadJSON(FEEDBACK_PATH, []);
+  const merged = compass.concat(feedback);
+  writeJSON(OUT_PATH, merged);
+  return merged;
+}
+
+if(require.main === module){
+  const data = syncSignals();
+  console.log(JSON.stringify(data, null, 2));
+}
+
+module.exports = { syncSignals };

--- a/shells/overlay_forge.html
+++ b/shells/overlay_forge.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Overlay Forge</title>
+  <style>
+    body { font-family: sans-serif; padding: 1em; }
+    #status { margin-top: 1em; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>LocalForge Access Gateway</h1>
+  <div id="status">Loading...</div>
+  <script>
+    async function load(){
+      try{
+        const cfg = await fetch('../configs/vaultfire_config.json').then(r=>r.json());
+        const id = cfg.partner_id || 'unknown';
+        document.getElementById('status').textContent = 'LocalForge active for '+id;
+      }catch(e){
+        document.getElementById('status').textContent = 'Config missing';
+      }
+    }
+    load();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement MirrorKey sync engine
- add signal sync hook for partner feedback
- add LocalForge overlay shell
- include partner config
- document Vaultfire v1.5 in changelog

## Testing
- `python -m unittest` *(fails: ModuleNotFoundError: flask)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688415a1e5c48322a43d97e284ff5325