### PR TITLE
Add logging fail traps

### DIFF
--- a/build_cli_bundle.py
+++ b/build_cli_bundle.py
@@ -2,9 +2,12 @@ import argparse
 import json
 import zipfile
 from pathlib import Path
+import logging
 
 from activate_global_kernel import activate as activate_kernel
 from activate_live_training import activate as activate_live
+
+logger = logging.getLogger(__name__)
 
 # optional import - file may not exist
 def log_proof(proof_path: str) -> None:
@@ -13,7 +16,7 @@ def log_proof(proof_path: str) -> None:
         if hasattr(module, 'confirm'):
             module.confirm()
     except Exception:
-        pass
+        logger.exception("Failed to log proof module %s", proof_path)
 
 def build_cli_bundle(output: Path, modules: list[str]) -> None:
     with zipfile.ZipFile(output, 'w', zipfile.ZIP_DEFLATED) as zf:

--- a/engine/feedback_loop.py
+++ b/engine/feedback_loop.py
@@ -3,6 +3,7 @@ import json
 import os
 from pathlib import Path
 from datetime import datetime
+import logging
 
 from vaultfire_signal import log_vaultfire_status
 from .yield_engine_v1 import mark_yield_boost
@@ -10,6 +11,8 @@ from .belief_validation import validate_belief
 from .immutable_log import append_entry
 
 BASE_DIR = Path(__file__).resolve().parents[1]
+
+logger = logging.getLogger(__name__)
 EVENT_LOG_PATH = BASE_DIR / "event_log.json"
 SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
 AUDIT_PATH = BASE_DIR / "logs" / "feedback_audit.json"
@@ -134,17 +137,20 @@ def check_thresholds(user_id):
 
 def sync_openai(user_id, event):
     """Placeholder for OpenAI reflection prompts."""
-    pass
+    logger.warning("sync_openai called but not implemented")
+    raise NotImplementedError("OpenAI integration not implemented")
 
 
 def sync_ns3(user_id, event):
     """Placeholder for NS3 quiz response mirror."""
-    pass
+    logger.warning("sync_ns3 called but not implemented")
+    raise NotImplementedError("NS3 integration not implemented")
 
 
 def sync_worldcoin(user_id):
     """Placeholder for Worldcoin ID verification hook."""
-    pass
+    logger.warning("sync_worldcoin called but not implemented")
+    raise NotImplementedError("Worldcoin integration not implemented")
 
 
 def _log_audit(entry):

--- a/engine/gaming_layer.py
+++ b/engine/gaming_layer.py
@@ -6,11 +6,14 @@ import json
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
+import logging
 
 from .partner_hooks import grant_reward
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 SESSIONS_PATH = BASE_DIR / "logs" / "game_sessions.json"
+
+logger = logging.getLogger(__name__)
 
 
 def _load_json(path: Path, default):
@@ -51,6 +54,7 @@ def create_session(
             start_stream(stream_handle)
             session["stream"] = stream_handle
         except Exception:
+            logger.exception("start_stream failed for %s", stream_handle)
             session["stream"] = stream_handle
     sessions.append(session)
     _write_json(SESSIONS_PATH, sessions)
@@ -81,13 +85,13 @@ def end_session(game_id: str, reward_per_player: float = 0.0, token: str = "ASM"
                     from .twitch_layer import end_stream
                     end_stream(session["stream"])
                 except Exception:
-                    pass
+                    logger.exception("end_stream failed for %s", session["stream"])
             _write_json(SESSIONS_PATH, sessions)
             if reward_per_player > 0:
                 for player in session.get("players", []):
                     try:
                         grant_reward(player, player, reward_per_player, token)
                     except Exception:
-                        pass
+                        logger.exception("grant_reward failed for player %s", player)
             return session
     return None

--- a/vaultfire_cli_tool.py
+++ b/vaultfire_cli_tool.py
@@ -1,6 +1,7 @@
 import argparse
 import hashlib
 import json
+import logging
 import urllib.request
 from importlib import import_module
 from pathlib import Path
@@ -8,6 +9,8 @@ from pathlib import Path
 BASE_DIR = Path(__file__).resolve().parent
 PROTOCOL_DIR = BASE_DIR / "belief_protocols"
 PLUGIN_DIR = BASE_DIR / "vaultfire_cli_plugins"
+
+logger = logging.getLogger(__name__)
 
 
 def _load_json(path: Path, default):
@@ -144,6 +147,7 @@ def load_plugins(subparsers: argparse._SubParsersAction) -> None:
                 if hasattr(module, "register"):
                     module.register(subparsers)
             except Exception:
+                logger.exception("Failed to load plugin %s", mod_name)
                 continue
 
 


### PR DESCRIPTION
## Summary
- add logger exception handling to CLI bundle builder
- report plugin load errors in vaultfire CLI
- log failures in gaming layer stream & reward hooks
- raise NotImplementedError for unimplemented feedback sync functions

## Testing
- `npm test`
- `pytest -q`
- `python run_full_system_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68899f87cf348322a2a3de5e881efd52