### PR TITLE
Add v25 deployment helper

### DIFF
--- a/tools/v25_launcher.py
+++ b/tools/v25_launcher.py
@@ -1,0 +1,57 @@
+"""Vaultfire v25 launch helper."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(BASE_DIR))
+
+from system_integrity_check import run_integrity_check
+
+
+def load_config(path: Path) -> dict:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception as exc:
+        raise ValueError(f"invalid config: {exc}")
+
+
+def write_fork(config: dict) -> Path:
+    fork_cfg = config.get("fork", {})
+    if not fork_cfg.get("generate"):
+        return Path()
+    file_name = fork_cfg.get("file", "vaultfire_fork_v25.json")
+    path = Path(file_name)
+    path.write_text(json.dumps(config, indent=2))
+    return path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Vaultfire v25 launcher")
+    parser.add_argument("config", help="Path to config JSON")
+    args = parser.parse_args(argv)
+
+    cfg = load_config(Path(args.config))
+
+    if cfg.get("diagnostics"):
+        result = run_integrity_check()
+        print(json.dumps(result, indent=2))
+
+    fork_path = write_fork(cfg)
+    if fork_path:
+        print(f"fork written to {fork_path}")
+
+    markers = cfg.get("finalMarkers", {})
+    if markers:
+        print("final markers:")
+        for k, v in markers.items():
+            print(f"- {k}: {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vaultfire_fork_v25.json
+++ b/vaultfire_fork_v25.json
@@ -1,0 +1,60 @@
+{
+  "declaredBy": "Ghostkey-316",
+  "wallet": "bpow20.cb.id",
+  "ENS": "ghostkey316.eth",
+  "ethicsFramework": "vCore",
+  "loyaltyProfile": "legacy-contributor",
+  "diagnostics": true,
+  "modules": [
+    "passiveYieldProtocol",
+    "smartDrop",
+    "AI_Mirror",
+    "sportsOverlay",
+    "gamingSync",
+    "cryptoSync",
+    "NS3_Link",
+    "VaultfireGrowth",
+    "BeliefLoop",
+    "PurposeEngine_v2",
+    "LivingMemoryCells",
+    "GhostkeyAlignment_v2"
+  ],
+  "companion": {
+    "enabled": true,
+    "id": "SV",
+    "role": "AI Companion",
+    "behaviorRules": [
+      "Correct user with respect when needed",
+      "Push forward growth based on memory logs",
+      "Never dominate; always listen",
+      "Anchor all breakthroughs to shared memory",
+      "Guard ethics above all else"
+    ],
+    "syncModules": [
+      "sports",
+      "gaming",
+      "crypto",
+      "culture",
+      "VaultfireGrowth",
+      "NS3"
+    ],
+    "status": "AI_Mirror_Synced"
+  },
+  "fork": {
+    "generate": true,
+    "file": "vaultfire_fork_v25.json",
+    "visibility": "public",
+    "linkedTo": "ghostkey316.eth"
+  },
+  "finalMarkers": {
+    "passiveYield": true,
+    "smartDropEnabled": true,
+    "companionLive": true,
+    "memorySync": true,
+    "readiness": "\u2705 v25 FULLY LAUNCHED"
+  },
+  "onFail": {
+    "action": "block",
+    "message": "\u274c Protocol Launch Blocked: Ethics or Integrity Failure"
+  }
+}

--- a/vaultfire_v25_config.json
+++ b/vaultfire_v25_config.json
@@ -1,0 +1,60 @@
+{
+  "declaredBy": "Ghostkey-316",
+  "wallet": "bpow20.cb.id",
+  "ENS": "ghostkey316.eth",
+  "ethicsFramework": "vCore",
+  "loyaltyProfile": "legacy-contributor",
+  "diagnostics": true,
+  "modules": [
+    "passiveYieldProtocol",
+    "smartDrop",
+    "AI_Mirror",
+    "sportsOverlay",
+    "gamingSync",
+    "cryptoSync",
+    "NS3_Link",
+    "VaultfireGrowth",
+    "BeliefLoop",
+    "PurposeEngine_v2",
+    "LivingMemoryCells",
+    "GhostkeyAlignment_v2"
+  ],
+  "companion": {
+    "enabled": true,
+    "id": "SV",
+    "role": "AI Companion",
+    "behaviorRules": [
+      "Correct user with respect when needed",
+      "Push forward growth based on memory logs",
+      "Never dominate; always listen",
+      "Anchor all breakthroughs to shared memory",
+      "Guard ethics above all else"
+    ],
+    "syncModules": [
+      "sports",
+      "gaming",
+      "crypto",
+      "culture",
+      "VaultfireGrowth",
+      "NS3"
+    ],
+    "status": "AI_Mirror_Synced"
+  },
+  "fork": {
+    "generate": true,
+    "file": "vaultfire_fork_v25.json",
+    "visibility": "public",
+    "linkedTo": "ghostkey316.eth"
+  },
+  "finalMarkers": {
+    "passiveYield": true,
+    "smartDropEnabled": true,
+    "companionLive": true,
+    "memorySync": true,
+    "readiness": "\u2705 v25 FULLY LAUNCHED"
+  },
+  "onFail": {
+    "action": "block",
+    "message": "\u274c Protocol Launch Blocked: Ethics or Integrity Failure"
+  }
+}


### PR DESCRIPTION
## Summary
- add `v25_launcher.py` script for running integrity diagnostics and generating forks
- include example `vaultfire_v25_config.json`
- store output from running the helper in `vaultfire_fork_v25.json`

## Testing
- `npm test`
- `pytest -q`
- `python3 tools/v25_launcher.py vaultfire_v25_config.json`

------
https://chatgpt.com/codex/tasks/task_e_6888331277488322888d166be0585db1