### PR TITLE
Add belief multiplier and flame tier integration

### DIFF
--- a/belief_bonus_display.py
+++ b/belief_bonus_display.py
@@ -1,0 +1,29 @@
+"""Display belief multiplier and flame tier."""
+from __future__ import annotations
+
+import argparse
+import json
+
+from engine.belief_multiplier import belief_multiplier
+
+
+def display_bonus(user_id: str, output: str = "cli") -> dict:
+    mult, tier = belief_multiplier(user_id)
+    result = {"user_id": user_id, "flame_tier": tier, "multiplier": mult}
+    if output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"{user_id}: {tier} ({mult}x)")
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Show belief bonus status")
+    parser.add_argument("user_id")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    display_bonus(args.user_id, output="json" if args.json else "cli")
+
+
+if __name__ == "__main__":
+    main()

--- a/belief_score.json
+++ b/belief_score.json
@@ -1,0 +1,1 @@
+{"alice": {"interactions": 10, "growth_events": 0, "milestones": 0, "flames": 1}}

--- a/changelog.json
+++ b/changelog.json
@@ -69,4 +69,9 @@
     "change": "Multiplier sync complete across all loyalty systems",
     "update_block": "PENDING_PUSH"
   }
+  {
+    "timestamp": "2025-07-27T00:00:03Z",
+    "change": "Vaultfire v1.13 — belief multiplier module added",
+    "update_block": "PENDING_PUSH"
+  }
 ]

