### PR TITLE
Finalize wallet metadata sync

### DIFF
--- a/belief_trigger_engine.py
+++ b/belief_trigger_engine.py
@@ -214,10 +214,10 @@ def activate_belief_reward(
     trigger_entry = func(wallet_id)
     result = {
         "wallet": wallet_id,
-        "score": score,
         "tier": tier,
-        "trigger": trigger_entry["trigger"],
+        "score": score,
         "timestamp": trigger_entry["timestamp"],
+        "trigger": trigger_entry["trigger"],
     }
     _log_trigger(result)
     if chain_log:
@@ -265,8 +265,8 @@ def evaluate_wallet(
 
     result = {
         "wallet": wallet_id,
-        "score": score,
         "tier": tier,
+        "score": score,
         "drop_score": loyalty.get("drop_score"),
     }
 
@@ -274,8 +274,8 @@ def evaluate_wallet(
         func = TRIGGERS.get(tier)
         if func:
             trigger_entry = func(wallet_id)
-            result["trigger"] = trigger_entry["trigger"]
             result["timestamp"] = trigger_entry["timestamp"]
+            result["trigger"] = trigger_entry["trigger"]
             _log_trigger(result)
             if chain_log:
                 log_chain_event(wallet_id, tier, score, result["timestamp"])

--- a/tests/test_live_flame_scan.py
+++ b/tests/test_live_flame_scan.py
@@ -34,6 +34,10 @@ class LiveFlameScanTest(unittest.TestCase):
                 list(payload.keys()),
                 ['wallet', 'tier', 'score', 'timestamp']
             )
+            self.assertEqual(
+                list(results[0].keys()),
+                ['wallet', 'tier', 'score', 'timestamp', 'trigger']
+            )
         triggers = {r['wallet']: r['trigger'] for r in results}
         self.assertEqual(triggers['high_wallet'], 'high_tier_reward')
         self.assertEqual(triggers['mid_wallet'], 'mid_tier_reward')


### PR DESCRIPTION
## Summary
- enforce consistent key order for belief reward payloads
- ensure first result entry has wallet tier score timestamp trigger order

## Testing
- `python -m unittest tests.test_belief_trigger_engine`
- `python -m unittest tests.test_live_flame_scan`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688440de818883229cac3fb3731bb4cb