### PR TITLE
Verify webhook parity

### DIFF
--- a/tests/test_live_flame_scan.py
+++ b/tests/test_live_flame_scan.py
@@ -21,8 +21,19 @@ class LiveFlameScanTest(unittest.TestCase):
             'boost_wallet': 20,
         }
         with patch('urllib.request.urlopen') as mock_url:
-            results = process_scores(scores, Path('test_flame_log.json'), webhook='http://localhost/web', chain=True)
+            results = process_scores(
+                scores,
+                Path('test_flame_log.json'),
+                webhook='http://localhost/web',
+                chain=True,
+            )
             self.assertEqual(mock_url.call_count, 4)
+            request_obj = mock_url.call_args_list[0][0][0]
+            payload = json.loads(request_obj.data.decode('utf-8'))
+            self.assertEqual(
+                list(payload.keys()),
+                ['wallet', 'tier', 'score', 'timestamp']
+            )
         triggers = {r['wallet']: r['trigger'] for r in results}
         self.assertEqual(triggers['high_wallet'], 'high_tier_reward')
         self.assertEqual(triggers['mid_wallet'], 'mid_tier_reward')
@@ -32,6 +43,12 @@ class LiveFlameScanTest(unittest.TestCase):
         self.assertEqual(len(log), 4)
         chain_log = json.loads(CHAIN_LOG_PATH.read_text())
         self.assertEqual(len(chain_log), 4)
+        self.assertEqual(
+            list(chain_log[0].keys()),
+            ['wallet', 'tier', 'score', 'timestamp']
+        )
+        self.assertEqual(payload['timestamp'], chain_log[0]['timestamp'])
+        self.assertEqual(payload['timestamp'], results[0]['timestamp'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- check webhook and chain log payload order in live flame scan

## Testing
- `python -m unittest tests.test_belief_trigger_engine tests.test_live_flame_scan`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68843ff18668832298e0b1ba2e5d1ad2