### PR TITLE
Add nano_synapsefire_v19 module

### DIFF
--- a/modules/regen/nano_synapsefire_v19.js
+++ b/modules/regen/nano_synapsefire_v19.js
@@ -1,0 +1,105 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const ECHO_STATUS = path.join(__dirname, '..', '..', 'vaultfire-core', 'nano_echopulse_v17_status.json');
+const MEMORY_LOG = path.join(__dirname, '..', '..', 'logs', 'memorybridge_sync_v18.log');
+const PATHATLAS_LOG = path.join(__dirname, '..', '..', 'logs', 'pathatlas_v16.log');
+
+const STATUS_PATH = path.join(__dirname, '..', '..', 'vaultfire-core', 'nano_synapsefire_v19_status.json');
+const SYNC_LOG = path.join(__dirname, '..', '..', 'logs', 'synapsefire_v19.log');
+const AUDIT_LOG = path.join(__dirname, '..', '..', 'logs', 'synapsefire_v19_audit.log');
+
+const METADATA = {
+  module: 'nano_synapsefire_v19',
+  deployed_by: 'Ghostkey-316',
+  time_index: 'v19.0',
+  signal_status: 'active',
+  last_emission: 'pending',
+  fire_sync_ready: true
+};
+
+function _loadJSON(p, def) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return def;
+  }
+}
+
+function _writeJSON(p, data) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(data, null, 2));
+}
+
+function moduleStatus() {
+  return _loadJSON(STATUS_PATH, { metadata: METADATA, ignition_signals: [], last_sync: null });
+}
+
+function _saveState(state) {
+  _writeJSON(STATUS_PATH, state);
+  return state;
+}
+
+function _logAudit(signal) {
+  const audit = _loadJSON(AUDIT_LOG, []);
+  const fingerprint = crypto.createHash('sha256').update(JSON.stringify(signal)).digest('hex');
+  const entry = {
+    fingerprint,
+    confidence: signal.confidence,
+    emotional_pulse: signal.emotional_pulse,
+    recommended_behavior: signal.recommended_behavior,
+    verified_by_ethics: signal.confidence > 0.8
+  };
+  audit.push(entry);
+  _writeJSON(AUDIT_LOG, audit);
+  return entry;
+}
+
+function generateIgnitionSignal(origin_trail, clarity_score, belief_match, memory_resonance, emotional_pulse, recommended_behavior) {
+  const state = moduleStatus();
+  const confidence = Math.max(0, Math.min(1, (Number(clarity_score) + Number(belief_match) + Number(memory_resonance)) / 3));
+  const signal = {
+    spark_id: crypto.randomUUID(),
+    origin_trail,
+    confidence: Number(confidence.toFixed(2)),
+    emotional_pulse,
+    recommended_behavior,
+    timestamp: new Date().toISOString()
+  };
+  state.ignition_signals.push(signal);
+  state.metadata.last_emission = signal.timestamp;
+  _saveState(state);
+  _logAudit(signal);
+  return signal;
+}
+
+function fireSyncEngine() {
+  const state = moduleStatus();
+  const echo = _loadJSON(ECHO_STATUS, { metadata: {} });
+  const memLog = _loadJSON(MEMORY_LOG, []);
+  const pathLog = _loadJSON(PATHATLAS_LOG, []);
+  if (echo.metadata.echo_confirmed && Number(echo.metadata.clarity_score) > 0.8 && memLog.length) {
+    const event = {
+      verified: true,
+      echo_fingerprint: echo.metadata.fingerprint || null,
+      memory_node_id: memLog[memLog.length - 1].memory_node?.node_id || null,
+      trail: pathLog[pathLog.length - 1]?.uuid || null,
+      timestamp: new Date().toISOString()
+    };
+    const log = _loadJSON(SYNC_LOG, []);
+    log.push(event);
+    _writeJSON(SYNC_LOG, log);
+    state.last_sync = event.timestamp;
+    _saveState(state);
+    return event;
+  }
+  return null;
+}
+
+module.exports = {
+  METADATA,
+  moduleStatus,
+  generateIgnitionSignal,
+  fireSyncEngine
+};

--- a/tests/nano_synapsefire_v19.test.js
+++ b/tests/nano_synapsefire_v19.test.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const { generateIgnitionSignal, fireSyncEngine, moduleStatus } = require('../modules/regen/nano_synapsefire_v19');
+
+const statusPath = path.join(__dirname, '..', 'vaultfire-core', 'nano_synapsefire_v19_status.json');
+const syncLogPath = path.join(__dirname, '..', 'logs', 'synapsefire_v19.log');
+const auditLogPath = path.join(__dirname, '..', 'logs', 'synapsefire_v19_audit.log');
+const echoStatusPath = path.join(__dirname, '..', 'vaultfire-core', 'nano_echopulse_v17_status.json');
+const memorySyncPath = path.join(__dirname, '..', 'logs', 'memorybridge_sync_v18.log');
+const pathatlasLog = path.join(__dirname, '..', 'logs', 'pathatlas_v16.log');
+
+function reset() {
+  [statusPath, syncLogPath, auditLogPath, echoStatusPath, memorySyncPath, pathatlasLog].forEach(p => { if (fs.existsSync(p)) fs.unlinkSync(p); });
+}
+
+try {
+  reset();
+  fs.mkdirSync(path.dirname(echoStatusPath), { recursive: true });
+  fs.writeFileSync(echoStatusPath, JSON.stringify({ metadata: { echo_confirmed: true, clarity_score: 0.85 } }));
+  fs.mkdirSync(path.dirname(memorySyncPath), { recursive: true });
+  fs.writeFileSync(memorySyncPath, JSON.stringify([{ memory_node: { node_id: 'n1' } }]));
+  fs.writeFileSync(pathatlasLog, JSON.stringify([{ uuid: 'trail1' }]));
+
+  generateIgnitionSignal('trail1', 0.9, 0.9, 0.9, 'stable', 'continue');
+  const state = moduleStatus();
+  assert(state.ignition_signals.length === 1);
+
+  fireSyncEngine();
+  const syncLog = JSON.parse(fs.readFileSync(syncLogPath, 'utf8'));
+  const auditLog = JSON.parse(fs.readFileSync(auditLogPath, 'utf8'));
+  assert(syncLog.length === 1);
+  assert(syncLog[0].verified === true);
+  assert(auditLog[0].verified_by_ethics === true);
+  console.log('OK');
+} catch (err) {
+  console.error('FAIL', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- implement `nano_synapsefire_v19` module for signal fusion
- add test covering ignition signal creation and FireSync engine

## Testing
- `npm test`
- `pytest -q`
- `node tests/nano_synapsefire_v19.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688811d354f08322a431073eb2c7553a