### PR TITLE
Extend belief trigger chain logging

### DIFF
--- a/belief_trigger_engine.py
+++ b/belief_trigger_engine.py
@@ -77,11 +77,19 @@ def send_to_webhook(url: str | None, wallet: str, tier: str, score: int) -> None
 
 
 def log_chain_event(wallet: str, tier: str, score: int, timestamp: str) -> None:
-    """Record a chain-style log entry with score and timestamp."""
-    _append_json(
-        CHAIN_LOG_PATH,
-        {"wallet": wallet, "tier": tier, "score": score, "timestamp": timestamp},
-    )
+    """Record a chain-style log entry.
+
+    Entries include wallet address, reward tier, score and timestamp to
+    satisfy audit requirements. Keys are ordered to match the Vaultfire
+    chain specification.
+    """
+    entry = {
+        "wallet": wallet,
+        "tier": tier,
+        "score": score,
+        "timestamp": timestamp,
+    }
+    _append_json(CHAIN_LOG_PATH, entry)
 
 
 # Trigger functions ----------------------------------------------------------

--- a/tests/test_belief_trigger_engine.py
+++ b/tests/test_belief_trigger_engine.py
@@ -50,11 +50,20 @@ class BeliefTriggerEngineTest(unittest.TestCase):
                 webhook='http://localhost/web'
             )
             self.assertEqual(mock_url.call_count, 1)
+            request_obj = mock_url.call_args[0][0]
+            payload = json.loads(request_obj.data.decode('utf-8'))
+            self.assertEqual(payload['wallet'], 'spark_wallet')
+            self.assertEqual(payload['tier'], 'Spark')
+            self.assertEqual(payload['score'], 10)
         self.assertTrue(CHAIN_LOG_PATH.exists())
         chain_data = json.loads(CHAIN_LOG_PATH.read_text())
-        self.assertEqual(chain_data[0]['wallet'], 'spark_wallet')
-        self.assertEqual(chain_data[0]['tier'], 'Spark')
-        self.assertEqual(chain_data[0]['score'], 10)
+        expected = {
+            'wallet': 'spark_wallet',
+            'tier': 'Spark',
+            'score': 10,
+        }
+        for key, value in expected.items():
+            self.assertEqual(chain_data[0][key], value)
         self.assertIn('timestamp', chain_data[0])
 
     def test_no_chain_no_webhook(self):
@@ -62,6 +71,17 @@ class BeliefTriggerEngineTest(unittest.TestCase):
             evaluate_wallet('spark_wallet')
             self.assertEqual(mock_url.call_count, 0)
         self.assertFalse(CHAIN_LOG_PATH.exists())
+
+    def test_activate_reward_chain_log(self):
+        from belief_trigger_engine import activate_belief_reward
+
+        activate_belief_reward('flame_wallet', 65, chain_log=True)
+        chain_data = json.loads(CHAIN_LOG_PATH.read_text())
+        entry = chain_data[0]
+        self.assertEqual(entry['wallet'], 'flame_wallet')
+        self.assertEqual(entry['tier'], 'loyalty')
+        self.assertEqual(entry['score'], 65)
+        self.assertIn('timestamp', entry)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- include wallet, tier, score and timestamp in chain event entries
- verify webhook payload contains all metadata
- add tests for activate_belief_reward chain logging

## Testing
- `python -m unittest tests.test_belief_trigger_engine`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68843ba4a0d48322867e8b06dd68af14