### PR TITLE
Implement loyalty backpay system v1.12

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -53,5 +53,20 @@
     "timestamp": "2025-07-26T12:00:00Z",
     "change": "Vaultfire v1.9: Insight Loop and passive monitoring",
     "update_block": "PENDING_PUSH"
+  },
+  {
+    "timestamp": "2025-07-27T00:00:00Z",
+    "change": "Vaultfire v1.12 — Loyalty Backpay activated",
+    "update_block": "PENDING_PUSH"
+  },
+  {
+    "timestamp": "2025-07-27T00:00:01Z",
+    "change": "Retroactive rewards now issued based on past loyalty memory growth",
+    "update_block": "PENDING_PUSH"
+  },
+  {
+    "timestamp": "2025-07-27T00:00:02Z",
+    "change": "Multiplier sync complete across all loyalty systems",
+    "update_block": "PENDING_PUSH"
   }
 ]

--- a/engine/loyalty_engine_v1.py
+++ b/engine/loyalty_engine_v1.py
@@ -17,6 +17,7 @@ BASE_DIR = Path(__file__).resolve().parents[1]
 LOG_PATH = BASE_DIR / "logs" / "loyalty_log.json"
 STREAK_PATH = BASE_DIR / "logs" / "loyalty_streaks.json"
 PARTNER_PATH = BASE_DIR / "partners.json"
+RETRO_PATH = BASE_DIR / "retroactive_rewards.json"
 
 
 def _load_json(path: Path, default):
@@ -57,6 +58,11 @@ def _update_streak(user_id: str) -> int:
     return info["count"]
 
 
+def _retro_multiplier(user_id: str) -> float:
+    rewards = _load_json(RETRO_PATH, {})
+    return float(rewards.get(user_id, {}).get("multiplier", 1.0))
+
+
 def record_interaction(user_id: str, action: str, overlay: Optional[str] = None, partner_id: Optional[str] = None) -> Dict:
     """Record a contributor interaction and update streak."""
     streak = _update_streak(user_id)
@@ -85,12 +91,16 @@ def loyalty_report(user_id: str) -> Dict:
     ghostscore = get_ghostscore(ens)
     partners = {p.get("partner_id") for p in _load_json(PARTNER_PATH, [])}
     partner_synced = user_id in partners
+    retro_mult = _retro_multiplier(user_id)
+    drop_score = streak_data.get("count", 0) * retro_mult
     return {
         "user_id": user_id,
         "streak": streak_data.get("count", 0),
         "overlay": overlay,
         "partner_synced": partner_synced,
         "ghostscore": ghostscore,
+        "retro_multiplier": retro_mult,
+        "drop_score": drop_score,
     }
 
 

