### PR TITLE
Add Vaultfire expansion stack modules

### DIFF
--- a/vaultfire/__init__.py
+++ b/vaultfire/__init__.py
@@ -1,0 +1,7 @@
+"""Vaultfire helper package."""
+
+from . import echo
+from . import growth
+from . import satellite
+
+__all__ = ["echo", "growth", "satellite"]

--- a/vaultfire/echo.py
+++ b/vaultfire/echo.py
@@ -1,0 +1,50 @@
+"""Companion echo layer deployment utilities.
+
+- Ambient data gathering requires opt-in consent from participants.
+- Nothing here constitutes financial or medical advice.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+STATUS_PATH = BASE_DIR / "vaultfire-core" / "companion_echo_status.json"
+LOG_PATH = BASE_DIR / "logs" / "companion_echo.log"
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data: Any) -> None:
+    os.makedirs(path.parent, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def deploy_companion(identity: Dict[str, Any]) -> Dict[str, Any]:
+    """Record companion deployment using ``identity`` info."""
+    state = _load_json(STATUS_PATH, {"deployments": []})
+    entry = {
+        "wallet": identity.get("wallet"),
+        "ens": identity.get("ens"),
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    state["deployments"].append(entry)
+    _write_json(STATUS_PATH, state)
+
+    log = _load_json(LOG_PATH, [])
+    log.append(entry)
+    _write_json(LOG_PATH, log)
+    return entry

--- a/vaultfire/growth.py
+++ b/vaultfire/growth.py
@@ -1,0 +1,52 @@
+"""Growth fork preparation helpers.
+
+- Ambient data gathering requires opt-in consent from participants.
+- Nothing here constitutes financial or medical advice.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+LOG_PATH = BASE_DIR / "logs" / "growth_prepare_v26.log"
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data: Any) -> None:
+    os.makedirs(path.parent, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def prepare_v26(
+    identity: Dict[str, Any],
+    enableMultipliers: bool = False,
+    enableOpenAISync: bool = False,
+    yieldRewards: bool = False,
+) -> Dict[str, Any]:
+    """Log preparation of the V26 growth fork."""
+    log = _load_json(LOG_PATH, [])
+    entry = {
+        "wallet": identity.get("wallet"),
+        "multipliers": enableMultipliers,
+        "openai_sync": enableOpenAISync,
+        "yield_rewards": yieldRewards,
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    log.append(entry)
+    _write_json(LOG_PATH, log)
+    return entry

--- a/vaultfire/satellite.py
+++ b/vaultfire/satellite.py
@@ -1,0 +1,52 @@
+"""Satellite fork deployment utilities.
+
+- Ambient data gathering requires opt-in consent from participants.
+- Nothing here constitutes financial or medical advice.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+LOG_PATH = BASE_DIR / "logs" / "satellite_lite_fork.log"
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data: Any) -> None:
+    os.makedirs(path.parent, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def deploy_lite_fork(
+    identity: Dict[str, Any],
+    restrictAdminAccess: bool = False,
+    allowReferral: bool = False,
+    passiveTracking: bool = False,
+) -> Dict[str, Any]:
+    """Log deployment of a lite satellite fork."""
+    log = _load_json(LOG_PATH, [])
+    entry = {
+        "wallet": identity.get("wallet"),
+        "restrict_admin": restrictAdminAccess,
+        "allow_referral": allowReferral,
+        "passive_tracking": passiveTracking,
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    log.append(entry)
+    _write_json(LOG_PATH, log)
+    return entry

--- a/vaultfire_expansion_stack.py
+++ b/vaultfire_expansion_stack.py
@@ -1,0 +1,47 @@
+"""Initialize the Vaultfire v25+ expansion stack.
+
+- This repository is production-ready with stable features.
+- Ambient data gathering requires opt-in consent from participants.
+- No module in this repository offers medical or legal advice.
+- System logs may store limited personal data for reflective analysis.
+- Partnerships are fully supported and integration examples run in production.
+- Plugin support is provided as-is with no guarantee of compatibility or continued maintenance.
+- Partners must perform their own compliance review before deploying.
+- Vaultfire modules may change without notice and are provided as-is.
+- Nothing in this repository constitutes financial advice.
+"""
+
+from __future__ import annotations
+
+from vaultfire import echo, growth, satellite
+
+
+user_identity = {
+    "wallet": "bpow20.cb.id",
+    "ens": "ghostkey316.eth",
+    "legacyTier": True,
+    "syncMode": "full",
+    "behaviorTracking": True,
+    "ethicsVerified": True,
+}
+
+
+def main() -> None:
+    echo.deploy_companion(user_identity)
+    growth.prepare_v26(
+        user_identity,
+        enableMultipliers=True,
+        enableOpenAISync=True,
+        yieldRewards=True,
+    )
+    satellite.deploy_lite_fork(
+        user_identity,
+        restrictAdminAccess=True,
+        allowReferral=True,
+        passiveTracking=True,
+    )
+    print("\u2705 Vaultfire Expansion Stack (Steps 1\u20134) Initialized")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new `vaultfire` package with `echo`, `growth`, and `satellite` modules
- log companion deploys, growth preparation, and satellite forks
- provide a script `vaultfire_expansion_stack.py` to run the initialization sequence

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888380fdf708322b0c76da3cbf3afd8