### PR TITLE
Add identity overlay note and sample rewards

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -39,4 +39,9 @@
     "change": "Vaultfire v1.6: Signal Fusion Engine and License Shell integration",
     "update_block": "PENDING_PUSH"
   }
+  ,{
+    "timestamp": "2025-07-26T00:00:00Z",
+    "change": "Vaultfire v1.7: Core Loop monetization and identity hooks",
+    "update_block": "PENDING_PUSH"
+  }
 ]

--- a/docs/gaming_layer.md
+++ b/docs/gaming_layer.md
@@ -10,6 +10,7 @@ The gaming layer provides reusable helpers so developers can launch multiplayer 
 - **Mirrored avatars** – contract events adjust stats, traits and questline.
 - **On-chain inventory** – record blockchain items per player and fetch them later.
 - **ENS overlays** – map a player ID to an ENS name for consistent identity display.
+- **Wallet-linked overlays** – display contributor identity when a verified wallet is detected. Behavior scores factor into overlay rank.
 - **Replay records** – log player decisions and actions, hash them on-chain and
   tie the replay to their identity for future verification and awards.
 

--- a/vaultfire_rewards.json
+++ b/vaultfire_rewards.json
@@ -1,0 +1,10 @@
+{
+  "ghostkey316.eth": {
+    "wallet": "bpow20.cb.id",
+    "payout": [
+      {"token": "ETH", "amount": 0.01},
+      {"token": "ASM", "amount": 50},
+      {"token": "WLD", "amount": 10}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- document wallet-linked overlay feature
- track upcoming v1.7 release
- add example `vaultfire_rewards.json`

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError in partner_plugins tests)*

------
https://chatgpt.com/codex/tasks/task_e_68841a070a2c8322b60467c05e9d2613