### PR TITLE
Update belief trigger logging

### DIFF
--- a/belief_trigger_engine.py
+++ b/belief_trigger_engine.py
@@ -68,11 +68,22 @@ def send_webhook(url: str, payload: dict) -> None:
         pass
 
 
-def send_to_webhook(url: str | None, wallet: str, tier: str, score: int) -> None:
+def send_to_webhook(
+    url: str | None,
+    wallet: str,
+    tier: str,
+    score: int,
+    timestamp: str,
+) -> None:
     """Send activation data to ``url`` if provided."""
     if not url:
         return
-    payload = {"wallet": wallet, "tier": tier, "score": score}
+    payload = {
+        "wallet": wallet,
+        "tier": tier,
+        "score": score,
+        "timestamp": timestamp,
+    }
     send_webhook(url, payload)
 
 
@@ -212,7 +223,7 @@ def activate_belief_reward(
     if chain_log:
         log_chain_event(wallet_id, tier, score, result["timestamp"])
     if webhook:
-        send_to_webhook(webhook, wallet_id, tier, score)
+        send_to_webhook(webhook, wallet_id, tier, score, result["timestamp"])
     return result
 
 
@@ -269,7 +280,7 @@ def evaluate_wallet(
             if chain_log:
                 log_chain_event(wallet_id, tier, score, result["timestamp"])
             if webhook:
-                send_to_webhook(webhook, wallet_id, tier, score)
+                send_to_webhook(webhook, wallet_id, tier, score, result["timestamp"])
     return result
 
 

--- a/live_flame_scan.py
+++ b/live_flame_scan.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
@@ -106,7 +107,7 @@ def create_app(log_path: Path = DEFAULT_LOG, webhook: str | None = None, chain: 
         wallet = payload.get("wallet")
         tier = payload.get("tier")
         score = payload.get("score")
-        send_to_webhook(webhook, wallet, tier, int(score))
+        send_to_webhook(webhook, wallet, tier, int(score), datetime.utcnow().isoformat())
         return jsonify({"sent": bool(webhook)})
 
     return app

--- a/tests/test_belief_trigger_engine.py
+++ b/tests/test_belief_trigger_engine.py
@@ -52,6 +52,7 @@ class BeliefTriggerEngineTest(unittest.TestCase):
             self.assertEqual(mock_url.call_count, 1)
             request_obj = mock_url.call_args[0][0]
             payload = json.loads(request_obj.data.decode('utf-8'))
+            self.assertEqual(list(payload.keys()), ['wallet', 'tier', 'score', 'timestamp'])
             self.assertEqual(payload['wallet'], 'spark_wallet')
             self.assertEqual(payload['tier'], 'Spark')
             self.assertEqual(payload['score'], 10)
@@ -65,6 +66,8 @@ class BeliefTriggerEngineTest(unittest.TestCase):
         for key, value in expected.items():
             self.assertEqual(chain_data[0][key], value)
         self.assertIn('timestamp', chain_data[0])
+        self.assertEqual(payload['timestamp'], chain_data[0]['timestamp'])
+        self.assertEqual(list(chain_data[0].keys()), ['wallet', 'tier', 'score', 'timestamp'])
 
     def test_no_chain_no_webhook(self):
         with patch('urllib.request.urlopen') as mock_url:
@@ -82,6 +85,13 @@ class BeliefTriggerEngineTest(unittest.TestCase):
         self.assertEqual(entry['tier'], 'loyalty')
         self.assertEqual(entry['score'], 65)
         self.assertIn('timestamp', entry)
+        self.assertEqual(list(entry.keys()), ['wallet', 'tier', 'score', 'timestamp'])
+
+    def test_activate_reward_no_chain_without_flag(self):
+        from belief_trigger_engine import activate_belief_reward
+
+        activate_belief_reward('flame_wallet', 65, chain_log=False)
+        self.assertFalse(CHAIN_LOG_PATH.exists())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- enforce audit-ready log structure with timestamp for webhook data
- verify webhook metadata and log entries in unit tests
- adjust live flame scan to pass timestamp to webhook

## Testing
- `python -m unittest tests.test_belief_trigger_engine`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68843d3529b48322a3c4203771cae73e