--- a/engine/retroactive_rewards.py
+++ b/engine/retroactive_rewards.py
@@ -1,0 +1,80 @@
+"""Vaultfire v1.12 Retroactive Rewards Module."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Tuple
+
+SNAPSHOT_DIR = Path("memory_snapshots")
+REWARD_PATH = Path("retroactive_rewards.json")
+
+# Growth thresholds and reward mapping (percentage increase -> (tier, multiplier, asm))
+GROWTH_TIERS: Tuple[Tuple[float, str, float, int], ...] = (
+    (0.5, "Tier 3", 1.5, 150),
+    (0.25, "Tier 2", 1.25, 75),
+    (0.10, "Tier 1", 1.1, 25),
+)
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _snapshot_files() -> list[Path]:
+    return sorted(SNAPSHOT_DIR.glob("wallet_memory_*.json"))
+
+
+def _growth_ratio(start: float, end: float) -> float:
+    if start <= 0:
+        if end > start:
+            return 1.0
+        return 0.0
+    return (end - start) / start
+
+
+def _tier_for_growth(growth: float) -> Tuple[str, float, int] | None:
+    for threshold, tier, mult, asm in GROWTH_TIERS:
+        if growth >= threshold:
+            return tier, mult, asm
+    return None
+
+
+def calculate_retro_rewards() -> Dict[str, Dict[str, float | int | str]]:
+    files = _snapshot_files()
+    if len(files) < 2:
+        return {}
+    first = _load_json(files[0], {})
+    last = _load_json(files[-1], {})
+    rewards: Dict[str, Dict[str, float | int | str]] = {}
+    for wallet, info in last.items():
+        start = first.get(wallet, {}).get("score", 0)
+        end = info.get("score", 0)
+        growth = _growth_ratio(start, end)
+        tier_info = _tier_for_growth(growth)
+        if tier_info:
+            tier, mult, asm = tier_info
+            rewards[wallet] = {
+                "tier": tier,
+                "multiplier": mult,
+                "asm": asm,
+            }
+    return rewards
+
+
+def write_retro_rewards(rewards: Dict[str, Dict[str, float | int | str]]) -> None:
+    _write_json(REWARD_PATH, rewards)
+
+
+__all__ = ["calculate_retro_rewards", "write_retro_rewards"]

--- a/run_backpay.py
+++ b/run_backpay.py
@@ -1,0 +1,17 @@
+"""Execute retroactive loyalty backpay distribution."""
+from __future__ import annotations
+
+import json
+
+from engine.retroactive_rewards import calculate_retro_rewards, write_retro_rewards
+
+
+def main() -> None:
+    rewards = calculate_retro_rewards()
+    write_retro_rewards(rewards)
+    print(json.dumps(rewards, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_backpay_rewards.py
+++ b/tests/test_backpay_rewards.py
@@ -1,0 +1,45 @@
+import json
+import unittest
+from pathlib import Path
+
+from engine.retroactive_rewards import calculate_retro_rewards, write_retro_rewards
+
+SNAP_DIR = Path('memory_snapshots')
+REWARD_PATH = Path('retroactive_rewards.json')
+
+class BackpayRewardsTest(unittest.TestCase):
+    def setUp(self):
+        if SNAP_DIR.exists():
+            for f in SNAP_DIR.iterdir():
+                f.unlink()
+        else:
+            SNAP_DIR.mkdir()
+        if REWARD_PATH.exists():
+            REWARD_PATH.unlink()
+        # create two snapshots
+        old = {
+            'w1': {'score': 100},
+            'w2': {'score': 100},
+            'w3': {'score': 100},
+        }
+        new = {
+            'w1': {'score': 160},
+            'w2': {'score': 120},
+            'w3': {'score': 80},
+        }
+        (SNAP_DIR / 'wallet_memory_2024-01-01.json').write_text(json.dumps(old))
+        (SNAP_DIR / 'wallet_memory_2024-02-01.json').write_text(json.dumps(new))
+
+    def test_growth_scoring(self):
+        rewards = calculate_retro_rewards()
+        write_retro_rewards(rewards)
+        data = json.loads(REWARD_PATH.read_text())
+        self.assertIn('w1', data)
+        self.assertEqual(data['w1']['tier'], 'Tier 3')
+        self.assertIn('w2', data)
+        self.assertEqual(data['w2']['tier'], 'Tier 1')
+        self.assertNotIn('w3', data)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_loyalty_engine.py
+++ b/tests/test_loyalty_engine.py
@@ -1,0 +1,27 @@
+import json
+import unittest
+from pathlib import Path
+
+from engine.loyalty_engine_v1 import loyalty_report
+
+REWARD_PATH = Path('retroactive_rewards.json')
+STREAK_PATH = Path('logs/loyalty_streaks.json')
+
+class LoyaltyEngineBackpayTest(unittest.TestCase):
+    def setUp(self):
+        if REWARD_PATH.exists():
+            REWARD_PATH.unlink()
+        if STREAK_PATH.exists():
+            STREAK_PATH.unlink()
+        REWARD_PATH.write_text(json.dumps({'alice': {'multiplier': 1.5}}))
+        STREAK_PATH.parent.mkdir(parents=True, exist_ok=True)
+        STREAK_PATH.write_text(json.dumps({'alice': {'last': '2024-02-01', 'count': 3}}))
+
+    def test_report_includes_retroactive_multiplier(self):
+        report = loyalty_report('alice')
+        self.assertAlmostEqual(report['retro_multiplier'], 1.5)
+        self.assertEqual(report['drop_score'], 4.5)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add retroactive reward calculation module
- integrate retro multipliers into loyalty engine v1
- script to run backpay distribution
- tests for loyalty backpay features
- document new backpay feature in changelog

## Testing
- `python3 run_backpay.py`
- `PYTHONPATH=. pytest tests/test_backpay_rewards.py tests/test_loyalty_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688426418c348322a343a7146515aaad