### PR TITLE
Add optional DB backend

### DIFF
--- a/engine/storage.py
+++ b/engine/storage.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import create_engine, Column, Integer, String, Text
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+CONFIG_PATH = BASE_DIR / "vaultfire_config.json"
+
+Base = declarative_base()
+_engine = None
+_Session = None
+
+
+def _load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _init_engine():
+    global _engine, _Session
+    if _engine is not None:
+        return
+    cfg = _load_config()
+    if not cfg.get("use_database"):
+        return
+    url = cfg.get("database_url", "sqlite:///vaultfire.db")
+    _engine = create_engine(url)
+    _Session = sessionmaker(bind=_engine)
+    Base.metadata.create_all(_engine)
+
+
+def is_enabled() -> bool:
+    cfg = _load_config()
+    return bool(cfg.get("use_database"))
+
+
+class KV(Base):
+    __tablename__ = "kv_store"
+    key = Column(String(255), primary_key=True)
+    value = Column(Text)
+
+
+def load_data(path: Path, default: Any):
+    if not is_enabled():
+        if path.exists():
+            try:
+                with open(path) as f:
+                    return json.load(f)
+            except json.JSONDecodeError:
+                return default
+        return default
+
+    _init_engine()
+    session = _Session()
+    record = session.query(KV).filter_by(key=str(path)).first()
+    session.close()
+    if record:
+        try:
+            return json.loads(record.value)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def write_data(path: Path, data: Any) -> None:
+    if not is_enabled():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+        return
+
+    _init_engine()
+    session = _Session()
+    record = session.query(KV).filter_by(key=str(path)).first()
+    data_json = json.dumps(data)
+    if record:
+        record.value = data_json
+    else:
+        record = KV(key=str(path), value=data_json)
+        session.add(record)
+    session.commit()
+    session.close()
+
+
+class LogEntry(Base):
+    __tablename__ = "log_entries"
+    id = Column(Integer, primary_key=True)
+    path = Column(String(255))
+    entry = Column(Text)
+
+
+def append_log(path: Path, entry: Any) -> None:
+    if not is_enabled():
+        log = []
+        if path.exists():
+            try:
+                with open(path) as f:
+                    log = json.load(f)
+            except json.JSONDecodeError:
+                log = []
+        log.append(entry)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(log, f, indent=2)
+        return
+
+    _init_engine()
+    session = _Session()
+    record = LogEntry(path=str(path), entry=json.dumps(entry))
+    session.add(record)
+    session.commit()
+    session.close()

--- a/engine/yield_engine_v1.py
+++ b/engine/yield_engine_v1.py
@@ -4,6 +4,7 @@
 import json
 from pathlib import Path
 from datetime import datetime
+from . import storage
 
 from .loyalty_engine import loyalty_score
 from .token_ops import send_token
@@ -26,9 +27,10 @@ OG_LIST_PATH = BASE_DIR / "og_loyalists.json"
 BASE_APR = 0.05
 
 
-def _load_json(path):
-    with open(path) as f:
-        return json.load(f)
+def _load_json(path, default=None):
+    if default is None:
+        default = {}
+    return storage.load_data(path, default)
 
 
 # --- Loyalty and verification helpers --------------------------------------
@@ -60,19 +62,10 @@ def _dynamic_apr(user_id: str) -> float:
 
 
 def _log_audit(entry):
-    """Append an entry to morals_audit_log.json."""
-    log = []
-    if AUDIT_LOG_PATH.exists():
-        with open(AUDIT_LOG_PATH) as f:
-            try:
-                log = json.load(f)
-            except json.JSONDecodeError:
-                log = []
+    """Append an audit entry using configured storage backend."""
     timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     entry_with_time = {"timestamp": timestamp, **entry}
-    log.append(entry_with_time)
-    with open(AUDIT_LOG_PATH, "w") as f:
-        json.dump(log, f, indent=2)
+    storage.append_log(AUDIT_LOG_PATH, entry_with_time)
 
 
 # --- Loyalty certification & passive yield ---------------------------------
@@ -129,18 +122,11 @@ def distribute_passive_yield(contributor_data: dict) -> dict:
 
 def _update_passive_ledger(entries: dict) -> None:
     """Append ``entries`` to the passive yield ledger."""
-    ledger = []
-    if PASSIVE_LEDGER_PATH.exists():
-        try:
-            with open(PASSIVE_LEDGER_PATH) as f:
-                ledger = json.load(f)
-        except json.JSONDecodeError:
-            ledger = []
+    ledger = storage.load_data(PASSIVE_LEDGER_PATH, [])
     timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     for wallet, data in entries.items():
         ledger.append({"timestamp": timestamp, "wallet": wallet, **data})