--- a/engine/belief_multiplier.py
+++ b/engine/belief_multiplier.py
@@ -1,0 +1,73 @@
+"""Belief multiplier calculations for Vaultfire v1.13."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Tuple
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+SCORE_PATH = BASE_DIR / "belief_score.json"
+TIER_NAMES = ("Spark", "Glow", "Burner", "Immortal Flame")
+
+
+def _load_json(path: Path) -> dict:
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def record_belief_action(user_id: str, action: str) -> None:
+    """Update ``belief_score.json`` with ``action`` for ``user_id``."""
+    data = _load_json(SCORE_PATH)
+    info = data.get(
+        user_id,
+        {"interactions": 0, "growth_events": 0, "milestones": 0, "flames": 0},
+    )
+    if action == "interaction":
+        info["interactions"] += 1
+    elif action == "growth":
+        info["growth_events"] += 1
+    elif action == "milestone":
+        info["milestones"] += 1
+    elif action == "flame":
+        info["flames"] += 1
+    data[user_id] = info
+    _write_json(SCORE_PATH, data)
+
+
+def _score(info: dict) -> int:
+    return (
+        info.get("interactions", 0)
+        + info.get("growth_events", 0) * 2
+        + info.get("milestones", 0) * 5
+        + info.get("flames", 0) * 10
+    )
+
+
+def belief_multiplier(user_id: str) -> Tuple[float, str]:
+    """Return ``(multiplier, tier)`` for ``user_id``."""
+    data = _load_json(SCORE_PATH)
+    info = data.get(user_id, {})
+    total = _score(info)
+    if total >= 100:
+        tier, mult = TIER_NAMES[3], 1.2
+    elif total >= 50:
+        tier, mult = TIER_NAMES[2], 1.1
+    elif total >= 20:
+        tier, mult = TIER_NAMES[1], 1.05
+    else:
+        tier, mult = TIER_NAMES[0], 1.0
+    return mult, tier
+
+
+__all__ = ["record_belief_action", "belief_multiplier"]

--- a/engine/loyalty_engine_v1.py
+++ b/engine/loyalty_engine_v1.py
@@ -12,6 +12,7 @@ from typing import Optional, Dict
 
 from .ens_overlay import resolve_overlay
 from .ghostscore_engine import get_ghostscore
+from .belief_multiplier import belief_multiplier, record_belief_action
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 LOG_PATH = BASE_DIR / "logs" / "loyalty_log.json"
@@ -80,6 +81,10 @@ def record_interaction(user_id: str, action: str, overlay: Optional[str] = None,
     log = _load_json(LOG_PATH, [])
     log.append(entry)
     _write_json(LOG_PATH, log)
+    try:
+        record_belief_action(user_id, "interaction")
+    except Exception:
+        pass
     return entry
 
 
@@ -92,7 +97,9 @@ def loyalty_report(user_id: str) -> Dict:
     partners = {p.get("partner_id") for p in _load_json(PARTNER_PATH, [])}
     partner_synced = user_id in partners
     retro_mult = _retro_multiplier(user_id)
+    belief_mult, flame_tier = belief_multiplier(user_id)
     drop_score = streak_data.get("count", 0) * retro_mult
+    drop_score *= belief_mult
     return {
         "user_id": user_id,
         "streak": streak_data.get("count", 0),
@@ -100,6 +107,8 @@ def loyalty_report(user_id: str) -> Dict:
         "partner_synced": partner_synced,
         "ghostscore": ghostscore,
         "retro_multiplier": retro_mult,
+        "belief_multiplier": belief_mult,
+        "flame_tier": flame_tier,
         "drop_score": drop_score,
     }
 

--- a/run_flame_tracker.py
+++ b/run_flame_tracker.py
@@ -1,0 +1,24 @@
+"""Simulate belief tracking for demo wallets."""
+from __future__ import annotations
+
+import json
+
+from engine.belief_multiplier import record_belief_action, belief_multiplier
+from belief_bonus_display import display_bonus
+
+MOCK_WALLETS = ["demo1.eth", "demo2.eth"]
+
+
+def simulate() -> None:
+    for w in MOCK_WALLETS:
+        record_belief_action(w, "interaction")
+        record_belief_action(w, "growth")
+    record_belief_action("demo1.eth", "flame")
+    results = {w: belief_multiplier(w)[0] for w in MOCK_WALLETS}
+    print(json.dumps(results, indent=2))
+    for w in MOCK_WALLETS:
+        display_bonus(w)
+
+
+if __name__ == "__main__":
+    simulate()

--- a/tests/test_belief_score.py
+++ b/tests/test_belief_score.py
@@ -1,0 +1,28 @@
+import json
+import unittest
+from pathlib import Path
+
+from engine.belief_multiplier import record_belief_action, belief_multiplier
+
+BELIEF_PATH = Path('belief_score.json')
+
+
+class BeliefScoreTest(unittest.TestCase):
+    def setUp(self):
+        if BELIEF_PATH.exists():
+            BELIEF_PATH.unlink()
+
+    def test_scoring_and_tier(self):
+        for _ in range(10):
+            record_belief_action('alice', 'interaction')
+        record_belief_action('alice', 'flame')
+        data = json.loads(BELIEF_PATH.read_text())
+        self.assertEqual(data['alice']['interactions'], 10)
+        self.assertEqual(data['alice']['flames'], 1)
+        mult, tier = belief_multiplier('alice')
+        self.assertEqual(tier, 'Glow')
+        self.assertAlmostEqual(mult, 1.05)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_loyalty_engine.py
+++ b/tests/test_loyalty_engine.py
@@ -3,9 +3,11 @@ import unittest
 from pathlib import Path
 
 from engine.loyalty_engine_v1 import loyalty_report
+from engine.belief_multiplier import belief_multiplier
 
 REWARD_PATH = Path('retroactive_rewards.json')
 STREAK_PATH = Path('logs/loyalty_streaks.json')
+BELIEF_PATH = Path('belief_score.json')
 
 class LoyaltyEngineBackpayTest(unittest.TestCase):
     def setUp(self):
@@ -13,14 +15,24 @@ class LoyaltyEngineBackpayTest(unittest.TestCase):
             REWARD_PATH.unlink()
         if STREAK_PATH.exists():
             STREAK_PATH.unlink()
+        if BELIEF_PATH.exists():
+            BELIEF_PATH.unlink()
         REWARD_PATH.write_text(json.dumps({'alice': {'multiplier': 1.5}}))
         STREAK_PATH.parent.mkdir(parents=True, exist_ok=True)
         STREAK_PATH.write_text(json.dumps({'alice': {'last': '2024-02-01', 'count': 3}}))
+        BELIEF_PATH.write_text(json.dumps({'alice': {'interactions': 10, 'growth_events': 0, 'milestones': 0, 'flames': 1}}))
 
     def test_report_includes_retroactive_multiplier(self):
         report = loyalty_report('alice')
         self.assertAlmostEqual(report['retro_multiplier'], 1.5)
-        self.assertEqual(report['drop_score'], 4.5)
+        self.assertAlmostEqual(report['drop_score'], 4.725)
+
+    def test_belief_stack_sync(self):
+        report = loyalty_report('alice')
+        self.assertEqual(report['flame_tier'], 'Glow')
+        base = 3 * 1.5
+        expected = base * 1.05
+        self.assertAlmostEqual(report['drop_score'], expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- create `belief_score.json` to track user belief activity
- implement `belief_multiplier.py` for tiered multipliers
- add CLI utilities and simulation scripts
- integrate belief multipliers into `loyalty_engine_v1`
- extend tests for belief scoring and loyalty engine sync
- document Vaultfire v1.13 in `changelog.json`

## Testing
- `python -m pytest tests/test_belief_score.py tests/test_loyalty_engine.py -q`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688427c80af8832290bfde409a8e5f17