### PR TITLE
Add NanoLoop MirrorSync v2 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Vaultfire Init is the reference implementation of the Ghostkey protocol. It prov
 - **NanoLoop v1.0** – dormant ethical anchor for cell-scale healing logic
 - **NanoLoop v1.1** – regenerative operations with trauma stabilization and
   adaptive tissue encoding
+- **NanoLoop v2.0** – MirrorSync regenerative module with adaptive healing
+
+## Regenerative Systems
+- `nano.repair` – cell-scale reconstruction of damaged belief threads
+- `nano.stabilize` – emotional and behavioral grounding stabilization
+- `nano.rebuild` – full trauma cycle replacement and pattern rethreading
+- `nano.sync-mirror` – sync healing rate with belief signals
+- `nano.adapt` – update ethics status for regeneration routines
+- `nano.upgrade-core` – evolve NanoLoop to future versions
 
 ## Repository Layout
 - `engine/` – core protocol logic such as signal processing and reward engines

--- a/cli/ghostkey-tools/nano.js
+++ b/cli/ghostkey-tools/nano.js
@@ -1,0 +1,93 @@
+const {
+  syncMirror,
+  repair,
+  stabilize,
+  rebuild,
+  adapt,
+  upgradeCore,
+} = require('../../modules/regen/nanoloop_mirrorsync_v2');
+
+function usage() {
+  console.log('Usage: node nano.js <command> [options]');
+  console.log('Commands:');
+  console.log('  repair --patient <id> --thread <thread>');
+  console.log('  stabilize --patient <id> --notes <text>');
+  console.log('  rebuild --patient <id> --pattern <pattern>');
+  console.log('  sync-mirror --signal <num> --belief <num>');
+  console.log('  adapt --status <status>');
+  console.log('  upgrade-core --tag <tag>');
+  process.exit(1);
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const cmd = args.shift();
+  const opts = {};
+  while (args.length) {
+    const a = args.shift();
+    switch (a) {
+      case '--patient':
+        opts.patient = args.shift();
+        break;
+      case '--thread':
+        opts.thread = args.shift();
+        break;
+      case '--notes':
+        opts.notes = args.shift();
+        break;
+      case '--pattern':
+        opts.pattern = args.shift();
+        break;
+      case '--signal':
+        opts.signal = parseFloat(args.shift());
+        break;
+      case '--belief':
+        opts.belief = parseFloat(args.shift());
+        break;
+      case '--status':
+        opts.status = args.shift();
+        break;
+      case '--tag':
+        opts.tag = args.shift();
+        break;
+      default:
+        console.error('Unknown arg', a);
+        usage();
+    }
+  }
+  return { cmd, opts };
+}
+
+function main() {
+  const { cmd, opts } = parseArgs();
+  let result;
+  switch (cmd) {
+    case 'repair':
+      result = repair(opts.patient, opts.thread);
+      break;
+    case 'stabilize':
+      result = stabilize(opts.patient, opts.notes);
+      break;
+    case 'rebuild':
+      result = rebuild(opts.patient, opts.pattern);
+      break;
+    case 'sync-mirror':
+      result = syncMirror(Number(opts.signal), Number(opts.belief));
+      break;
+    case 'adapt':
+      result = adapt(opts.status);
+      break;
+    case 'upgrade-core':
+      result = upgradeCore(opts.tag);
+      break;
+    default:
+      usage();
+  }
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main };

--- a/docs/nanoloop_v2.md
+++ b/docs/nanoloop_v2.md
@@ -1,0 +1,15 @@
+# NanoLoop v2.0
+
+NanoLoop_MirrorSync_v2.0 links Ghostkey-316's behavior metrics to real-time regenerative logic. Healing speed adapts to Purpose Engine v2 signal clarity and the current belief synchronization state. When `ghostkey.alignment` is set to `ethical`, the module accelerates all recovery operations by 20%.
+
+## Commands
+- `nano.repair` – cell-scale reconstruction of damaged belief threads
+- `nano.stabilize` – emotional and behavioral grounding stabilization
+- `nano.rebuild` – full trauma cycle replacement and pattern rethreading
+- `nano.sync-mirror` – sync healing rate with belief signals
+- `nano.adapt` – update ethics status for regeneration routines
+- `nano.upgrade-core` – evolve NanoLoop to future versions
+
+All trauma cycles are logged in a secure Vaultfire memory mirror. Milestones unlock soft rewards and hidden growth modules once the trauma→belief loop completes cleanly.
+
+*This document does not constitute medical advice.*

--- a/modules/regen/nanoloop_mirrorsync_v2.js
+++ b/modules/regen/nanoloop_mirrorsync_v2.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+
+const STATUS_PATH = path.join(__dirname, '..', '..', 'vaultfire-core', 'nanoloop_v2_status.json');
+const LOG_PATH = path.join(__dirname, '..', '..', 'vaultfire-core', 'nanoloop_v2_log.json');
+
+const MODULE_INFO = {
+  module_name: 'NanoLoop_MirrorSync_v2.0',
+  owner: 'Ghostkey-316',
+  purpose_engine_link: 'v2'
+};
+
+const ghostkey = { alignment: 'ethical' };
+
+function _loadJSON(p, def){
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return def;
+  }
+}
+
+function _writeJSON(p, data){
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(data, null, 2));
+}
+
+function moduleStatus(){
+  return _loadJSON(STATUS_PATH, { healing_rate: 0 });
+}
+
+function _log(entry){
+  const log = _loadJSON(LOG_PATH, []);
+  log.push({ ...entry, timestamp: new Date().toISOString() });
+  _writeJSON(LOG_PATH, log);
+  return entry;
+}
+
+function syncMirror(signalClarity, beliefSync){
+  const state = moduleStatus();
+  let rate = signalClarity * beliefSync;
+  if(ghostkey.alignment === 'ethical') rate *= 1.2;
+  state.healing_rate = Number(rate.toFixed(2));
+  _writeJSON(STATUS_PATH, state);
+  return state;
+}
+
+function repair(patient, thread){
+  return _log({ action: 'repair', patient, thread });
+}
+
+function stabilize(patient, notes){
+  return _log({ action: 'stabilize', patient, notes });
+}
+
+function rebuild(patient, pattern){
+  return _log({ action: 'rebuild', patient, pattern });
+}
+
+function adapt(status){
+  const state = moduleStatus();
+  state.ethics_status = status;
+  _writeJSON(STATUS_PATH, state);
+  return state;
+}
+
+function upgradeCore(tag){
+  const state = moduleStatus();
+  state.upgraded_to = tag;
+  _writeJSON(STATUS_PATH, state);
+  return state;
+}
+
+module.exports = {
+  MODULE_INFO,
+  moduleStatus,
+  syncMirror,
+  repair,
+  stabilize,
+  rebuild,
+  adapt,
+  upgradeCore,
+};


### PR DESCRIPTION
## Summary
- add NanoLoop_MirrorSync_v2.0 implementation under `modules/regen`
- expose CLI commands via `cli/ghostkey-tools/nano.js`
- document new module in `docs/nanoloop_v2.md`
- mention v2.0 in README and list MirrorSync commands

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError for several modules)*

------
https://chatgpt.com/codex/tasks/task_e_6886f9f154dc83229a9d8a17395cb38a