### PR TITLE
Deploy Vaultfire Codex Bundle v1.0

### DIFF
--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -112,6 +112,6 @@
     "role": "Architect"
   },
   "date_created": "2025-07-25T04:33:48Z",
-  "system_status": "active, stable, partner-ready",
+  "system_status": "\ud83d\udd13 Codex-Activated: Belief-Based System",
   "checksum": "7e45f084491cdc04d046a080909694c90f77be515ed11b54aad1c9fb3fd311f6"
 }

--- a/deploy_codex_bundle.py
+++ b/deploy_codex_bundle.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import zipfile
+
+BASE_DIR = Path(__file__).resolve().parent
+OUTPUT_PATH = BASE_DIR / "vaultfire_codex_bundle_v1.zip"
+
+
+def gather_files() -> list[Path]:
+    files = [BASE_DIR / "partner_auto_onboard.py"]
+    files.extend(sorted(BASE_DIR.glob("vaultfire_*.json")))
+    return [f for f in files if f.exists()]
+
+
+def build_bundle(output: Path, files: list[Path]) -> None:
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in files:
+            zf.write(path, path.name)
+
+
+def main() -> int:
+    files = gather_files()
+    build_bundle(OUTPUT_PATH, files)
+    manifest = {"bundle": OUTPUT_PATH.name, "files": [f.name for f in files]}
+    print(json.dumps(manifest, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a simple deployment script that packages partner modules and config JSON
- update codex manifest status to show belief-based activation

## Testing
- `python3 -m pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888544f1c048322afb7eefdd191d65d