### PR TITLE
Ensure Jest covers tests directory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  testMatch: ['**/__tests__/**/*.test.js'],
+  // Include both legacy __tests__ directory and the newer tests directory
+  testMatch: ['**/__tests__/**/*.test.js', '**/tests/**/*.test.js'],
 };

--- a/tests/nano_echopulse_v17.test.js
+++ b/tests/nano_echopulse_v17.test.js
@@ -14,9 +14,9 @@ const logPath = path.join(__dirname, '..', 'logs', 'echopulse_feedback_v17.log')
 
 function reset() {
   [statusPath, logPath].forEach(p => { if (fs.existsSync(p)) fs.unlinkSync(p); });
-}
 
-try {
+}
+test('nano_echopulse_v17.test', () => {
   reset();
   matchBeliefEcho('belief', 'belief');
   measureSignalClarity('intent', 'intentional');
@@ -28,8 +28,4 @@ try {
   const logs = JSON.parse(fs.readFileSync(logPath, 'utf8'));
   assert(logs.length === 1);
   assert(logs[0].fingerprint === 'finger1');
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nano_ghostlink_return_v21.test.js
+++ b/tests/nano_ghostlink_return_v21.test.js
@@ -17,9 +17,9 @@ function reset() {
   [gl20Status, gl20Log, statusPath, logPath, memLog, echoStatus, synStatus].forEach(p => {
     if (fs.existsSync(p)) fs.unlinkSync(p);
   });
-}
 
-try {
+}
+test('nano_ghostlink_return_v21.test', () => {
   reset();
   fs.mkdirSync(path.dirname(memLog), { recursive: true });
   fs.writeFileSync(memLog, JSON.stringify([{ ok: true }]));
@@ -40,8 +40,4 @@ try {
   assert(state.metadata.return_status === 'verified');
   const log = JSON.parse(fs.readFileSync(logPath, 'utf8'));
   assert(log[0].verified === true);
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nano_ghostlink_v20.test.js
+++ b/tests/nano_ghostlink_v20.test.js
@@ -10,9 +10,9 @@ const memoryLog = path.join(__dirname, '..', 'logs', 'memorybridge_v18.log');
 
 function reset() {
   [statusPath, logPath, memoryLog].forEach(p => { if (fs.existsSync(p)) fs.unlinkSync(p); });
-}
 
-try {
+}
+test('nano_ghostlink_v20.test', () => {
   reset();
   fs.mkdirSync(path.dirname(memoryLog), { recursive: true });
   fs.writeFileSync(memoryLog, JSON.stringify([{ ok: true }]));
@@ -24,8 +24,4 @@ try {
   assert(log.length === 1);
   assert(log[0].bridge_confirmed === true);
   assert(log[0].recipient_node === 'node1');
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nano_loyaltyforge_v15.test.js
+++ b/tests/nano_loyaltyforge_v15.test.js
@@ -17,9 +17,9 @@ const logPath = path.join(__dirname, '..', 'logs', 'nano_loyaltyforge_v15.log');
 function reset() {
   if (fs.existsSync(statusPath)) fs.unlinkSync(statusPath);
   if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
-}
 
-try {
+}
+test('nano_loyaltyforge_v15.test', () => {
   reset();
   initLoyaltyProfile('g316', 'wallet1');
   updateBeliefScore('g316', 'action1', 10);
@@ -32,8 +32,4 @@ try {
   assert(state.profiles['g316'].tier === 'Tier3');
   assert(state.syncs.length === 1);
   assert(state.minted.length === 1);
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nano_memorybridge_v18.test.js
+++ b/tests/nano_memorybridge_v18.test.js
@@ -14,9 +14,9 @@ function reset() {
   [statusPath, logPath, moralPath, paStatus, paLog].forEach(p => {
     if (fs.existsSync(p)) fs.unlinkSync(p);
   });
-}
 
-try {
+}
+test('nano_memorybridge_v18.test', () => {
   reset();
   recordSignalEvent('nano_echopulse_v17', 'belief1', 0.8, true, ['t1']);
   recordSignalEvent('nano_echopulse_v17', 'belief1', 0.85, true, ['t1']);
@@ -28,8 +28,4 @@ try {
   assert(log.length === 1);
   assert(log[0].memory_node.origin_module === 'nano_echopulse_v17');
   assert(fs.existsSync(moralPath));
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nano_pathatlas_v16.test.js
+++ b/tests/nano_pathatlas_v16.test.js
@@ -15,9 +15,9 @@ const moralPath = path.join(__dirname, '..', 'logs', 'moral_mirror.json');
 
 function reset() {
   [statusPath, logPath, moralPath].forEach(p => { if (fs.existsSync(p)) fs.unlinkSync(p); });
-}
 
-try {
+}
+test('nano_pathatlas_v16.test', () => {
   reset();
   captureBeliefEvent('user1', 'beliefX', { type: 'click' });
   assignConsequenceTrail('user1', 'beliefX', 'success');
@@ -27,8 +27,4 @@ try {
   assert(state.trails.length === 1);
   assert(state.predictions.length === 1);
   assert(fs.existsSync(moralPath));
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nano_quantaignition_v22.test.js
+++ b/tests/nano_quantaignition_v22.test.js
@@ -19,9 +19,9 @@ const qiLog = path.join(__dirname, '..', 'logs', 'nano_quantaignition_v22.log');
 
 function reset() {
   [echoStatus, memLog, synStatus, retStatus, qiStatus, qiLog].forEach(p => { if (fs.existsSync(p)) fs.unlinkSync(p); });
-}
 
-try {
+}
+test('nano_quantaignition_v22.test', () => {
   reset();
   fs.mkdirSync(path.dirname(echoStatus), { recursive: true });
   fs.writeFileSync(echoStatus, JSON.stringify({ metadata: { echo_confirmed: true, clarity_score: 0.9 } }));
@@ -40,8 +40,4 @@ try {
   assert(state.metadata.verification_tag === 'final-tag');
   assert(state.metadata.loop_completed === true);
   assert(state.checkpoints.length === 2); // ignition + loop_final
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nano_synapsefire_v19.test.js
+++ b/tests/nano_synapsefire_v19.test.js
@@ -13,9 +13,9 @@ const pathatlasLog = path.join(__dirname, '..', 'logs', 'pathatlas_v16.log');
 
 function reset() {
   [statusPath, syncLogPath, auditLogPath, echoStatusPath, memorySyncPath, pathatlasLog].forEach(p => { if (fs.existsSync(p)) fs.unlinkSync(p); });
-}
 
-try {
+}
+test('nano_synapsefire_v19.test', () => {
   reset();
   fs.mkdirSync(path.dirname(echoStatusPath), { recursive: true });
   fs.writeFileSync(echoStatusPath, JSON.stringify({ metadata: { echo_confirmed: true, clarity_score: 0.85 } }));
@@ -33,8 +33,4 @@ try {
   assert(syncLog.length === 1);
   assert(syncLog[0].verified === true);
   assert(auditLog[0].verified_by_ethics === true);
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nano_trustengine_v14.test.js
+++ b/tests/nano_trustengine_v14.test.js
@@ -18,9 +18,9 @@ function reset() {
   [statusPath, logPath].forEach(p => {
     if (fs.existsSync(p)) fs.unlinkSync(p);
   });
-}
 
-try {
+}
+test('nano_trustengine_v14.test', () => {
   reset();
   initTrustMap('g316', 'wallet1');
   updateScore('g316', 'action1', 5);
@@ -34,8 +34,4 @@ try {
   assert(state.validations.length === 1);
   assert(state.syncs.length === 1);
   assert(state.fingerprints.length === 1);
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nanoloop_conscious_v7.test.js
+++ b/tests/nanoloop_conscious_v7.test.js
@@ -10,9 +10,9 @@ const logPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v7_log.js
 function reset() {
   if (fs.existsSync(statusPath)) fs.unlinkSync(statusPath);
   if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
-}
 
-try {
+}
+test('nanoloop_conscious_v7.test', () => {
   reset();
   reflect('Ghostkey-316', 4, 'ghostkey316.ethics_core');
   mirror('Ghostkey-316');
@@ -24,8 +24,4 @@ try {
   assert(state.mirrors.length === 1);
   assert(state.reminders.length === 1);
   assert(state.checkloops.length === 1);
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nanoloop_counterforce_v5.test.js
+++ b/tests/nanoloop_counterforce_v5.test.js
@@ -10,9 +10,9 @@ const logPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v5_log.js
 function reset() {
   if (fs.existsSync(statusPath)) fs.unlinkSync(statusPath);
   if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
-}
 
-try {
+}
+test('nanoloop_counterforce_v5.test', () => {
   process.env.NS3_MIRROR = 'active';
   reset();
   trace('Ghostkey-316', 'alpha');
@@ -24,8 +24,4 @@ try {
   assert(state.echoes.length === 1);
   assert(state.counters.length === 1);
   assert(state.deflects.length === 1);
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nanoloop_ghostlayer_v12.test.js
+++ b/tests/nanoloop_ghostlayer_v12.test.js
@@ -10,9 +10,9 @@ const logPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v12_log.j
 function reset() {
   if (fs.existsSync(statusPath)) fs.unlinkSync(statusPath);
   if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
-}
 
-try {
+}
+test('nanoloop_ghostlayer_v12.test', () => {
   reset();
   deploy_decoy('probe-sig');
   reflect('exploit');
@@ -23,8 +23,4 @@ try {
   assert(state.reflections.length === 1);
   assert(state.tracebacks.length === 1);
   assert(state.events.length === 1);
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nanoloop_innervoice_v8.test.js
+++ b/tests/nanoloop_innervoice_v8.test.js
@@ -10,9 +10,9 @@ const logPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v8_log.js
 function reset() {
   if (fs.existsSync(statusPath)) fs.unlinkSync(statusPath);
   if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
-}
 
-try {
+}
+test('nanoloop_innervoice_v8.test', () => {
   reset();
   echo('Ghostkey-316', 'internal thought');
   listen('Ghostkey-316');
@@ -25,8 +25,4 @@ try {
   assert(state.biaschecks.length === 1);
   assert(state.whispers.length === 1);
   assert(state.resolves.length === 1);
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nanoloop_memory_v10.test.js
+++ b/tests/nanoloop_memory_v10.test.js
@@ -10,9 +10,9 @@ const logPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v10_log.j
 function reset() {
   if (fs.existsSync(statusPath)) fs.unlinkSync(statusPath);
   if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
-}
 
-try {
+}
+test('nanoloop_memory_v10.test', () => {
   reset();
   graft('override.log', 'ctx', 123);
   bind('ghostkey316.eth', 'ethics_foundation');
@@ -23,8 +23,4 @@ try {
   assert(state.locks.length === 1);
   const report = audit();
   assert(report.grafts.length === 1);
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nanoloop_metamirror_v13.test.js
+++ b/tests/nanoloop_metamirror_v13.test.js
@@ -18,9 +18,9 @@ function reset() {
   [statusPath, logPath].forEach(p => {
     if (fs.existsSync(p)) fs.unlinkSync(p);
   });
-}
 
-try {
+}
+test('nanoloop_metamirror_v13.test', () => {
   reset();
   reflectSignal({ id: 's1', decoy: true });
   verifyOrigin('trace1', 'phash1');
@@ -32,8 +32,4 @@ try {
   assert(state.echos.length === 1);
   assert(state.loops.length === 1);
   assert(fs.existsSync(pingPath));
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nanoloop_sovereign_v6.test.js
+++ b/tests/nanoloop_sovereign_v6.test.js
@@ -10,9 +10,9 @@ const logPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v6_log.js
 function reset() {
   if (fs.existsSync(statusPath)) fs.unlinkSync(statusPath);
   if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
-}
 
-try {
+}
+test('nanoloop_sovereign_v6.test', () => {
   reset();
   recursify('Ghostkey-316', 2);
   realign('Ghostkey-316', 'ethics-first');
@@ -23,8 +23,4 @@ try {
   assert(state.realigns.length === 1);
   assert(state.vowchecks.length === 1);
   assert(state.growthmaps.length === 1);
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/nanoloop_v3_predictive.test.js
+++ b/tests/nanoloop_v3_predictive.test.js
@@ -10,17 +10,13 @@ const logPath = path.join(__dirname, '..', 'vaultfire-core', 'nanoloop_v3_log.js
 function reset(){
   if (fs.existsSync(statusPath)) fs.unlinkSync(statusPath);
   if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
-}
 
-try {
+}
+test('nanoloop_v3_predictive.test', () => {
   reset();
   predict('Ghostkey-316', 'sys', 0.8);
   shield('Ghostkey-316', 'sys');
   const state = audit();
   assert(state.predictions.length === 1);
   assert(state.shields.length === 1);
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/test_multiplayer_sync.js
+++ b/tests/test_multiplayer_sync.js
@@ -8,7 +8,6 @@ const { createIframe } = require('../web_mirror_viewer');
 function resetLog() {
   const p = path.join(__dirname, '..', 'fork_log.json');
   fs.writeFileSync(p, '[]');
-}
 
 function testSync() {
   resetLog();
@@ -20,7 +19,6 @@ function testSync() {
   assert(received && received.choice === 'A');
   const log = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'fork_log.json')));
   assert(log.length === 1);
-}
 
 function testViewerConfig() {
   const cfgPath = path.join(__dirname, '..', 'embed_config.json');
@@ -30,13 +28,9 @@ function testViewerConfig() {
   assert(html.includes('?visual_shell=1'));
   assert(html.includes('width="500"'));
   fs.writeFileSync(cfgPath, JSON.stringify({ width: 640, height: 480 }));
-}
 
-try {
+}
+test('test_multiplayer_sync', () => {
   testSync();
   testViewerConfig();
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
-}
+});

--- a/tests/test_observer_map.js
+++ b/tests/test_observer_map.js
@@ -5,12 +5,8 @@ function testHtml() {
   const html = fs.readFileSync('observer_hub.html', 'utf8');
   assert(html.includes('Global Belief Map'));
   assert(html.includes('tr.high'));
-}
 
-try {
-  testHtml();
-  console.log('OK');
-} catch (err) {
-  console.error('FAIL', err);
-  process.exit(1);
 }
+test('test_observer_map', () => {
+  testHtml();
+});


### PR DESCRIPTION
## Summary
- point Jest to run all JavaScript tests in `tests/`
- convert Node-based test scripts to Jest syntax

## Testing
- `npm test`
- `pytest -q`
- `python run_full_system_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_6889afb93d288322aa31318335c2bb6f