### PR TITLE
Add tests for yield engine and security monitor

### DIFF
--- a/__tests__/security_monitor.test.js
+++ b/__tests__/security_monitor.test.js
@@ -1,0 +1,7 @@
+const { spawnSync } = require('child_process');
+
+test('security_monitor python tests', () => {
+  const result = spawnSync('python3', ['-m', 'unittest', 'tests.test_security_monitor'], { encoding: 'utf8' });
+  const output = (result.stdout + result.stderr).trim();
+  expect(output).toMatch(/OK/);
+});

--- a/__tests__/yield_engine_v1.test.js
+++ b/__tests__/yield_engine_v1.test.js
@@ -1,0 +1,7 @@
+const { spawnSync } = require('child_process');
+
+test('yield_engine_v1 python tests', () => {
+  const result = spawnSync('python3', ['-m', 'unittest', 'tests.test_yield_engine_v1'], { encoding: 'utf8' });
+  const output = (result.stdout + result.stderr).trim();
+  expect(output).toMatch(/OK/);
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   // Include both legacy __tests__ directory and the newer tests directory
   testMatch: ['**/__tests__/**/*.test.js', '**/tests/**/*.test.js'],
+  // Run in a single process to avoid stateful test interference
+  maxWorkers: 1,
 };

--- a/tests/test_security_monitor.py
+++ b/tests/test_security_monitor.py
@@ -1,0 +1,40 @@
+import json
+import unittest
+import tempfile
+from pathlib import Path
+
+import security_monitor as sm
+
+class SecurityMonitorTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        sm.BASE_DIR = self.dir
+        sm.BASELINE_PATH = self.dir / 'baseline.json'
+        sm.BACKUP_DIR = self.dir / 'backups'
+        sm.LOG_PATH = self.dir / 'audit.json'
+        self.f1 = self.dir / 'a.txt'
+        self.f2 = self.dir / 'b.txt'
+        self.f1.write_text('one')
+        self.f2.write_text('two')
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_baseline_and_integrity_reporting(self):
+        sm.set_baseline([self.f1, self.f2])
+        baseline = json.loads(sm.BASELINE_PATH.read_text())
+        self.assertEqual(set(baseline.keys()), {'a.txt', 'b.txt'})
+        self.f1.write_text('changed')
+        incidents = sm.check_integrity()
+        self.assertEqual(len(incidents), 1)
+        self.assertEqual(incidents[0]['file'], 'a.txt')
+        log = json.loads(sm.LOG_PATH.read_text())
+        self.assertEqual(log[0]['file'], 'a.txt')
+
+    def test_integrity_repair_restores_file(self):
+        sm.set_baseline([self.f1])
+        self.f1.write_text('bad')
+        sm.check_integrity(repair=True)
+        self.assertEqual(self.f1.read_text(), 'one')
+

--- a/tests/test_yield_engine_v1.py
+++ b/tests/test_yield_engine_v1.py
@@ -1,0 +1,61 @@
+import json
+import unittest
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from engine import yield_engine_v1 as ye
+
+class YieldEngineV1Test(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self.tmp.name)
+        ye.AUDIT_LOG_PATH = self.tmp_path / "audit.json"
+        ye.CONFIG_PATH = self.tmp_path / "config.json"
+        ye.TRIGGER_PATH = self.tmp_path / "triggers.json"
+        ye.VALUES_PATH = self.tmp_path / "values.json"
+        ye.OG_LIST_PATH = self.tmp_path / "og.json"
+        ye.CONFIG_PATH.write_text(json.dumps({"ethics_anchor": True}))
+        ye.TRIGGER_PATH.write_text(json.dumps(["A", "B"]))
+        ye.VALUES_PATH.write_text(json.dumps({"loyalty_multipliers": {"default": 1.0}}))
+        ye.OG_LIST_PATH.write_text(json.dumps([]))
+
+        def _mock_load_json(path, default=None):
+            if Path(path).exists():
+                with open(path) as f:
+                    return json.load(f)
+            return default
+
+        self.patcher = patch.object(ye, "_load_json", side_effect=_mock_load_json)
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+        self.tmp.cleanup()
+
+    def test_log_audit_writes_timestamped_entry(self):
+        ye._log_audit({"action": "test"})
+        log = json.loads(ye.AUDIT_LOG_PATH.read_text())
+        self.assertEqual(log[0]["action"], "test")
+        self.assertIn("timestamp", log[0])
+
+    def test_distribute_rewards_calculates_amount_and_logs(self):
+        with patch.object(ye, "_load_multiplier", return_value=2.0), \
+             patch.object(ye, "_wallet_verified", return_value=True), \
+             patch.object(ye, "_dynamic_apr", return_value=0.05), \
+             patch.object(ye, "get_mission", return_value="m1"):
+            data = {"u1": {"wallet": "w1.eth", "behavior": ["A", "C"]}}
+            ledger = ye.distribute_rewards(data)
+        expected = 1 * 2.0 * 1.15 * 0.05
+        self.assertAlmostEqual(ledger["rewards"]["w1.eth"]["amount"], expected)
+        log = json.loads(ye.AUDIT_LOG_PATH.read_text())
+        self.assertEqual(log[0]["action"], "reward")
+        self.assertEqual(log[0]["user_id"], "u1")
+
+    def test_distribute_rewards_respects_ethics_anchor(self):
+        ye.CONFIG_PATH.write_text(json.dumps({"ethics_anchor": False}))
+        result = ye.distribute_rewards({"u1": {"wallet": "w1.eth"}})
+        self.assertEqual(result, {})
+        log = json.loads(ye.AUDIT_LOG_PATH.read_text())
+        self.assertEqual(log[0]["approved"], False)
+


### PR DESCRIPTION
## Summary
- test reward calculations and audit logging in yield_engine_v1
- test baseline checks and integrity repairs for security_monitor
- invoke these python tests from Jest
- run Jest in a single worker to avoid file conflicts during tests

## Testing
- `npm --silent test`

------
https://chatgpt.com/codex/tasks/task_e_6889c6ca3e5883229f76e794a7ecc01c