### PR TITLE
Implement live belief reward scanning with webhooks

### DIFF
--- a/belief_trigger_engine.py
+++ b/belief_trigger_engine.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import urllib.request
 from datetime import datetime
 from pathlib import Path
 
@@ -22,6 +23,7 @@ BELIEF_THRESHOLDS = {
 }
 
 LOG_PATH = Path("vault_trigger_log.json")
+CHAIN_LOG_PATH = Path("chain_event_log.json")
 
 
 def _log_trigger(entry: dict) -> None:
@@ -35,6 +37,31 @@ def _log_trigger(entry: dict) -> None:
         log = []
     log.append(entry)
     LOG_PATH.write_text(json.dumps(log, indent=2))
+
+
+def _append_json(path: Path, entry: dict) -> None:
+    """Append ``entry`` to a JSON list at ``path``."""
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            data = []
+    else:
+        data = []
+    data.append(entry)
+    path.write_text(json.dumps(data, indent=2))
+
+
+def send_webhook(url: str, payload: dict) -> None:
+    """POST ``payload`` to ``url`` ignoring errors."""
+    if not url:
+        return
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    try:
+        urllib.request.urlopen(req, timeout=5)
+    except Exception:
+        pass
 
 
 # Trigger functions ----------------------------------------------------------
@@ -117,6 +144,36 @@ def belief_boost_suggestion(wallet_id: str) -> dict:
         "timestamp": datetime.utcnow().isoformat(),
     }
     _log_trigger(result)
+    return result
+
+
+def activate_belief_reward(wallet_id: str, score: int, *, chain_log: bool = False) -> dict:
+    """Activate reward based on ``score`` and return activation entry."""
+    if score >= 90:
+        func = high_tier_reward
+        tier = "high"
+    elif score >= 70:
+        func = mid_tier_reward
+        tier = "mid"
+    elif score >= 50:
+        func = loyalty_ping
+        tier = "loyalty"
+    else:
+        func = belief_boost_suggestion
+        tier = "boost"
+    trigger_entry = func(wallet_id)
+    result = {
+        "wallet_id": wallet_id,
+        "score": score,
+        "tier": tier,
+        "trigger": trigger_entry["trigger"],
+        "timestamp": trigger_entry["timestamp"],
+    }
+    if chain_log:
+        _append_json(
+            CHAIN_LOG_PATH,
+            {"wallet": wallet_id, "tier": tier, "timestamp": trigger_entry["timestamp"]},
+        )
     return result
 
 

--- a/live_flame_scan.py
+++ b/live_flame_scan.py
@@ -2,38 +2,113 @@ import argparse
 import json
 import time
 from pathlib import Path
+from typing import Dict, List
 
 from belief_trigger_engine import (
-    high_tier_reward,
-    mid_tier_reward,
-    loyalty_ping,
-    belief_boost_suggestion,
+    activate_belief_reward,
+    send_webhook,
 )
 
-SCORES_PATH = Path('live_wallet_scores.json')
+try:
+    from flask import Flask, jsonify, request
+except Exception:  # pragma: no cover - Flask optional at runtime
+    Flask = None  # type: ignore
+
+DEFAULT_INPUT = Path("live_wallet_scores.json")
+DEFAULT_LOG = Path("flame_log.json")
 
 
-def scan_loop(iterations: int = 1, delay: float = 2.0) -> None:
-    for _ in range(iterations):
+def _append(path: Path, entry: Dict) -> None:
+    if path.exists():
         try:
-            data = json.loads(SCORES_PATH.read_text())
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            data = []
+    else:
+        data = []
+    data.append(entry)
+    path.write_text(json.dumps(data, indent=2))
+
+
+def process_scores(
+    scores: Dict[str, int],
+    log_path: Path = DEFAULT_LOG,
+    webhook: str | None = None,
+    chain: bool = False,
+) -> List[Dict]:
+    results: List[Dict] = []
+    for wallet, score in scores.items():
+        entry = activate_belief_reward(wallet, int(score), chain_log=chain)
+        results.append(entry)
+        _append(log_path, entry)
+        if webhook:
+            send_webhook(webhook, entry)
+    return results
+
+
+def scan_loop(
+    input_path: Path = DEFAULT_INPUT,
+    log_path: Path = DEFAULT_LOG,
+    iterations: int = 1,
+    delay: float = 2.0,
+    monitor: bool = False,
+    webhook: str | None = None,
+    chain: bool = False,
+) -> None:
+    count = 0
+    while True:
+        try:
+            data = json.loads(input_path.read_text())
         except Exception:
             data = {}
