### PR TITLE
Add optional EXIF removal in GeoLock

### DIFF
--- a/geolock_filter.py
+++ b/geolock_filter.py
@@ -2,10 +2,30 @@
 from __future__ import annotations
 
 from pathlib import Path
+from io import BytesIO
+
+
+try:  # Pillow is optional
+    from PIL import Image  # type: ignore
+except Exception:  # pragma: no cover - Pillow may not be installed
+    Image = None  # type: ignore
 
 
 def strip_exif(data: bytes, blur_faces: bool = False) -> bytes:
-    """Remove simple GPS markers from ``data``."""
+    """Remove basic EXIF information including GPS markers.
+
+    Falls back to a simple byte replace if Pillow is unavailable. ``blur_faces``
+    is accepted for API compatibility but not implemented.
+    """
+    if Image:
+        try:
+            img = Image.open(BytesIO(data))
+            img.info.pop("exif", None)
+            out = BytesIO()
+            img.save(out, format=img.format or "JPEG")
+            data = out.getvalue()
+        except Exception:  # pragma: no cover - pillow errors fall back
+            data = data
     return data.replace(b"GPS", b"")
 
 


### PR DESCRIPTION
## Summary
- improve `geolock_filter.strip_exif` to optionally remove EXIF data using Pillow when available
- keep original GPS byte filter as a fallback
- maintain existing secure upload and belief trigger pipeline functionality

## Testing
- `python -m pytest tests/test_belief_trigger_engine.py tests/test_flame_scan.py tests/test_live_flame_scan.py tests/test_secure_upload.py -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688445d289e08322b60a56aab74f7421