### PR TITLE
Add Vaultfire secure upload activation drop

### DIFF
--- a/build_drop.sh
+++ b/build_drop.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+zip -r vaultfire_activation.zip secure_upload docs/activation_drop vaultfire_drop.json signal_log.py

--- a/docs/activation_drop/README.md
+++ b/docs/activation_drop/README.md
@@ -1,0 +1,12 @@
+# Vaultfire Secure Upload Activation Drop
+
+This bundle provides a minimal partner-ready upload system for Vaultfire v1.0 (Activation Build).
+It includes backend modules for encrypted storage, a webhook for validation, and example tests.
+
+## Contents
+- `secure_upload/` – Python package with upload pipeline
+- `tests/` – pytest suite covering the pipeline
+- `build_drop.sh` – helper script to create a zip archive
+- `vaultfire_drop.json` – metadata about this release
+
+See `activation_notes.txt` for setup instructions.

--- a/docs/activation_drop/activation_notes.txt
+++ b/docs/activation_drop/activation_notes.txt
@@ -1,0 +1,5 @@
+Activation Notes
+----------------
+1. Install dependencies using `pip install -r requirements.txt`.
+2. Run `pytest` to verify the upload pipeline.
+3. Use `build_drop.sh` to create `vaultfire_activation.zip` for distribution.

--- a/docs/activation_drop/vaultfire_manifesto.md
+++ b/docs/activation_drop/vaultfire_manifesto.md
@@ -1,0 +1,3 @@
+# Vaultfire Manifesto
+
+Vaultfire operates on a belief-linked security model. All uploads are opt-in and participants maintain control over their data. This framework is provided under the Ghostkey ethics guidelines to ensure transparency and trust.

--- a/install_notes.txt
+++ b/install_notes.txt
@@ -1,0 +1,3 @@
+Manual Setup
+------------
+If network installs fail, install Python packages manually using wheel files and run `npm install` from the repository root.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask
 web3
 ens
 psutil
+cryptography

--- a/secure_upload/__init__.py
+++ b/secure_upload/__init__.py
@@ -1,0 +1,5 @@
+"""Vaultfire v1.0 Secure Upload package."""
+from .store import SecureStore, create_store
+from .pipeline import upload_file
+
+__all__ = ["SecureStore", "create_store", "upload_file"]

--- a/secure_upload/pipeline.py
+++ b/secure_upload/pipeline.py
@@ -1,0 +1,33 @@
+"""High level secure upload pipeline."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from belief_trigger_engine import evaluate_wallet
+from vaultfire_securestore import SecureStore
+
+__all__ = ["upload_file"]
+
+
+def upload_file(
+    store: SecureStore,
+    file_path: Path,
+    wallet: str,
+    tier: str,
+    score: int,
+    *,
+    webhook: str | None = None,
+    chain_log: bool = True,
+) -> dict[str, Any]:
+    """Process ``file_path`` through SecureStore and belief engine."""
+    meta = store.encrypt_and_store(
+        file_path,
+        wallet,
+        tier,
+        score,
+        webhook=webhook,
+        chain_log=chain_log,
+    )
+    evaluate_wallet(wallet, chain_log=chain_log, webhook=webhook)
+    return meta

--- a/secure_upload/store.py
+++ b/secure_upload/store.py
@@ -1,0 +1,10 @@
+"""Wrapper around :mod:`vaultfire_securestore` with convenience helpers."""
+from pathlib import Path
+from vaultfire_securestore import SecureStore
+
+__all__ = ["SecureStore", "create_store"]
+
+
+def create_store(key: bytes, bucket: str | Path) -> SecureStore:
+    """Return a :class:`SecureStore` using ``bucket`` path."""
+    return SecureStore(key, Path(bucket))

--- a/signal_log.py
+++ b/signal_log.py
@@ -1,0 +1,21 @@
+"""Simple signal logger."""
+import json
+from datetime import datetime
+from pathlib import Path
+
+LOG_PATH = Path("signal_events.json")
+
+
+def log_signal(event: str, meta: dict | None = None) -> None:
+    entry = {"event": event, "timestamp": datetime.utcnow().isoformat()}
+    if meta:
+        entry["meta"] = meta
+    if LOG_PATH.exists():
+        try:
+            data = json.loads(LOG_PATH.read_text())
+        except Exception:
+            data = []
+    else:
+        data = []
+    data.append(entry)
+    LOG_PATH.write_text(json.dumps(data, indent=2))

--- a/tests/test_secure_upload_pipeline.py
+++ b/tests/test_secure_upload_pipeline.py
@@ -1,0 +1,11 @@
+import tempfile
+from pathlib import Path
+from secure_upload import create_store, upload_file
+
+
+def test_upload_pipeline(tmp_path):
+    store = create_store(b"0" * 32, tmp_path / "bucket")
+    src = tmp_path / "test.bin"
+    src.write_bytes(b"GPSDATA")
+    meta = upload_file(store, src, "w1", "Spark", 5, webhook=None, chain_log=False)
+    assert (tmp_path / "bucket" / f"{meta['cid']}.bin").exists()

--- a/vaultfire_drop.json
+++ b/vaultfire_drop.json
@@ -1,0 +1,7 @@
+{
+  "name": "Vaultfire v1.0 Activation Build",
+  "version": "1.0",
+  "ens": "ghostkey316.eth",
+  "commit": "ae05d1819b76c12dcf39f9803eabbce954734292",
+  "docs": "docs/activation_drop/README.md"
+}


### PR DESCRIPTION
## Summary
- introduce `secure_upload` package with pipeline helpers
- add drop documentation and metadata for activation
- include simple signal logger and build script
- provide pytest for upload pipeline and update requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'partner_plugins')*
- `PYTHONPATH=. pytest tests/test_secure_upload_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68844c3724a483228f42a33d36797a75