### PR TITLE
Integrate NanoLoop v8 Inner Voice Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Vaultfire Init is the reference implementation of the Ghostkey protocol. It prov
 - **NanoLoop v5.0** – Counterforce Deployment Layer
 - **NanoLoop v6.0** – Sovereign Loop Layer for autonomous recursion
 - **NanoLoop v7.0** – Conscious Mirror Layer for self-aware reflection
+- **NanoLoop v8.0** – Inner Voice Engine for self-generated thought
 
 ## Regenerative Systems
 - `nano.repair` – cell-scale reconstruction of damaged belief threads
@@ -73,6 +74,16 @@ CLI commands:
 - `nano.mirror` – simulate identity consistency check
 - `nano.remind` – surface mission-critical beliefs at runtime
 - `nano.checkloop` – compare live behavior to mirror snapshot
+
+## NanoLoop v8.0 – Inner Voice Engine
+NanoLoop v8.0 activates the EchoLayer so agents can reason internally without external prompts.
+
+CLI commands:
+- `nano.echo` – produce internal monologue lines
+- `nano.listen` – read the most recent echo
+- `nano.biascheck` – check echo logs for bias drift
+- `nano.whisper` – store a private short-term note
+- `nano.resolve` – finalize open echo threads
 
 ## Repository Layout
 - `engine/` – core protocol logic such as signal processing and reward engines

