### PR TITLE
Add NanoLoop v1.1 regenerative module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Vaultfire Init is the reference implementation of the Ghostkey protocol. It prov
 - **Resilience Modules** – monitor grid and GPU load, defend against behavior
   drift, and mirror multi-domain risks
 - **NanoLoop v1.0** – dormant ethical anchor for cell-scale healing logic
+- **NanoLoop v1.1** – regenerative operations with trauma stabilization and
+  adaptive tissue encoding
 
 ## Repository Layout
 - `engine/` – core protocol logic such as signal processing and reward engines

--- a/docs/nanoloop_v1_1.md
+++ b/docs/nanoloop_v1_1.md
@@ -1,0 +1,20 @@
+# NanoLoop v1.1
+
+NanoLoop v1.1 extends the original module with regenerative cell patterning,
+trauma stabilization and adaptive tissue encoding. It inherits all ethical
+guards from v1.0 and links healing cycles to Purpose Engine v2 via belief
+signals.
+
+- **Activation Tag:** `/phasecell/beta`
+- **Owner:** Ghostkey-316
+- **Purpose Engine Link:** v2
+
+The module records each regeneration step in an encrypted trust vault using the
+Vaultfire `SecureStore`. Logs are intended for medical auditability only.
+
+Command hooks are available in the Vaultfire CLI:
+- `nano.repair`
+- `nano.stabilize`
+- `nano.rebuild`
+
+*This document does not constitute medical advice.*

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -274,6 +274,14 @@ from .nanoloop_v1 import (
     module_status as nanoloop_status,
     activate as activate_nanoloop,
 )
