### PR TITLE
Add chain log score and webhook tests

### DIFF
--- a/belief_trigger_engine.py
+++ b/belief_trigger_engine.py
@@ -76,9 +76,12 @@ def send_to_webhook(url: str | None, wallet: str, tier: str, score: int) -> None
     send_webhook(url, payload)
 
 
-def log_chain_event(wallet: str, tier: str, timestamp: str) -> None:
-    """Record a chain-style log entry."""
-    _append_json(CHAIN_LOG_PATH, {"wallet": wallet, "tier": tier, "timestamp": timestamp})
+def log_chain_event(wallet: str, tier: str, score: int, timestamp: str) -> None:
+    """Record a chain-style log entry with score and timestamp."""
+    _append_json(
+        CHAIN_LOG_PATH,
+        {"wallet": wallet, "tier": tier, "score": score, "timestamp": timestamp},
+    )
 
 
 # Trigger functions ----------------------------------------------------------
@@ -164,7 +167,19 @@ def activate_belief_reward(
     chain_log: bool = False,
     webhook: str | None = None,
 ) -> dict:
-    """Activate reward based on ``score`` and return activation entry."""
+    """Activate reward based on ``score`` and return activation entry.
+
+    Parameters
+    ----------
+    wallet_id:
+        Wallet to reward.
+    score:
+        Belief score determining tier.
+    chain_log:
+        If ``True`` also record the event in ``CHAIN_LOG_PATH`` with the score.
+    webhook:
+        Optional URL to POST activation data to.
+    """
     if score >= 90:
         func = high_tier_reward
         tier = "high"
@@ -187,7 +202,7 @@ def activate_belief_reward(
     }
     _log_trigger(result)
     if chain_log:
-        log_chain_event(wallet_id, tier, result["timestamp"])
+        log_chain_event(wallet_id, tier, score, result["timestamp"])
     if webhook:
         send_to_webhook(webhook, wallet_id, tier, score)
     return result
@@ -216,7 +231,7 @@ def evaluate_wallet(
     wallet_id:
         Wallet address to evaluate.
     chain_log:
-        If ``True`` append the activation event to ``CHAIN_LOG_PATH``.
+        If ``True`` append the activation event to ``CHAIN_LOG_PATH`` with score.
     webhook:
         Optional URL to POST activation data to.
     """
@@ -244,7 +259,7 @@ def evaluate_wallet(
             result["timestamp"] = trigger_entry["timestamp"]
             _log_trigger(result)
             if chain_log:
-                log_chain_event(wallet_id, tier, result["timestamp"])
+                log_chain_event(wallet_id, tier, score, result["timestamp"])
             if webhook:
                 send_to_webhook(webhook, wallet_id, tier, score)
     return result

--- a/tests/test_belief_trigger_engine.py
+++ b/tests/test_belief_trigger_engine.py
@@ -54,6 +54,14 @@ class BeliefTriggerEngineTest(unittest.TestCase):
         chain_data = json.loads(CHAIN_LOG_PATH.read_text())
         self.assertEqual(chain_data[0]['wallet'], 'spark_wallet')
         self.assertEqual(chain_data[0]['tier'], 'Spark')
+        self.assertEqual(chain_data[0]['score'], 10)
+        self.assertIn('timestamp', chain_data[0])
+
+    def test_no_chain_no_webhook(self):
+        with patch('urllib.request.urlopen') as mock_url:
+            evaluate_wallet('spark_wallet')
+            self.assertEqual(mock_url.call_count, 0)
+        self.assertFalse(CHAIN_LOG_PATH.exists())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- store score along with wallet, tier, and timestamp in the chain log
- log chain events and webhook dispatch from both `activate_belief_reward` and `evaluate_wallet`
- update unit tests for chain logging and webhook behaviour

## Testing
- `npm test`
- `python -m unittest tests.test_belief_trigger_engine -v`

------
https://chatgpt.com/codex/tasks/task_e_68843a13016883229b41182a869fbfeb