-        for wallet, score in data.items():
-            if score >= 90:
-                high_tier_reward(wallet)
-            elif score >= 70:
-                mid_tier_reward(wallet)
-            elif score >= 50:
-                loyalty_ping(wallet)
-            else:
-                belief_boost_suggestion(wallet)
+        process_scores(data, log_path, webhook, chain)
+        count += 1
+        if not monitor and count >= iterations:
+            break
         time.sleep(delay)
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Live flame scan')
-    parser.add_argument('--iterations', type=int, default=1)
-    parser.add_argument('--delay', type=float, default=2.0)
-    args = parser.parse_args()
-    scan_loop(args.iterations, args.delay)
+def create_app(log_path: Path = DEFAULT_LOG, webhook: str | None = None, chain: bool = False) -> "Flask":
+    if not Flask:
+        raise RuntimeError("Flask is not available")
+    app = Flask(__name__)
+
+    @app.post("/scan")
+    def scan_endpoint():
+        payload = request.get_json(silent=True) or {}
+        scores = payload.get("scores", {})
+        results = process_scores(scores, log_path, webhook, chain)
+        return jsonify(results)
+
+    return app
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Live flame scan")
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--log", type=Path, default=DEFAULT_LOG)
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--delay", type=float, default=2.0)
+    parser.add_argument("--monitor", action="store_true")
+    parser.add_argument("--webhook")
+    parser.add_argument("--chain", action="store_true")
+    parser.add_argument("--api", action="store_true", help="Run Flask API")
+    args = parser.parse_args(argv)
+
+    if args.api:
+        app = create_app(args.log, args.webhook, args.chain)
+        app.run()
+    else:
+        scan_loop(
+            input_path=args.input,
+            log_path=args.log,
+            iterations=args.iterations,
+            delay=args.delay,
+            monitor=args.monitor,
+            webhook=args.webhook,
+            chain=args.chain,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_live_flame_scan.py
+++ b/tests/test_live_flame_scan.py
@@ -1,0 +1,38 @@
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from belief_trigger_engine import LOG_PATH, CHAIN_LOG_PATH
+from live_flame_scan import process_scores
+
+
+class LiveFlameScanTest(unittest.TestCase):
+    def setUp(self):
+        for p in (LOG_PATH, CHAIN_LOG_PATH, Path('test_flame_log.json')):
+            if p.exists():
+                p.unlink()
+
+    def test_process_scores_all_tiers(self):
+        scores = {
+            'high_wallet': 95,
+            'mid_wallet': 75,
+            'loyal_wallet': 55,
+            'boost_wallet': 20,
+        }
+        with patch('urllib.request.urlopen') as mock_url:
+            results = process_scores(scores, Path('test_flame_log.json'), webhook='http://localhost/web', chain=True)
+            self.assertEqual(mock_url.call_count, 4)
+        triggers = {r['wallet_id']: r['trigger'] for r in results}
+        self.assertEqual(triggers['high_wallet'], 'high_tier_reward')
+        self.assertEqual(triggers['mid_wallet'], 'mid_tier_reward')
+        self.assertEqual(triggers['loyal_wallet'], 'loyalty_ping')
+        self.assertEqual(triggers['boost_wallet'], 'belief_boost_suggestion')
+        log = json.loads(Path('test_flame_log.json').read_text())
+        self.assertEqual(len(log), 4)
+        chain_log = json.loads(CHAIN_LOG_PATH.read_text())
+        self.assertEqual(len(chain_log), 4)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enhance belief_trigger_engine with webhook helper and chain logging
- add activate_belief_reward utility for tiered rewards
- implement live_flame_scan CLI/Flask tool for real-time scanning
- test processing of live wallet scores

## Testing
- `python -m unittest discover -s tests -p 'test_*.py'`

------
https://chatgpt.com/codex/tasks/task_e_6884313164088322a867d4e5d86a6cc0