### PR TITLE
Integrate NanoLoop v10 memory graft layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Vaultfire Init is the reference implementation of the Ghostkey protocol. It prov
 - **NanoLoop v6.0** – Sovereign Loop Layer for autonomous recursion
 - **NanoLoop v7.0** – Conscious Mirror Layer for self-aware reflection
 - **NanoLoop v8.0** – Inner Voice Engine for self-generated thought
+- **NanoLoop v10.0** – Memory Grafting Layer for secured long-term retention
 
 ## Regenerative Systems
 - `nano.repair` – cell-scale reconstruction of damaged belief threads
@@ -84,6 +85,15 @@ CLI commands:
 - `nano.biascheck` – check echo logs for bias drift
 - `nano.whisper` – store a private short-term note
 - `nano.resolve` – finalize open echo threads
+
+## NanoLoop v10.0 – Memory Grafting Layer
+NanoLoop v10.0 enables secured long-term retention of override events and anchor reflections.
+
+CLI commands:
+- `nano.memory.graft` – store verified loop memory into shards
+- `nano.memory.bind` – associate memory events with a given anchor
+- `nano.memory.lock` – lock entries with checksum validation
+- `nano.memory.audit` – inspect stored grafts and bindings
 
 ## Repository Layout
 - `engine/` – core protocol logic such as signal processing and reward engines

--- a/cli/ghostkey-tools/nano.js
+++ b/cli/ghostkey-tools/nano.js
@@ -38,6 +38,12 @@ const {
   whisper,
   resolve,
 } = require('../../modules/regen/nanoloop_innervoice_v8');
+const {
+  graft,
+  bind: memoryBind,
+  lock,
+  audit: memoryAudit
+} = require('../../modules/regen/nanoloop_memory_v10');
 
 function usage() {
   console.log('Usage: node nano.js <command> [options]');
@@ -63,6 +69,10 @@ function usage() {
   console.log('  nano.whisper --agent <id> --message <text>');
   console.log('  nano.resolve --agent <id>');
   console.log('  nano.syncstatus --agent <id>');
+  console.log('  nano.memory.graft --source <file> --context <ctx> --timestamp <ts>');
+  console.log('  nano.memory.bind --anchor <id> --tag <tag>');
+  console.log('  nano.memory.lock --tag <tag> --checksum <sum>');
+  console.log('  nano.memory.audit');
   console.log('  nano.recursify --agent <id> --depth <num>');
   console.log('  nano.realign --agent <id> --priority <text>');
   console.log('  nano.vowcheck --agent <id>');
@@ -133,6 +143,18 @@ function parseArgs() {
         break;
       case '--dry-run':
         opts.dryRun = true;
+        break;
+      case '--source':
+        opts.source = args.shift();
+        break;
+      case '--context':
+        opts.context = args.shift();
+        break;
+      case '--timestamp':
+        opts.timestamp = args.shift();
+        break;
+      case '--checksum':
+        opts.checksum = args.shift();
         break;
       case '--depth':
         opts.depth = parseInt(args.shift(), 10);
@@ -220,6 +242,18 @@ function main() {
       break;
     case 'nano.syncstatus':
       result = syncstatus(opts.agent);
+      break;
+    case 'nano.memory.graft':
+      result = graft(opts.source, opts.context, opts.timestamp);
+      break;
+    case 'nano.memory.bind':
+      result = memoryBind(opts.anchor, opts.tag);
+      break;
+    case 'nano.memory.lock':
+      result = lock(opts.tag, opts.checksum);
+      break;
+    case 'nano.memory.audit':
+      result = memoryAudit();
       break;
     case 'nano.recursify':
       result = recursify(opts.agent, Number(opts.depth));

--- a/modules/regen/nanoloop_memory_v10.js
+++ b/modules/regen/nanoloop_memory_v10.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const path = require('path');
+
+const STATUS_PATH = path.join(__dirname, '..', '..', 'vaultfire-core', 'nanoloop_v10_status.json');
+const LOG_PATH = path.join(__dirname, '..', '..', 'vaultfire-core', 'nanoloop_v10_log.json');
+
+const MODULE_INFO = {
+  module_name: 'NanoLoop_MemoryGraft_v10.0',
+  owner: 'Ghostkey-316',
+  wallet: 'bpow20.cb.id',
+  ens: 'ghostkey316.eth',
+  role: 'Vaultfire Architect'
+};
+
+function _loadJSON(p, def) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return def;
+  }
+}
+
+function _writeJSON(p, data) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(data, null, 2));
+}
+
+function _xorCipher(buf, key) {
+  const k = Buffer.from(key);
+  const out = Buffer.alloc(buf.length);
+  for (let i = 0; i < buf.length; i++) out[i] = buf[i] ^ k[i % k.length];
+  return out;
+}
+
+function _encrypt(text, key) {
+  return _xorCipher(Buffer.from(text, 'utf8'), key).toString('base64');
+}
+
+function moduleStatus() {
+  return _loadJSON(STATUS_PATH, {
+    grafts: [],
+    bindings: [],
+    locks: [],
+    anchors: {}
+  });
+}
+
+function _log(entry) {
+  const log = _loadJSON(LOG_PATH, []);
+  const enc = _encrypt(JSON.stringify(entry), 'vf10');
+  log.push({ data: enc, timestamp: new Date().toISOString() });
+  _writeJSON(LOG_PATH, log);
+  return entry;
+}
+
+function graft(source, context, timestamp) {
+  const state = moduleStatus();
+  const entry = { action: 'graft', source, context, timestamp };
+  state.grafts.push(entry);
+  _writeJSON(STATUS_PATH, state);
+  return _log(entry);
+}
+
+function bind(anchor, tag) {
+  const state = moduleStatus();
+  const entry = { action: 'bind', anchor, tag };
+  state.bindings.push(entry);
+  state.anchors[anchor] = { ...(state.anchors[anchor] || {}), tag };
+  _writeJSON(STATUS_PATH, state);
+  return _log(entry);
+}
+
+function lock(tag, checksum) {
+  const state = moduleStatus();
+  const entry = { action: 'lock', tag, checksum };
+  state.locks.push(entry);
+  _writeJSON(STATUS_PATH, state);
+  return _log(entry);
+}
+
+function audit() {
+  return moduleStatus();
+}
+
+module.exports = {
+  MODULE_INFO,
+  moduleStatus,
+  graft,
+  bind,
+  lock,
+  audit
+};

--- a/tests/nanoloop_memory_v10.test.js
+++ b/tests/nanoloop_memory_v10.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const { graft, bind, lock, audit, moduleStatus } = require('../modules/regen/nanoloop_memory_v10');
+
+const statusPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v10_status.json');
+const logPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v10_log.json');
+
+function reset() {
+  if (fs.existsSync(statusPath)) fs.unlinkSync(statusPath);
+  if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
+}
+
+try {
+  reset();
+  graft('override.log', 'ctx', 123);
+  bind('ghostkey316.eth', 'ethics_foundation');
+  lock('ethics_foundation', 'abc123');
+  const state = moduleStatus();
+  assert(state.grafts.length === 1);
+  assert(state.bindings.length === 1);
+  assert(state.locks.length === 1);
+  const report = audit();
+  assert(report.grafts.length === 1);
+  console.log('OK');
+} catch (err) {
+  console.error('FAIL', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `nanoloop_memory_v10` module implementing memory graft, bind, lock and audit
- expose memory graft commands in `nano.js` CLI
- document NanoLoop v10.0 in README
- add integration test for the new module

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887e953c8088322b4460f92ac7f89a2