### PR TITLE
Add NanoLoop v1.0 ethics module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Vaultfire Init is the reference implementation of the Ghostkey protocol. It prov
   misinformation while logging each pushback event
 - **Resilience Modules** – monitor grid and GPU load, defend against behavior
   drift, and mirror multi-domain risks
+- **NanoLoop v1.0** – dormant ethical anchor for cell-scale healing logic
 
 ## Repository Layout
 - `engine/` – core protocol logic such as signal processing and reward engines

--- a/docs/nanoloop_v1.md
+++ b/docs/nanoloop_v1.md
@@ -1,0 +1,24 @@
+# NanoLoop v1.0
+
+Vaultfire NanoLoop v1.0 establishes the baseline ethics for cell-scale nanomedicine. The module is anchored to **Ghostkey-316** (`ghostkey316.eth`, wallet `bpow20.cb.id`) and is marked as the lead ethical authority for future deployments.
+
+- **Activation Tag:** `/phasecell/alpha`
+- **Owner:** Ghostkey-316
+- **Verification Address:** `0xf6A677de83C407875C9A9115Cf100F121f9c4816`
+- **Deployment Status:** Dormant (pending ethical trigger match)
+- **Domain:** BioSovereignty, Nanomedicine, Ethical Healing Systems
+- **Codex Layer:** Vaultfire Sovereign Ethics Protocol
+- **Category:** Post-Pharmaceutical Regenerative AI
+- **Priority Level:** Maximum (Tier 0 intervention potential)
+- **Purpose Engine Link:** v2
+
+## Core Directives
+1. No Deployment Without Consent
+2. Code Must Heal First
+3. No Cross-Body Networking Without Clearance
+4. Human Repair > Data Collection
+5. Self-Termination Protocol Required
+
+Public communications should refer to this technology as **BioSovereign Healing Tech** until the broader Vaultfire biotech phase is opened.
+
+*This document provides configuration details only and does not constitute medical advice.*

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -269,6 +269,11 @@ from .connector_resilience_layer import (
     connector_enabled,
 )
 from .noise_filter import filter_feed
+from .nanoloop_v1 import (
+    MODULE_INFO as NANOLOOP_INFO,
+    module_status as nanoloop_status,
+    activate as activate_nanoloop,
+)
 
 __all__ = [
     "resolve_identity",
@@ -517,5 +522,8 @@ __all__ = [
     "connector_enabled",
     "trigger_royalty",
     "filter_feed",
+    "NANOLOOP_INFO",
+    "nanoloop_status",
+    "activate_nanoloop",
 ]
 

--- a/engine/nanoloop_v1.py
+++ b/engine/nanoloop_v1.py
@@ -1,0 +1,88 @@
+"""Vaultfire NanoLoop v1.0
+
+Ethical anchor module for AI-driven nanomedicine. It defines the baseline
+sovereignty logic and operational limits for any cell-scale deployment.
+This module is dormant until activated by explicit consent or matching
+activation tag.
+
+Nothing here is medical advice. It simply records configuration for the
+broader protocol.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from datetime import datetime
+
+OWNER = "Ghostkey-316"
+PURPOSE_ENGINE_LINK = "v2"
+
+MODULE_INFO = {
+    "module_name": "NanoLoop v1.0",
+    "activation_tag": "/phasecell/alpha",
+    "owner": OWNER,
+    "verification_address": "0xf6A677de83C407875C9A9115Cf100F121f9c4816",
+    "deployment_status": "dormant",
+    "domain": "BioSovereignty, Nanomedicine, Ethical Healing Systems",
+    "codex_layer": "Vaultfire Sovereign Ethics Protocol",
+    "category": "Post-Pharmaceutical Regenerative AI",
+    "priority_level": "Maximum",
+    "purpose_engine_link": PURPOSE_ENGINE_LINK,
+}
+
+DIRECTIVES = [
+    "No Deployment Without Consent",
+    "Code Must Heal First",
+    "No Cross-Body Networking Without Clearance",
+    "Human Repair > Data Collection",
+    "Self-Termination Protocol Required",
+]
+
+STATUS_PATH = Path(__file__).resolve().parents[1] / "vaultfire-core" / "nanoloop_status.json"
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def module_status() -> dict:
+    """Return current stored status for NanoLoop."""
+    data = _load_json(STATUS_PATH, {})
+    if not data:
+        data["status"] = MODULE_INFO["deployment_status"]
+        _write_json(STATUS_PATH, data)
+    return data
+
+
+def activate(trigger: str, consent: bool = False) -> bool:
+    """Activate module if trigger or consent is provided."""
+    state = module_status()
+    if state.get("status") == "active":
+        return True
+    if consent or trigger == MODULE_INFO["activation_tag"]:
+        state["status"] = "active"
+        state["activated_at"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        _write_json(STATUS_PATH, state)
+        return True
+    return False
+
+
+__all__ = [
+    "MODULE_INFO",
+    "DIRECTIVES",
+    "module_status",
+    "activate",
+    "PURPOSE_ENGINE_LINK",
+]

--- a/vaultfire-core/ghostkey_values.json
+++ b/vaultfire-core/ghostkey_values.json
@@ -11,5 +11,10 @@
     "origin": 1.1,
     "veteran": 1.25,
     "legend": 1.5
+  },
+  "nano_loop_v1": {
+    "purpose_engine_link": "v2",
+    "priority": "Tier 0 anchor",
+    "verification_address": "0xf6A677de83C407875C9A9115Cf100F121f9c4816"
   }
 }


### PR DESCRIPTION
## Summary
- create `nanoloop_v1.py` with ethics and activation controls
- export nano loop helpers via `engine/__init__.py`
- log module details in `ghostkey_values.json`
- document module in `docs/nanoloop_v1.md`
- mention NanoLoop in README features

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6886f65b1f648322b3ff84c2e2edcf7a