### PR TITLE
Implement chain/webhook tracking in belief engine

### DIFF
--- a/belief_trigger_engine.py
+++ b/belief_trigger_engine.py
@@ -203,8 +203,23 @@ def _get_belief_score(wallet_id: str) -> int:
 
 # Public API ----------------------------------------------------------------
 
-def evaluate_wallet(wallet_id: str) -> dict:
-    """Evaluate ``wallet_id`` and activate the correct trigger."""
+def evaluate_wallet(
+    wallet_id: str,
+    *,
+    chain_log: bool = False,
+    webhook: str | None = None,
+) -> dict:
+    """Evaluate ``wallet_id`` and activate the correct trigger.
+
+    Parameters
+    ----------
+    wallet_id:
+        Wallet address to evaluate.
+    chain_log:
+        If ``True`` append the activation event to ``CHAIN_LOG_PATH``.
+    webhook:
+        Optional URL to POST activation data to.
+    """
     score = _get_belief_score(wallet_id)
     loyalty = loyalty_report(wallet_id)
 
@@ -228,6 +243,10 @@ def evaluate_wallet(wallet_id: str) -> dict:
             result["trigger"] = trigger_entry["trigger"]
             result["timestamp"] = trigger_entry["timestamp"]
             _log_trigger(result)
+            if chain_log:
+                log_chain_event(wallet_id, tier, result["timestamp"])
+            if webhook:
+                send_to_webhook(webhook, wallet_id, tier, score)
     return result
 
 

--- a/tests/test_belief_trigger_engine.py
+++ b/tests/test_belief_trigger_engine.py
@@ -1,15 +1,20 @@
 import json
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-from belief_trigger_engine import evaluate_wallet, LOG_PATH
+from belief_trigger_engine import (
+    evaluate_wallet,
+    LOG_PATH,
+    CHAIN_LOG_PATH,
+)
 
 BELIEF_PATH = Path('belief_score.json')
 
 
 class BeliefTriggerEngineTest(unittest.TestCase):
     def setUp(self):
-        for p in (BELIEF_PATH, LOG_PATH):
+        for p in (BELIEF_PATH, LOG_PATH, CHAIN_LOG_PATH):
             if p.exists():
                 p.unlink()
         BELIEF_PATH.write_text(json.dumps({
@@ -36,6 +41,19 @@ class BeliefTriggerEngineTest(unittest.TestCase):
         result = evaluate_wallet('below_wallet')
         self.assertIsNone(result['tier'])
         self.assertFalse(LOG_PATH.exists())
+
+    def test_chain_and_webhook_logging(self):
+        with patch('urllib.request.urlopen') as mock_url:
+            evaluate_wallet(
+                'spark_wallet',
+                chain_log=True,
+                webhook='http://localhost/web'
+            )
+            self.assertEqual(mock_url.call_count, 1)
+        self.assertTrue(CHAIN_LOG_PATH.exists())
+        chain_data = json.loads(CHAIN_LOG_PATH.read_text())
+        self.assertEqual(chain_data[0]['wallet'], 'spark_wallet')
+        self.assertEqual(chain_data[0]['tier'], 'Spark')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- extend `evaluate_wallet` to optionally log to chain log and dispatch a webhook
- document parameters in `evaluate_wallet`
- test new features by mocking webhook and confirming chain log entries

## Testing
- `python3 -m unittest discover -s tests -p 'test_*.py'`

------
https://chatgpt.com/codex/tasks/task_e_68843809cc2883228357529502b3eba1