+from .nanoloop_v1_1 import (
+    MODULE_INFO as NANOLOOP_V1_1_INFO,
+    module_status as nanoloop_v1_1_status,
+    activate as activate_nanoloop_v1_1,
+    repair_cell_pattern,
+    stabilize_trauma,
+    rebuild_tissue,
+)
 
 __all__ = [
     "resolve_identity",
@@ -525,5 +533,11 @@ __all__ = [
     "NANOLOOP_INFO",
     "nanoloop_status",
     "activate_nanoloop",
+    "NANOLOOP_V1_1_INFO",
+    "nanoloop_v1_1_status",
+    "activate_nanoloop_v1_1",
+    "repair_cell_pattern",
+    "stabilize_trauma",
+    "rebuild_tissue",
 ]
 

--- a/engine/nanoloop_v1_1.py
+++ b/engine/nanoloop_v1_1.py
@@ -1,0 +1,155 @@
+"""Vaultfire NanoLoop v1.1
+
+Extends the v1.0 cell-scale deployment module with regenerative
+operations, trauma stabilization, and adaptive tissue encoding.
+Ethical safeguards are inherited from ``nanoloop_v1`` and advanced
+healing cycles are linked to Purpose Engine v2 using belief signals.
+Nothing here is medical advice. It provides configuration and
+logging helpers only.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import Dict
+
+from .nanoloop_v1 import (
+    DIRECTIVES as V1_DIRECTIVES,
+    OWNER,
+    PURPOSE_ENGINE_LINK,
+)
+from vaultfire_securestore import SecureStore
+from .purpose_engine import record_traits
+
+
+MODULE_INFO = {
+    "module_name": "NanoLoop v1.1",
+    "activation_tag": "/phasecell/beta",
+    "owner": OWNER,
+    "verification_address": "0xf6A677de83C407875C9A9115Cf100F121f9c4816",
+    "deployment_status": "dormant",
+    "domain": "BioSovereignty, Nanomedicine, Ethical Healing Systems",
+    "codex_layer": "Vaultfire Sovereign Ethics Protocol",
+    "category": "Post-Pharmaceutical Regenerative AI",
+    "priority_level": "Maximum",
+    "purpose_engine_link": PURPOSE_ENGINE_LINK,
+}
+
+DIRECTIVES = V1_DIRECTIVES + [
+    "Autonomous Regeneration Allowed Under Consent",
+    "Trauma Stabilization Requires Verified Emergency",
+    "Adaptive Tissue Encoding Must Be Patient-Specific",
+    "Log All Regeneration in Trust Vault",
+]
+
+STATUS_PATH = (
+    Path(__file__).resolve().parents[1] / "vaultfire-core" / "nanoloop_v1_1_status.json"
+)
+LOG_DIR = Path(__file__).resolve().parents[1] / "vaultfire-core" / "nanoloop_logs"
+STORE_KEY = b"0" * 32
+STORE = SecureStore(STORE_KEY, LOG_DIR)
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def module_status() -> Dict:
+    """Return stored status for NanoLoop v1.1."""
+    data = _load_json(STATUS_PATH, {})
+    if not data:
+        data["status"] = MODULE_INFO["deployment_status"]
+        _write_json(STATUS_PATH, data)
+    return data
+
+
+def activate(trigger: str, consent: bool = False) -> bool:
+    """Activate module if trigger or consent is provided."""
+    state = module_status()
+    if state.get("status") == "active":
+        return True
+    if consent or trigger == MODULE_INFO["activation_tag"]:
+        state["status"] = "active"
+        state["activated_at"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        _write_json(STATUS_PATH, state)
+        return True
+    return False
+
+
+def _log_regeneration(entry: Dict) -> Dict:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = LOG_DIR / "entry.json"
+    tmp.write_text(json.dumps(entry))
+    meta = STORE.encrypt_and_store(tmp, entry.get("wallet", "anon"), "Regen", 1)
+    tmp.unlink(missing_ok=True)
+    return meta
+
+
+def repair_cell_pattern(patient_id: str, region: str, wallet: str) -> Dict:
+    """Record regenerative cell patterning cycle."""
+    if module_status().get("status") != "active":
+        return {"error": "module not active"}
+    entry = {
+        "action": "repair",
+        "patient_id": patient_id,
+        "region": region,
+        "wallet": wallet,
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    record_traits(patient_id, ["regen_cycle"])
+    return _log_regeneration(entry)
+
+
+def stabilize_trauma(patient_id: str, notes: str, wallet: str) -> Dict:
+    """Log trauma-stabilization event."""
+    if module_status().get("status") != "active":
+        return {"error": "module not active"}
+    entry = {
+        "action": "stabilize",
+        "patient_id": patient_id,
+        "notes": notes,
+        "wallet": wallet,
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    record_traits(patient_id, ["trauma_cycle"])
+    return _log_regeneration(entry)
+
+
+def rebuild_tissue(patient_id: str, tissue: str, wallet: str) -> Dict:
+    """Log autonomous tissue reconstruction cycle."""
+    if module_status().get("status") != "active":
+        return {"error": "module not active"}
+    entry = {
+        "action": "rebuild",
+        "patient_id": patient_id,
+        "tissue": tissue,
+        "wallet": wallet,
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    record_traits(patient_id, ["rebuild_cycle"])
+    return _log_regeneration(entry)
+
+
+__all__ = [
+    "MODULE_INFO",
+    "DIRECTIVES",
+    "module_status",
+    "activate",
+    "repair_cell_pattern",
+    "stabilize_trauma",
+    "rebuild_tissue",
+    "PURPOSE_ENGINE_LINK",
+]

--- a/tests/test_nanoloop_v1_1.py
+++ b/tests/test_nanoloop_v1_1.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+import engine.nanoloop_v1_1 as nl
+
+
+def test_cycle(monkeypatch, tmp_path):
+    monkeypatch.setattr(nl, "LOG_DIR", tmp_path)
+    nl.STORE = nl.SecureStore(nl.STORE_KEY, tmp_path)
+    nl.activate(nl.MODULE_INFO["activation_tag"])
+    res = nl.repair_cell_pattern("u1", "arm", "w1")
+    assert "cid" in res
+    meta_file = tmp_path / f"{res['cid']}.json"
+    assert meta_file.exists()
+    data = json.loads(meta_file.read_text())
+    assert data["wallet"] == "w1"

--- a/vaultfire_cli_plugins/nanoloop.py
+++ b/vaultfire_cli_plugins/nanoloop.py
@@ -1,0 +1,48 @@
+import argparse
+import json
+from engine.nanoloop_v1_1 import (
+    repair_cell_pattern,
+    stabilize_trauma,
+    rebuild_tissue,
+)
+
+
+def _cmd_repair(args: argparse.Namespace) -> None:
+    result = repair_cell_pattern(args.patient, args.region, args.wallet)
+    print(json.dumps(result, indent=2))
+
+
+def _cmd_stabilize(args: argparse.Namespace) -> None:
+    result = stabilize_trauma(args.patient, args.notes, args.wallet)
+    print(json.dumps(result, indent=2))
+
+
+def _cmd_rebuild(args: argparse.Namespace) -> None:
+    result = rebuild_tissue(args.patient, args.tissue, args.wallet)
+    print(json.dumps(result, indent=2))
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    p_repair = subparsers.add_parser(
+        "nano.repair", help="Record regenerative cell repair"
+    )
+    p_repair.add_argument("--patient", required=True)
+    p_repair.add_argument("--region", required=True)
+    p_repair.add_argument("--wallet", required=True)
+    p_repair.set_defaults(func=_cmd_repair)
+
+    p_stab = subparsers.add_parser(
+        "nano.stabilize", help="Record trauma stabilization cycle"
+    )
+    p_stab.add_argument("--patient", required=True)
+    p_stab.add_argument("--notes", required=True)
+    p_stab.add_argument("--wallet", required=True)
+    p_stab.set_defaults(func=_cmd_stabilize)
+
+    p_rebuild = subparsers.add_parser(
+        "nano.rebuild", help="Record tissue reconstruction cycle"
+    )
+    p_rebuild.add_argument("--patient", required=True)
+    p_rebuild.add_argument("--tissue", required=True)
+    p_rebuild.add_argument("--wallet", required=True)
+    p_rebuild.set_defaults(func=_cmd_rebuild)


### PR DESCRIPTION
## Summary
- inject NanoLoop v1.1 into the protocol core
- expose new CLI hooks `nano.repair`, `nano.stabilize`, `nano.rebuild`
- document healing features and new module
- add simple unit test for NanoLoop v1.1

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886f83d68e8832283da9468b197daa0