### PR TITLE
Enforce webhook chain log sync

### DIFF
--- a/belief_trigger_engine.py
+++ b/belief_trigger_engine.py
@@ -107,7 +107,7 @@ def log_chain_event(wallet: str, tier: str, score: int, timestamp: str) -> None:
 
 def bonus_drop(wallet_id: str) -> dict:
     result = {
-        "wallet_id": wallet_id,
+        "wallet": wallet_id,
         "trigger": "bonus_drop",
         "timestamp": datetime.utcnow().isoformat(),
     }
@@ -116,7 +116,7 @@ def bonus_drop(wallet_id: str) -> dict:
 
 def unlock_nft_trait(wallet_id: str) -> dict:
     result = {
-        "wallet_id": wallet_id,
+        "wallet": wallet_id,
         "trigger": "unlock_nft_trait",
         "timestamp": datetime.utcnow().isoformat(),
     }
@@ -125,7 +125,7 @@ def unlock_nft_trait(wallet_id: str) -> dict:
 
 def claim_reward(wallet_id: str) -> dict:
     result = {
-        "wallet_id": wallet_id,
+        "wallet": wallet_id,
         "trigger": "claim_reward",
         "timestamp": datetime.utcnow().isoformat(),
     }
@@ -144,7 +144,7 @@ TRIGGERS = {
 def high_tier_reward(wallet_id: str) -> dict:
     """Reward for very high belief scores."""
     result = {
-        "wallet_id": wallet_id,
+        "wallet": wallet_id,
         "trigger": "high_tier_reward",
         "message": "\ud83d\udd25 Flame Unlocked",
         "timestamp": datetime.utcnow().isoformat(),
@@ -154,7 +154,7 @@ def high_tier_reward(wallet_id: str) -> dict:
 
 def mid_tier_reward(wallet_id: str) -> dict:
     result = {
-        "wallet_id": wallet_id,
+        "wallet": wallet_id,
         "trigger": "mid_tier_reward",
         "timestamp": datetime.utcnow().isoformat(),
     }
@@ -163,7 +163,7 @@ def mid_tier_reward(wallet_id: str) -> dict:
 
 def loyalty_ping(wallet_id: str) -> dict:
     result = {
-        "wallet_id": wallet_id,
+        "wallet": wallet_id,
         "trigger": "loyalty_ping",
         "timestamp": datetime.utcnow().isoformat(),
     }
@@ -172,7 +172,7 @@ def loyalty_ping(wallet_id: str) -> dict:
 
 def belief_boost_suggestion(wallet_id: str) -> dict:
     result = {
-        "wallet_id": wallet_id,
+        "wallet": wallet_id,
         "trigger": "belief_boost_suggestion",
         "timestamp": datetime.utcnow().isoformat(),
     }
@@ -213,7 +213,7 @@ def activate_belief_reward(
         tier = "boost"
     trigger_entry = func(wallet_id)
     result = {
-        "wallet_id": wallet_id,
+        "wallet": wallet_id,
         "score": score,
         "tier": tier,
         "trigger": trigger_entry["trigger"],
@@ -264,7 +264,7 @@ def evaluate_wallet(
             break
 
     result = {
-        "wallet_id": wallet_id,
+        "wallet": wallet_id,
         "score": score,
         "tier": tier,
         "drop_score": loyalty.get("drop_score"),
@@ -327,7 +327,7 @@ def main() -> None:
 
     if LOG_PATH.exists():
         data = json.loads(LOG_PATH.read_text())
-        active = {e["wallet_id"] for e in data}
+        active = {e.get("wallet") for e in data}
         print("Active wallets:", ", ".join(sorted(active)))
     else:
         print("No active wallets")

--- a/tests/test_belief_trigger_engine.py
+++ b/tests/test_belief_trigger_engine.py
@@ -31,7 +31,7 @@ class BeliefTriggerEngineTest(unittest.TestCase):
         evaluate_wallet('flame_wallet')
         evaluate_wallet('inferno_wallet')
         data = json.loads(LOG_PATH.read_text())
-        triggers = {d['wallet_id']: d['trigger'] for d in data}
+        triggers = {d['wallet']: d['trigger'] for d in data}
         self.assertEqual(triggers['spark_wallet'], 'bonus_drop')
         self.assertEqual(triggers['torch_wallet'], 'unlock_nft_trait')
         self.assertEqual(triggers['flame_wallet'], 'claim_reward')

--- a/tests/test_live_flame_scan.py
+++ b/tests/test_live_flame_scan.py
@@ -23,7 +23,7 @@ class LiveFlameScanTest(unittest.TestCase):
         with patch('urllib.request.urlopen') as mock_url:
             results = process_scores(scores, Path('test_flame_log.json'), webhook='http://localhost/web', chain=True)
             self.assertEqual(mock_url.call_count, 4)
-        triggers = {r['wallet_id']: r['trigger'] for r in results}
+        triggers = {r['wallet']: r['trigger'] for r in results}
         self.assertEqual(triggers['high_wallet'], 'high_tier_reward')
         self.assertEqual(triggers['mid_wallet'], 'mid_tier_reward')
         self.assertEqual(triggers['loyal_wallet'], 'loyalty_ping')


### PR DESCRIPTION
## Summary
- add canonical wallet key to belief trigger logs
- keep chain log and webhook metadata in sync
- adjust live flame scan tests

## Testing
- `python -m unittest tests.test_belief_trigger_engine tests.test_live_flame_scan`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68843e62c2bc8322bf5cf70ac40842cd