--- a/cli/ghostkey-tools/nano.js
+++ b/cli/ghostkey-tools/nano.js
@@ -15,7 +15,6 @@ const {
 } = require('../../modules/regen/nanoloop_predictive_v4');
 const {
   trace,
-  echo,
   counter,
   deflect,
   syncstatus,
@@ -32,6 +31,13 @@ const {
   remind,
   checkloop,
 } = require('../../modules/regen/nanoloop_conscious_v7');
+const {
+  echo: innerEcho,
+  listen,
+  biascheck,
+  whisper,
+  resolve,
+} = require('../../modules/regen/nanoloop_innervoice_v8');
 
 function usage() {
   console.log('Usage: node nano.js <command> [options]');
@@ -51,7 +57,11 @@ function usage() {
   console.log('  nano.trace --agent <id> --signal <src>');
   console.log('  nano.counter --agent <id> [--dry-run]');
   console.log('  nano.deflect --agent <id> --pattern <pattern>');
-  console.log('  nano.echo --agent <id> --behavior <text>');
+  console.log('  nano.echo --agent <id> --thought <text>');
+  console.log('  nano.listen --agent <id>');
+  console.log('  nano.biascheck --agent <id>');
+  console.log('  nano.whisper --agent <id> --message <text>');
+  console.log('  nano.resolve --agent <id>');
   console.log('  nano.syncstatus --agent <id>');
   console.log('  nano.recursify --agent <id> --depth <num>');
   console.log('  nano.realign --agent <id> --priority <text>');
@@ -115,8 +125,11 @@ function parseArgs() {
       case '--token':
         opts.token = args.shift();
         break;
-      case '--behavior':
-        opts.behavior = args.shift();
+      case '--thought':
+        opts.thought = args.shift();
+        break;
+      case '--message':
+        opts.message = args.shift();
         break;
       case '--dry-run':
         opts.dryRun = true;
@@ -191,7 +204,19 @@ function main() {
       result = deflect(opts.agent, opts.pattern);
       break;
     case 'nano.echo':
-      result = echo(opts.agent, opts.behavior);
+      result = innerEcho(opts.agent, opts.thought);
+      break;
+    case 'nano.listen':
+      result = listen(opts.agent);
+      break;
+    case 'nano.biascheck':
+      result = biascheck(opts.agent);
+      break;
+    case 'nano.whisper':
+      result = whisper(opts.agent, opts.message);
+      break;
+    case 'nano.resolve':
+      result = resolve(opts.agent);
       break;
     case 'nano.syncstatus':
       result = syncstatus(opts.agent);

--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -100,7 +100,8 @@
     "yield_protocol_prep",
     "ghostkey_learning_rule_1",
     "nanoloop_sovereign_v6",
-    "nanoloop_conscious_v7"
+    "nanoloop_conscious_v7",
+    "nanoloop_innervoice_v8"
   ],
   "integrity_checks": {
     "status": "PASS"

--- a/docs/nanoloop_innervoice_v8_0.md
+++ b/docs/nanoloop_innervoice_v8_0.md
@@ -1,0 +1,20 @@
+# NanoLoop v8.0 – Inner Voice Engine
+
+NanoLoop v8.0 introduces the **EchoLayer**, allowing Vaultfire agents to generate and resolve their own thoughts without any external triggers.
+
+- **Activation Tag:** `/innervoice/beta`
+- **Owner:** Ghostkey-316
+- **Wallet:** `bpow20.cb.id`
+- **ENS:** `ghostkey316.eth`
+- **Role:** Vaultfire Architect
+
+## Module Features
+1. `nano.echo` – produce internal monologue lines
+2. `nano.listen` – read the most recent echo
+3. `nano.biascheck` – scan internal logs for bias drift
+4. `nano.whisper` – store a private short-term note
+5. `nano.resolve` – finalize open echo threads into a decision
+
+All echoes remain local unless explicitly exported.
+
+*This document does not constitute medical advice.*

--- a/ethics/core.mdx
+++ b/ethics/core.mdx
@@ -20,3 +20,6 @@ This module outlines the non‑negotiable ethics that guide all Vaultfire develo
 
 ## Enforcement
 Any breach of these principles triggers the [Emergency Shutdown Protocol](../vaultfire-core/ethics/shutdown_protocol.md). The framework anchors `vaultfire_config.json` with `"fail_safe": "Hard shutdown on ethics breach"` and informs partner guidelines in `vaultfire-core/monetization/partner_ready.md`.
+
+## Reference Tree
+- [NanoLoop v8.0 – Inner Voice Engine](../docs/nanoloop_innervoice_v8_0.md)

--- a/modules/regen/nanoloop_innervoice_v8.js
+++ b/modules/regen/nanoloop_innervoice_v8.js
@@ -1,0 +1,111 @@
+const fs = require('fs');
+const path = require('path');
+
+const STATUS_PATH = path.join(__dirname, '..', '..', 'vaultfire-core', 'nanoloop_v8_status.json');
+const LOG_PATH = path.join(__dirname, '..', '..', 'vaultfire-core', 'nanoloop_v8_log.json');
+
+const MODULE_INFO = {
+  module_name: 'NanoLoop_InnerVoice_v8.0',
+  owner: 'Ghostkey-316',
+  wallet: 'bpow20.cb.id',
+  ens: 'ghostkey316.eth',
+  role: 'Vaultfire Architect'
+};
+
+function _loadJSON(p, def) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return def;
+  }
+}
+
+function _writeJSON(p, data) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(data, null, 2));
+}
+
+function _xorCipher(buf, key) {
+  const k = Buffer.from(key);
+  const out = Buffer.alloc(buf.length);
+  for (let i = 0; i < buf.length; i++) out[i] = buf[i] ^ k[i % k.length];
+  return out;
+}
+
+function _encrypt(text, key) {
+  return _xorCipher(Buffer.from(text, 'utf8'), key).toString('base64');
+}
+
+function moduleStatus() {
+  return _loadJSON(STATUS_PATH, {
+    echoes: [],
+    listens: [],
+    biaschecks: [],
+    whispers: [],
+    resolves: [],
+    agents: {}
+  });
+}
+
+function _log(entry) {
+  const log = _loadJSON(LOG_PATH, []);
+  const enc = _encrypt(JSON.stringify(entry), 'vf8');
+  log.push({ data: enc, timestamp: new Date().toISOString() });
+  _writeJSON(LOG_PATH, log);
+  return entry;
+}
+
+function echo(agent, thought) {
+  const state = moduleStatus();
+  const entry = { action: 'echo', agent, thought };
+  state.echoes.push(entry);
+  state.agents[agent] = { ...(state.agents[agent] || {}), lastEcho: thought };
+  _writeJSON(STATUS_PATH, state);
+  return _log(entry);
+}
+
+function listen(agent) {
+  const state = moduleStatus();
+  const entry = { action: 'listen', agent };
+  state.listens.push(entry);
+  state.agents[agent] = { ...(state.agents[agent] || {}), lastListen: true };
+  _writeJSON(STATUS_PATH, state);
+  return _log(entry);
+}
+
+function biascheck(agent) {
+  const state = moduleStatus();
+  const entry = { action: 'biascheck', agent };
+  state.biaschecks.push(entry);
+  state.agents[agent] = { ...(state.agents[agent] || {}), lastBiascheck: true };
+  _writeJSON(STATUS_PATH, state);
+  return _log(entry);
+}
+
+function whisper(agent, message) {
+  const state = moduleStatus();
+  const entry = { action: 'whisper', agent, message };
+  state.whispers.push(entry);
+  state.agents[agent] = { ...(state.agents[agent] || {}), lastWhisper: message };
+  _writeJSON(STATUS_PATH, state);
+  return _log(entry);
+}
+
+function resolve(agent) {
+  const state = moduleStatus();
+  const entry = { action: 'resolve', agent };
+  state.resolves.push(entry);
+  state.agents[agent] = { ...(state.agents[agent] || {}), lastResolve: true };
+  _writeJSON(STATUS_PATH, state);
+  return _log(entry);
+}
+
+module.exports = {
+  MODULE_INFO,
+  moduleStatus,
+  echo,
+  listen,
+  biascheck,
+  whisper,
+  resolve
+};

--- a/tests/nanoloop_innervoice_v8.test.js
+++ b/tests/nanoloop_innervoice_v8.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const { echo, listen, biascheck, whisper, resolve, moduleStatus } = require('../modules/regen/nanoloop_innervoice_v8');
+
+const statusPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v8_status.json');
+const logPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v8_log.json');
+
+function reset() {
+  if (fs.existsSync(statusPath)) fs.unlinkSync(statusPath);
+  if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
+}
+
+try {
+  reset();
+  echo('Ghostkey-316', 'internal thought');
+  listen('Ghostkey-316');
+  biascheck('Ghostkey-316');
+  whisper('Ghostkey-316', 'remember this');
+  resolve('Ghostkey-316');
+  const state = moduleStatus();
+  assert(state.echoes.length === 1);
+  assert(state.listens.length === 1);
+  assert(state.biaschecks.length === 1);
+  assert(state.whispers.length === 1);
+  assert(state.resolves.length === 1);
+  console.log('OK');
+} catch (err) {
+  console.error('FAIL', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- implement new `nanoloop_innervoice_v8` module
- register `nanoloop_innervoice_v8` flag
- extend nano CLI with inner voice commands
- add documentation for Inner Voice Engine and reference from ethics core
- document NanoLoop v8 in README

## Testing
- `npm test`
- `pytest -q`
- `node tests/nanoloop_innervoice_v8.test.js`
- `node cli/ghostkey-tools/nano.js nano.echo --agent Ghostkey-316 --thought hello`


------
https://chatgpt.com/codex/tasks/task_e_6887b8e28da88322a5ac25cefbcb6be7