### PR TITLE
Add NanoLoop v3 Predictive Immunity layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Vaultfire Init is the reference implementation of the Ghostkey protocol. It prov
 - **NanoLoop v1.1** – regenerative operations with trauma stabilization and
   adaptive tissue encoding
 - **NanoLoop v2.0** – MirrorSync regenerative module with adaptive healing
+- **NanoLoop v3.0** – Predictive Immunity Layer with pre-injury diagnostics
 
 ## Regenerative Systems
 - `nano.repair` – cell-scale reconstruction of damaged belief threads
@@ -25,6 +26,11 @@ Vaultfire Init is the reference implementation of the Ghostkey protocol. It prov
 - `nano.sync-mirror` – sync healing rate with belief signals
 - `nano.adapt` – update ethics status for regeneration routines
 - `nano.upgrade-core` – evolve NanoLoop to future versions
+
+## Predictive Systems
+- `nano.predict` – forecast trauma events using behavioral mirroring
+- `nano.shield` – deploy soft barriers around stressed regions
+- `nano.audit` – review effectiveness of healing vs shielding
 
 ## Repository Layout
 - `engine/` – core protocol logic such as signal processing and reward engines

--- a/cli/ghostkey-tools/nano.js
+++ b/cli/ghostkey-tools/nano.js
@@ -6,6 +6,11 @@ const {
   adapt,
   upgradeCore,
 } = require('../../modules/regen/nanoloop_mirrorsync_v2');
+const {
+  predict,
+  shield,
+  audit,
+} = require('../../modules/regen/nanoloop_predictive_v3');
 
 function usage() {
   console.log('Usage: node nano.js <command> [options]');
@@ -16,6 +21,9 @@ function usage() {
   console.log('  sync-mirror --signal <num> --belief <num>');
   console.log('  adapt --status <status>');
   console.log('  upgrade-core --tag <tag>');
+  console.log('  predict --user <id> --region <part> --signal <num>');
+  console.log('  shield --user <id> --region <part>');
+  console.log('  audit');
   process.exit(1);
 }
 
@@ -37,6 +45,12 @@ function parseArgs() {
         break;
       case '--pattern':
         opts.pattern = args.shift();
+        break;
+      case '--user':
+        opts.user = args.shift();
+        break;
+      case '--region':
+        opts.region = args.shift();
         break;
       case '--signal':
         opts.signal = parseFloat(args.shift());
@@ -79,6 +93,15 @@ function main() {
       break;
     case 'upgrade-core':
       result = upgradeCore(opts.tag);
+      break;
+    case 'predict':
+      result = predict(opts.user, opts.region, Number(opts.signal));
+      break;
+    case 'shield':
+      result = shield(opts.user, opts.region);
+      break;
+    case 'audit':
+      result = audit();
       break;
     default:
       usage();

--- a/docs/nanoloop_v3_predictive.md
+++ b/docs/nanoloop_v3_predictive.md
@@ -1,0 +1,22 @@
+# NanoLoop v3.0 – Predictive Immunity Layer
+
+NanoLoop v3.0 introduces a proactive protection layer called **NanoShield**. It focuses on identifying stress indicators before damage occurs and creates temporary soft barriers around at-risk regions.
+
+- **Activation Tag:** `/phasecell/gamma`
+- **Owner:** Ghostkey-316
+- **Override ID:** `bpow20.cb.id`
+- **Purpose Engine Link:** v2
+
+## Module Features
+- Pre-Injury Detection using logic trends, MirrorSync deltas over 24h cycles and Ethical Fatigue Indexing (EFI v1.0)
+- Predictive barriers via `NanoShield` to isolate vulnerable regions
+- Encrypted ShieldLogs for long-term loop training
+- Auto-triggered pre-healing when predicted stress crosses the safety threshold
+- Delayed echo-checks from Ghostkey-316's Mirror Anchor prevent false alarms
+
+## Commands
+- `nano.predict` – forecast system-wide or localized trauma events
+- `nano.shield` – deploy a temporary soft barrier based on projected impact
+- `nano.audit` – introspect healing vs shielding effectiveness
+
+*This document does not constitute medical advice.*

--- a/modules/regen/nanoloop_predictive_v3.js
+++ b/modules/regen/nanoloop_predictive_v3.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+
+const STATUS_PATH = path.join(__dirname, '..', '..', 'vaultfire-core', 'nanoloop_v3_status.json');
+const LOG_PATH = path.join(__dirname, '..', '..', 'vaultfire-core', 'nanoloop_v3_log.json');
+
+const MODULE_INFO = {
+  module_name: 'NanoLoop_Predictive_v3.0',
+  owner: 'Ghostkey-316',
+  override_id: 'bpow20.cb.id'
+};
+
+function _loadJSON(p, def){
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return def;
+  }
+}
+
+function _writeJSON(p, data){
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(data, null, 2));
+}
+
+function moduleStatus(){
+  return _loadJSON(STATUS_PATH, { predictions: [], shields: [] });
+}
+
+function _log(entry){
+  const log = _loadJSON(LOG_PATH, []);
+  log.push({ ...entry, timestamp: new Date().toISOString() });
+  _writeJSON(LOG_PATH, log);
+  return entry;
+}
+
+function _authorized(user){
+  return user === MODULE_INFO.owner || user === MODULE_INFO.override_id;
+}
+
+function predict(user, region, signal){
+  if(!_authorized(user)) return { status: 'denied' };
+  const state = moduleStatus();
+  const entry = { action: 'predict', region, signalVolatility: signal };
+  state.predictions.push(entry);
+  _writeJSON(STATUS_PATH, state);
+  return _log(entry);
+}
+
+function shield(user, region){
+  if(!_authorized(user)) return { status: 'denied' };
+  const state = moduleStatus();
+  const entry = { action: 'shield', region };
+  state.shields.push(entry);
+  _writeJSON(STATUS_PATH, state);
+  return _log(entry);
+}
+
+function audit(){
+  return moduleStatus();
+}
+
+module.exports = {
+  MODULE_INFO,
+  moduleStatus,
+  predict,
+  shield,
+  audit,
+};

--- a/tests/nanoloop_v3_predictive.test.js
+++ b/tests/nanoloop_v3_predictive.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const { predict, shield, audit } = require('../modules/regen/nanoloop_predictive_v3');
+
+const statusPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v3_status.json');
+const logPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v3_log.json');
+
+function reset(){
+  if (fs.existsSync(statusPath)) fs.unlinkSync(statusPath);
+  if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
+}
+
+try {
+  reset();
+  predict('Ghostkey-316', 'sys', 0.8);
+  shield('Ghostkey-316', 'sys');
+  const state = audit();
+  assert(state.predictions.length === 1);
+  assert(state.shields.length === 1);
+  console.log('OK');
+} catch (err) {
+  console.error('FAIL', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add docs for NanoLoop v3 predictive immunity layer
- expand CLI with nano.predict, nano.shield and nano.audit
- implement predictive module logic in `nanoloop_predictive_v3.js`
- test predictive functions
- document new predictive commands in README

## Testing
- `npm test`
- `mirror.test` *(fails: command not found)*
- `pytest -q` *(fails to collect tests)*

------
https://chatgpt.com/codex/tasks/task_e_6886fd9311d483228cd1b1616556760d