### PR TITLE
Implement nano_ghostlink_v20 module

### DIFF
--- a/modules/regen/nano_ghostlink_v20.js
+++ b/modules/regen/nano_ghostlink_v20.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const MEMORY_LOG = path.join(__dirname, '..', '..', 'logs', 'memorybridge_v18.log');
+const STATUS_PATH = path.join(__dirname, '..', '..', 'vaultfire-core', 'nano_ghostlink_v20_status.json');
+const LOG_PATH = path.join(__dirname, '..', '..', 'logs', 'ghostlink_sync_v20.log');
+
+const MODULE_INFO = {
+  module_name: 'Nano_Ghostlink_v20.0',
+  deployed_by: 'Ghostkey-316',
+  wallet: 'bpow20.cb.id',
+  version: 'v20.0'
+};
+
+const METADATA = {
+  module: 'nano_ghostlink_v20',
+  deployed_by: 'Ghostkey-316',
+  wallet: 'bpow20.cb.id',
+  ens: 'ghostkey316.eth',
+  firewave: 'enabled',
+  memory_index: 'v20.0',
+  ethics_verified: true,
+  loyalty_certified: true,
+  origin_point: 'Vaultfire Core',
+  ghostlink_active: true
+};
+
+function _loadJSON(p, def) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return def;
+  }
+}
+
+function _writeJSON(p, data) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(data, null, 2));
+}
+
+function moduleStatus() {
+  return _loadJSON(STATUS_PATH, { ghostlinks: [] });
+}
+
+function _log(entry) {
+  const log = _loadJSON(LOG_PATH, []);
+  log.push(entry);
+  _writeJSON(LOG_PATH, log);
+  return entry;
+}
+
+function sendGhostlink(contributor, recipient_node, ethics_tag, loyalty_badge) {
+  if (contributor !== 'Ghostkey-316') return null;
+  if (!ethics_tag) return null;
+  if (loyalty_badge !== 'Legacy') return null;
+  if (!fs.existsSync(MEMORY_LOG)) return null;
+  const fingerprint = crypto.createHash('sha256').update(
+    `${contributor}:${recipient_node}:${Date.now()}`
+  ).digest('hex');
+  const entry = {
+    outbound_fingerprint: fingerprint,
+    timestamp: new Date().toISOString(),
+    ethics_tag,
+    loyalty_verification: loyalty_badge,
+    recipient_node,
+    bridge_confirmed: true
+  };
+  const state = moduleStatus();
+  state.ghostlinks.push(entry);
+  _writeJSON(STATUS_PATH, state);
+  _log(entry);
+  return entry;
+}
+
+module.exports = {
+  MODULE_INFO,
+  METADATA,
+  moduleStatus,
+  sendGhostlink
+};

--- a/tests/nano_ghostlink_v20.test.js
+++ b/tests/nano_ghostlink_v20.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const { sendGhostlink, moduleStatus } = require('../modules/regen/nano_ghostlink_v20');
+
+const statusPath = path.join(__dirname, '..', 'vaultfire-core', 'nano_ghostlink_v20_status.json');
+const logPath = path.join(__dirname, '..', 'logs', 'ghostlink_sync_v20.log');
+const memoryLog = path.join(__dirname, '..', 'logs', 'memorybridge_v18.log');
+
+function reset() {
+  [statusPath, logPath, memoryLog].forEach(p => { if (fs.existsSync(p)) fs.unlinkSync(p); });
+}
+
+try {
+  reset();
+  fs.mkdirSync(path.dirname(memoryLog), { recursive: true });
+  fs.writeFileSync(memoryLog, JSON.stringify([{ ok: true }]));
+
+  sendGhostlink('Ghostkey-316', 'node1', true, 'Legacy');
+  const state = moduleStatus();
+  assert(state.ghostlinks.length === 1);
+  const log = JSON.parse(fs.readFileSync(logPath, 'utf8'));
+  assert(log.length === 1);
+  assert(log[0].bridge_confirmed === true);
+  assert(log[0].recipient_node === 'node1');
+  console.log('OK');
+} catch (err) {
+  console.error('FAIL', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `nano_ghostlink_v20` module for outbound Ghostlink packets
- log Ghostlink activity and track status
- test Ghostlink module with Node

## Testing
- `npm test`
- `pytest -q`
- `node tests/nano_ghostlink_v20.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6888133795488322b7bce5ef2b217315