### PR TITLE
Vaultfire v1.8 loyalty and drop scheduler

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -38,10 +38,15 @@
     "timestamp": "2025-07-25T23:50:00Z",
     "change": "Vaultfire v1.6: Signal Fusion Engine and License Shell integration",
     "update_block": "PENDING_PUSH"
-  }
-  ,{
+  },
+  {
     "timestamp": "2025-07-26T00:00:00Z",
     "change": "Vaultfire v1.7: Core Loop monetization and identity hooks",
+    "update_block": "PENDING_PUSH"
+  },
+  {
+    "timestamp": "2025-07-26T00:22:48Z",
+    "change": "Vaultfire v1.8: Loyalty Engine and Drop Scheduler",
     "update_block": "PENDING_PUSH"
   }
 ]

--- a/drop_scheduler.py
+++ b/drop_scheduler.py
@@ -1,0 +1,77 @@
+"""Weekly drop scheduler using ghost scores and reward config."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict
+
+from engine.ghostscore_engine import get_ghostscore
+
+BASE_DIR = Path(__file__).resolve().parent
+REWARDS_PATH = BASE_DIR / "vaultfire_rewards.json"
+CONFIG_PATH = BASE_DIR / "vault_config.json"
+DROP_LOG_PATH = BASE_DIR / "logs" / "drop_schedule_log.json"
+SCORES_PATH = BASE_DIR / "ghostscores.json"
+
+DEFAULT_CONFIG = {
+    "weekly_drop_day": "Fri",
+    "weekly_drop_hour_et": 16
+}
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _window_open(config: dict, now: datetime) -> bool:
+    day = config.get("weekly_drop_day", "Fri")
+    hour_et = config.get("weekly_drop_hour_et", 16)
+    hour_utc = (hour_et + 4) % 24
+    return now.strftime("%a") == day and now.hour == hour_utc
+
+
+def schedule_drops(now: datetime | None = None) -> List[Dict]:
+    dt = now or datetime.utcnow()
+    config = _load_json(CONFIG_PATH, DEFAULT_CONFIG)
+    if not _window_open(config, dt):
+        return []
+    rewards = _load_json(REWARDS_PATH, {})
+    results: List[Dict] = []
+    for ens, info in rewards.items():
+        wallet = info.get("wallet")
+        payouts = info.get("payout", [])
+        score = get_ghostscore(ens)
+        multiplier = 1 + score / 100
+        for p in payouts:
+            amount = round(p.get("amount", 0) * multiplier, 3)
+            entry = {
+                "timestamp": dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ens": ens,
+                "wallet": wallet,
+                "token": p.get("token"),
+                "amount": amount,
+                "ghostscore": score,
+            }
+            results.append(entry)
+    if results:
+        log = _load_json(DROP_LOG_PATH, [])
+        log.extend(results)
+        _write_json(DROP_LOG_PATH, log)
+    return results
+
+
+if __name__ == "__main__":
+    print(json.dumps(schedule_drops(), indent=2))

--- a/engine/loyalty_engine_v1.py
+++ b/engine/loyalty_engine_v1.py
@@ -1,0 +1,97 @@
+"""Vaultfire Loyalty Engine v1.0.
+
+Tracks contributor interactions, overlay state and partner sync data.
+Logs streak counts and returns a summary with ghostscore alignment.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional, Dict
+
+from .ens_overlay import resolve_overlay
+from .ghostscore_engine import get_ghostscore
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LOG_PATH = BASE_DIR / "logs" / "loyalty_log.json"
+STREAK_PATH = BASE_DIR / "logs" / "loyalty_streaks.json"
+PARTNER_PATH = BASE_DIR / "partners.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _update_streak(user_id: str) -> int:
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    data = _load_json(STREAK_PATH, {})
+    info = data.get(user_id, {"last": "", "count": 0})
+    if info["last"] != today:
+        if info["last"]:
+            try:
+                prev = datetime.strptime(info["last"], "%Y-%m-%d")
+                if datetime.utcnow() - prev <= timedelta(days=1):
+                    info["count"] += 1
+                else:
+                    info["count"] = 1
+            except ValueError:
+                info["count"] = 1
+        else:
+            info["count"] = 1
+        info["last"] = today
+        data[user_id] = info
+        _write_json(STREAK_PATH, data)
+    return info["count"]
+
+
+def record_interaction(user_id: str, action: str, overlay: Optional[str] = None, partner_id: Optional[str] = None) -> Dict:
+    """Record a contributor interaction and update streak."""
+    streak = _update_streak(user_id)
+    overlay_resolved = overlay or resolve_overlay(user_id)
+    partners = {p.get("partner_id") for p in _load_json(PARTNER_PATH, [])}
+    partner_synced = partner_id in partners if partner_id else False
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "user_id": user_id,
+        "action": action,
+        "overlay": overlay_resolved,
+        "partner_sync": partner_synced,
+        "streak": streak,
+    }
+    log = _load_json(LOG_PATH, [])
+    log.append(entry)
+    _write_json(LOG_PATH, log)
+    return entry
+
+
+def loyalty_report(user_id: str) -> Dict:
+    """Return a loyalty status report for ``user_id``."""
+    streak_data = _load_json(STREAK_PATH, {}).get(user_id, {"count": 0})
+    overlay = resolve_overlay(user_id)
+    ens = overlay or user_id
+    ghostscore = get_ghostscore(ens)
+    partners = {p.get("partner_id") for p in _load_json(PARTNER_PATH, [])}
+    partner_synced = user_id in partners
+    return {
+        "user_id": user_id,
+        "streak": streak_data.get("count", 0),
+        "overlay": overlay,
+        "partner_synced": partner_synced,
+        "ghostscore": ghostscore,
+    }
+
+
+__all__ = ["record_interaction", "loyalty_report"]

--- a/loyalty_tiers.json
+++ b/loyalty_tiers.json
@@ -1,0 +1,6 @@
+{
+  "ghostkey316.eth": {
+    "tier": "Legacy",
+    "multiplier": 1.2
+  }
+}

--- a/vault_config.json
+++ b/vault_config.json
@@ -1,0 +1,4 @@
+{
+  "weekly_drop_day": "Fri",
+  "weekly_drop_hour_et": 16
+}


### PR DESCRIPTION
## Summary
- implement `loyalty_engine_v1` with streak logging and overlay sync
- add configurable weekly drop scheduler
- store config and new loyalty tier files
- update changelog for v1.8

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68841f2f15648322a4edde59ba6f3ae6