### PR TITLE
Log remote v27.2 activation

### DIFF
--- a/contributors/VaultfireManifest.log
+++ b/contributors/VaultfireManifest.log
@@ -2,3 +2,4 @@ Ghostkey-316 | Vaultfire v26.1 | 2025-07-29 | Commit: Expansion Protocol Initial
 Ghostkey-316 | v26.2–v27.0 Full Stack Expansion | 2025-07-29
 Ghostkey-316 | Vaultfire Forkpoint v27.0 Finalized | 2025-07-29 | Partner onboarding and global sync active
 Ghostkey-316 | Vaultfire v27.0 | 2025-07-29 | Commit: Partner Forkpoint Activated and Global Handshake Initiated
+Ghostkey-316 | Vaultfire v27.2 | 2025-07-30 | Remote activation validated. Echo relay confirmed. Snapshot ID minted.


### PR DESCRIPTION
## Summary
- record remote activation in `VaultfireManifest.log`

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6888f800fb3c8322a248cc78b55e0a88