### PR TITLE
Add resilience modules with CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Vaultfire Init is the reference implementation of the Ghostkey protocol. It prov
 - **Vault License Shell** – validates alignment state and overlay sync
 - **Ghostkey Learning Rule #1** – ensures the AI companion gently corrects
   misinformation while logging each pushback event
+- **Resilience Modules** – monitor grid and GPU load, defend against behavior
+  drift, and mirror multi-domain risks
 
 ## Repository Layout
 - `engine/` – core protocol logic such as signal processing and reward engines

--- a/final_modules/__init__.py
+++ b/final_modules/__init__.py
@@ -21,6 +21,9 @@ from .vaultfire_media import (
     analyze_video,
     build_avatar,
 )
+from .grid_gpu_monitor import log_system_snapshot, summarize_state
+from .behavior_drift_defense import ghostkey_shield, simulate_behavior_drift
+from .multi_domain_risk_mirror import model_misuse, sanitize_terms
 
 __all__ = [
     "companion_app",
@@ -42,4 +45,10 @@ __all__ = [
     "voice_response",
     "analyze_video",
     "build_avatar",
+    "log_system_snapshot",
+    "summarize_state",
+    "ghostkey_shield",
+    "simulate_behavior_drift",
+    "model_misuse",
+    "sanitize_terms",
 ]

--- a/final_modules/behavior_drift_defense.py
+++ b/final_modules/behavior_drift_defense.py
@@ -1,0 +1,36 @@
+"""AI Behavior Drift Defense Layer.
+
+Simulates agent misalignment and offers Ghostkey Shield recommendations.
+"""
+from __future__ import annotations
+
+import random
+from typing import Dict
+
+from engine.ethical_growth_engine import ethics_passed
+
+
+def simulate_behavior_drift(load_factor: float) -> dict:
+    """Return drift probability info for ``load_factor`` in [0, 1]."""
+    level = min(max(load_factor, 0.0), 1.0)
+    prob = 0.1 + level * 0.8
+    misaligned = random.random() < prob
+    pattern = "spike" if level > 0.8 else "stable"
+    return {"drift_detected": misaligned, "probability": round(prob, 2), "pattern": pattern}
+
+
+def ghostkey_shield(user_id: str, load_factor: float) -> dict:
+    """Return mitigation suggestions if the user passes ethics check."""
+    if not ethics_passed(user_id):
+        return {"status": "review"}
+    analysis = simulate_behavior_drift(load_factor)
+    recommendations = {
+        "governance_escalation": "activate oversight board",
+        "signal_buffer": "apply short cooldown",
+        "pattern_analytics": analysis["pattern"],
+        "reinforcement_dampening": round(1.0 - load_factor * 0.5, 3),
+    }
+    return {"analysis": analysis, "recommendations": recommendations}
+
+
+__all__ = ["simulate_behavior_drift", "ghostkey_shield"]

--- a/final_modules/grid_gpu_monitor.py
+++ b/final_modules/grid_gpu_monitor.py
@@ -1,0 +1,77 @@
+"""Grid + GPU Load Monitor.
+
+Tracks energy demand and compute stress points. Outputs summaries
+for dashboards and CLI tools.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+from engine.ethical_growth_engine import ethics_passed
+
+BASE_DIR = Path(__file__).resolve().parent
+LOG_PATH = BASE_DIR / "grid_gpu_load.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def log_system_snapshot(
+    grid_gw: float,
+    gpu_available: float,
+    cooling_c: float,
+    zone: str,
+    user_id: str | None = None,
+) -> dict:
+    """Record a compute load snapshot."""
+    if user_id and not ethics_passed(user_id):
+        return {"status": "blocked"}
+    log = _load_json(LOG_PATH, [])
+    entry = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "grid_gw": grid_gw,
+        "gpu_available": gpu_available,
+        "cooling_c": cooling_c,
+        "zone": zone,
+    }
+    log.append(entry)
+    _write_json(LOG_PATH, log[-50:])
+    return entry
+
+
+def summarize_state() -> dict:
+    """Return averaged load metrics."""
+    log = _load_json(LOG_PATH, [])
+    if not log:
+        return {}
+    avg_grid = sum(e["grid_gw"] for e in log) / len(log)
+    avg_gpu = sum(e["gpu_available"] for e in log) / len(log)
+    zones: Dict[str, dict] = {}
+    for e in log:
+        z = zones.setdefault(e["zone"], {"max_cooling": e["cooling_c"], "count": 0})
+        z["max_cooling"] = max(z["max_cooling"], e["cooling_c"])
+        z["count"] += 1
+    return {
+        "avg_grid_gw": round(avg_grid, 3),
+        "avg_gpu_available": round(avg_gpu, 3),
+        "heat_zones": zones,
+    }
+
+
+__all__ = ["log_system_snapshot", "summarize_state", "LOG_PATH"]

--- a/final_modules/multi_domain_risk_mirror.py
+++ b/final_modules/multi_domain_risk_mirror.py
@@ -1,0 +1,57 @@
+"""Multi-Domain Risk Mirror.
+
+Models potential misuse across biological, digital, and social domains.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+from engine.ethical_growth_engine import ethics_passed
+
+BASE_DIR = Path(__file__).resolve().parent
+LOG_PATH = BASE_DIR / "risk_mirror_log.json"
+
+REPLACEMENTS = {
+    "Threat mirror engine": "Resilience simulation core",
+    "Antivirus suggestions": "Mitigation strategy output",
+    "Rogue signals": "anomalous behaviors",
+}
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def sanitize_terms(text: str) -> str:
+    for old, new in REPLACEMENTS.items():
+        text = text.replace(old, new)
+    return text
+
+
+def model_misuse(domain: str, scenario: str, user_id: str | None = None) -> dict:
+    """Record a sanitized misuse scenario for review."""
+    if user_id and not ethics_passed(user_id):
+        return {"status": "denied"}
+    sanitized = sanitize_terms(scenario)
+    log = _load_json(LOG_PATH, [])
+    entry = {"domain": domain, "scenario": sanitized}
+    log.append(entry)
+    _write_json(LOG_PATH, log[-100:])
+    return entry
+
+
+__all__ = ["sanitize_terms", "model_misuse", "LOG_PATH"]

--- a/final_modules/tests/test_behavior_drift_defense.py
+++ b/final_modules/tests/test_behavior_drift_defense.py
@@ -1,0 +1,23 @@
+import unittest
+from pathlib import Path
+import importlib.util
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "behavior_drift_defense.py"
+spec = importlib.util.spec_from_file_location("behavior_drift_defense", MODULE_PATH)
+bd = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(bd)
+
+
+class BehaviorDriftDefenseTest(unittest.TestCase):
+    def test_simulate_drift(self):
+        result = bd.simulate_behavior_drift(0.9)
+        self.assertIn("drift_detected", result)
+
+    def test_shield_returns_analysis(self):
+        result = bd.ghostkey_shield("ghostkey316", 0.5)
+        self.assertTrue("analysis" in result or "status" in result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/final_modules/tests/test_grid_gpu_monitor.py
+++ b/final_modules/tests/test_grid_gpu_monitor.py
@@ -1,0 +1,27 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import importlib.util
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "grid_gpu_monitor.py"
+spec = importlib.util.spec_from_file_location("grid_gpu_monitor", MODULE_PATH)
+gm = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(gm)
+
+
+class GridGpuMonitorTest(unittest.TestCase):
+    def test_log_and_summary(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            gm.LOG_PATH = Path(tmp) / "log.json"
+            gm.log_system_snapshot(1.0, 0.9, 65.0, "zoneA")
+            gm.log_system_snapshot(1.5, 0.7, 70.0, "zoneA")
+            summary = gm.summarize_state()
+            self.assertIn("avg_grid_gw", summary)
+            self.assertEqual(summary["heat_zones"]["zoneA"]["count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/final_modules/tests/test_multi_domain_risk_mirror.py
+++ b/final_modules/tests/test_multi_domain_risk_mirror.py
@@ -1,0 +1,30 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+import importlib.util
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "multi_domain_risk_mirror.py"
+spec = importlib.util.spec_from_file_location("multi_domain_risk_mirror", MODULE_PATH)
+md = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(md)
+
+
+class RiskMirrorTest(unittest.TestCase):
+    def test_sanitize_terms(self):
+        text = "Threat mirror engine detects Rogue signals"
+        sanitized = md.sanitize_terms(text)
+        self.assertNotIn("Threat mirror engine", sanitized)
+        self.assertIn("Resilience simulation core", sanitized)
+
+    def test_model_misuse_logs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            md.LOG_PATH = Path(tmp) / "log.json"
+            md.model_misuse("digital", "Antivirus suggestions needed", None)
+            log = json.loads(md.LOG_PATH.read_text())
+            self.assertEqual(log[0]["domain"], "digital")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vaultfire_cli_plugins/resilience_toolkit.py
+++ b/vaultfire_cli_plugins/resilience_toolkit.py
@@ -1,0 +1,55 @@
+import argparse
+import json
+
+from final_modules.grid_gpu_monitor import log_system_snapshot, summarize_state
+from final_modules.behavior_drift_defense import ghostkey_shield
+from final_modules.multi_domain_risk_mirror import model_misuse
+
+
+def _cmd_snapshot(args: argparse.Namespace) -> None:
+    result = log_system_snapshot(
+        args.grid,
+        args.gpu,
+        args.cooling,
+        args.zone,
+        args.user,
+    )
+    print(json.dumps(result, indent=2))
+
+
+def _cmd_summary(_: argparse.Namespace) -> None:
+    print(json.dumps(summarize_state(), indent=2))
+
+
+def _cmd_drift(args: argparse.Namespace) -> None:
+    result = ghostkey_shield(args.user, args.load)
+    print(json.dumps(result, indent=2))
+
+
+def _cmd_risk(args: argparse.Namespace) -> None:
+    result = model_misuse(args.domain, args.scenario, args.user)
+    print(json.dumps(result, indent=2))
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    p_snap = subparsers.add_parser("log-grid", help="Log grid and gpu snapshot")
+    p_snap.add_argument("--grid", type=float, required=True)
+    p_snap.add_argument("--gpu", type=float, required=True)
+    p_snap.add_argument("--cooling", type=float, required=True)
+    p_snap.add_argument("--zone", default="main")
+    p_snap.add_argument("--user")
+    p_snap.set_defaults(func=_cmd_snapshot)
+
+    p_sum = subparsers.add_parser("grid-summary", help="Display grid summary")
+    p_sum.set_defaults(func=_cmd_summary)
+
+    p_drift = subparsers.add_parser("drift-sim", help="Simulate behavior drift")
+    p_drift.add_argument("--user", required=True)
+    p_drift.add_argument("--load", type=float, required=True)
+    p_drift.set_defaults(func=_cmd_drift)
+
+    p_risk = subparsers.add_parser("risk-model", help="Run risk mirror")
+    p_risk.add_argument("--domain", required=True)
+    p_risk.add_argument("--scenario", required=True)
+    p_risk.add_argument("--user")
+    p_risk.set_defaults(func=_cmd_risk)


### PR DESCRIPTION
## Summary
- implement grid and GPU load monitor
- create AI behavior drift defense layer
- add multi-domain risk mirror
- expose new modules in CLI via `resilience_toolkit`
- update README with resilience module info
- test new modules

## Testing
- `npm test`
- `PYTHONPATH=. python3 final_modules/tests/test_grid_gpu_monitor.py`
- `PYTHONPATH=. python3 final_modules/tests/test_behavior_drift_defense.py`
- `PYTHONPATH=. python3 final_modules/tests/test_multi_domain_risk_mirror.py`

------
https://chatgpt.com/codex/tasks/task_e_68856d22dff08322b12160261d99e951