### PR TITLE
Add partner protocol shell plugin

### DIFF
--- a/partner_plugins/partner_protocol_shell.py
+++ b/partner_plugins/partner_protocol_shell.py
@@ -1,0 +1,48 @@
+"""Partner protocol shell utilities for Vaultfire v27.2."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Dict
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+TESTBED_DIR = Path(os.getenv("PARTNER_PROTOCOL_DIR", BASE_DIR / "partner_protocols"))
+
+
+def clone_protocol(version: str, partner_id: str) -> Path:
+    """Create or replace a versioned testbed directory."""
+    target = TESTBED_DIR / f"{partner_id}_{version}"
+    if target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True)
+    return target
+
+
+def setup_shell(version: str, partner_id: str, ens: str, wallet: str) -> Dict:
+    """Initialize protocol shell with bound ENS and wallet."""
+    path = clone_protocol(version, partner_id)
+    cfg = {
+        "version": version,
+        "partner_id": partner_id,
+        "ens": ens,
+        "wallet": wallet,
+        "plugin_ready": True,
+    }
+    (path / "partner_shell_config.json").write_text(json.dumps(cfg, indent=2))
+    return cfg
+
+
+def sync_echo(path: Path) -> None:
+    """Record echo sync confirmation."""
+    (path / "echo_synced").write_text("ok")
+
+
+def register_fallback(path: Path, endpoint: str) -> None:
+    """Register remote fallback endpoint for the shell."""
+    (path / "remote_fallback.json").write_text(json.dumps({"endpoint": endpoint}, indent=2))
+
+
+__all__ = ["setup_shell", "sync_echo", "register_fallback", "TESTBED_DIR"]

--- a/partner_plugins/tests/test_partner_protocol_shell.py
+++ b/partner_plugins/tests/test_partner_protocol_shell.py
@@ -1,0 +1,34 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from partner_plugins import partner_protocol_shell as pps
+
+
+class ProtocolShellTest(unittest.TestCase):
+    def test_setup_and_sync(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["PARTNER_PROTOCOL_DIR"] = tmp
+            pps.TESTBED_DIR = Path(tmp)
+            cfg = pps.setup_shell(
+                "Vaultfire_v27.2",
+                "Ghostkey-316",
+                "ghostkey316.eth",
+                "bpow20.cb.id",
+            )
+            tb = Path(tmp) / "Ghostkey-316_Vaultfire_v27.2"
+            self.assertTrue(tb.exists())
+            data = json.loads((tb / "partner_shell_config.json").read_text())
+            self.assertTrue(data["plugin_ready"])
+            pps.sync_echo(tb)
+            self.assertTrue((tb / "echo_synced").exists())
+            pps.register_fallback(tb, "https://remote.example")
+            fb = json.loads((tb / "remote_fallback.json").read_text())
+            self.assertEqual(fb["endpoint"], "https://remote.example")
+            del os.environ["PARTNER_PROTOCOL_DIR"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vaultfire_cli_plugins/protocol_shell_cli.py
+++ b/vaultfire_cli_plugins/protocol_shell_cli.py
@@ -1,0 +1,56 @@
+import argparse
+import json
+from partner_plugins.partner_protocol_shell import (
+    setup_shell,
+    sync_echo,
+    register_fallback,
+    TESTBED_DIR,
+)
+
+VERSION = "Vaultfire_v27.2"
+
+
+def _cmd_clone(args: argparse.Namespace) -> None:
+    conf = setup_shell(VERSION, args.partner, args.ens, args.wallet)
+    print(json.dumps(conf, indent=2))
+
+
+def _cmd_echo(args: argparse.Namespace) -> None:
+    path = TESTBED_DIR / f"{args.partner}_{VERSION}"
+    if not path.exists():
+        print("testbed not found")
+        return
+    sync_echo(path)
+    print("echo synced")
+
+
+def _cmd_fallback(args: argparse.Namespace) -> None:
+    path = TESTBED_DIR / f"{args.partner}_{VERSION}"
+    if not path.exists():
+        print("testbed not found")
+        return
+    register_fallback(path, args.endpoint)
+    print("fallback registered")
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    p_clone = subparsers.add_parser(
+        "protocol.clone", help="Clone Vaultfire v27.2 testbed"
+    )
+    p_clone.add_argument("--partner", default="Ghostkey-316")
+    p_clone.add_argument("--ens", default="ghostkey316.eth")
+    p_clone.add_argument("--wallet", default="bpow20.cb.id")
+    p_clone.set_defaults(func=_cmd_clone)
+
+    p_echo = subparsers.add_parser(
+        "protocol.sync-echo", help="Confirm echo sync for testbed"
+    )
+    p_echo.add_argument("--partner", default="Ghostkey-316")
+    p_echo.set_defaults(func=_cmd_echo)
+
+    p_fallback = subparsers.add_parser(
+        "protocol.set-fallback", help="Register remote fallback"
+    )
+    p_fallback.add_argument("--partner", default="Ghostkey-316")
+    p_fallback.add_argument("endpoint")
+    p_fallback.set_defaults(func=_cmd_fallback)


### PR DESCRIPTION
## Summary
- add partner_protocol_shell plugin for setting up a vaultfire testbed
- wire plugin to CLI via `protocol_shell_cli`
- cover plugin with unit test

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888f93eef008322b66f922cd36c65ff