### PR TITLE
Add Genesis Beacon & yield activation scripts

### DIFF
--- a/activate_yield.js
+++ b/activate_yield.js
@@ -1,0 +1,1 @@
+console.log("💸 Passive Yield Logic Activated by Ghostkey-316");

--- a/scripts/sync_genesis_beacon.sh
+++ b/scripts/sync_genesis_beacon.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "🚨 Genesis Beacon Synced by Ghostkey-316"
+# log checksum or trigger event here


### PR DESCRIPTION
## Summary
- add a script to sync the genesis beacon
- add a small yield activation helper

## Testing
- `npm test`
- `pytest -q`
- `git push origin main` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6888679997288322871d25ca21c21559