-    with open(PASSIVE_LEDGER_PATH, "w") as f:
-        json.dump(ledger, f, indent=2)
+    storage.write_data(PASSIVE_LEDGER_PATH, ledger)
 
 
 # --- Yield Calculation ------------------------------------------------------
@@ -214,14 +200,8 @@ BOOST_CANDIDATE_PATH = BASE_DIR / "logs" / "yield_boost.json"
 def mark_yield_boost(user_id):
     """Flag user for yield boost consideration."""
     candidates = []
-    if BOOST_CANDIDATE_PATH.exists():
-        try:
-            with open(BOOST_CANDIDATE_PATH) as f:
-                candidates = json.load(f)
-        except json.JSONDecodeError:
-            candidates = []
+    candidates = storage.load_data(BOOST_CANDIDATE_PATH, [])
     if user_id not in candidates:
         candidates.append(user_id)
-        with open(BOOST_CANDIDATE_PATH, "w") as f:
-            json.dump(candidates, f, indent=2)
+        storage.write_data(BOOST_CANDIDATE_PATH, candidates)
         _log_audit({"action": "yield_boost_mark", "user_id": user_id})

--- a/onboarding_api.py
+++ b/onboarding_api.py
@@ -1,6 +1,7 @@
 # Reference: ethics/core.mdx
 import json
 from pathlib import Path
+from engine import storage
 from flask import Flask, request, jsonify
 from simulate_partner_activation import simulate_activation, ALIGNMENT_PHRASE
 from engine.ens_sync_status import read_sync_status
@@ -29,18 +30,11 @@ CONFIG_PATH = BASE_DIR / "vault_config.json"
 
 
 def _load_json(path: Path, default):
-    if path.exists():
-        try:
-            with open(path) as f:
-                return json.load(f)
-        except json.JSONDecodeError:
-            return default
-    return default
+    return storage.load_data(path, default)
 
 
 def _write_json(path: Path, data) -> None:
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2)
+    storage.write_data(path, data)
 
 
 @app.post("/activate/simulate")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ web3
 ens
 psutil
 cryptography
+SQLAlchemy
+psycopg2-binary

--- a/scripts/migrate_json_to_db.py
+++ b/scripts/migrate_json_to_db.py
@@ -1,0 +1,41 @@
+"""Convert JSON data files and logs to the database backend."""
+from pathlib import Path
+import json
+from engine import storage
+
+FILES = [
+    Path("partners.json"),
+    Path("user_list.json"),
+    Path("earners.json"),
+    Path("user_scorecard.json"),
+    Path("og_loyalists.json"),
+    Path("vaultfire-core") / "ethics" / "morals_audit_log.json",
+    Path("logs") / "passive_yield.json",
+]
+
+def migrate_file(path: Path):
+    if not path.exists():
+        return
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        return
+    if isinstance(data, list) or isinstance(data, dict):
+        storage.write_data(path, data)
+    else:
+        for entry in data:
+            storage.append_log(path, entry)
+    print(f"migrated {path}")
+
+
+def main():
+    if not storage.is_enabled():
+        print("Database not enabled in configuration")
+        return
+    for f in FILES:
+        migrate_file(Path(f))
+
+
+if __name__ == "__main__":
+    main()

--- a/vaultfire-core/vaultfire_config.json
+++ b/vaultfire-core/vaultfire_config.json
@@ -7,4 +7,7 @@
   "wallet_auth_hook": true,
   "live_training_mode": true,
   "fail_safe": "Hard shutdown on ethics breach"
+  ,
+  "use_database": false,
+  "database_url": "sqlite:///vaultfire.db"
 }

--- a/vaultfire_config.json
+++ b/vaultfire_config.json
@@ -7,5 +7,7 @@
   "wallet_auth_hook": true,
   "live_training_mode": true,
   "fail_safe": "Hard shutdown on ethics breach",
-  "localforge_enabled": true
+  "localforge_enabled": true,
+  "use_database": false,
+  "database_url": "sqlite:///vaultfire.db"
 }


### PR DESCRIPTION
## Summary
- support optional SQL database backend
- log database helpers in `engine/storage.py`
- update yield and onboarding modules to use storage helper
- migrate JSON logs with new script
- document DB config options

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6889c6c7afc08322a4062c5d69767bea