### PR TITLE
Add automated refund system

### DIFF
--- a/__tests__/auto_refund.test.js
+++ b/__tests__/auto_refund.test.js
@@ -1,0 +1,7 @@
+const { spawnSync } = require('child_process');
+
+test('auto_refund python tests', () => {
+  const result = spawnSync('python3', ['-m', 'unittest', 'tests.test_auto_refund'], { encoding: 'utf8' });
+  const output = (result.stdout + result.stderr).trim();
+  expect(output).toMatch(/OK/);
+});

--- a/tests/test_auto_refund.py
+++ b/tests/test_auto_refund.py
@@ -1,0 +1,39 @@
+import json
+import unittest
+import tempfile
+from pathlib import Path
+import importlib
+
+ar = importlib.import_module("vaultfire.refund.auto_refund")
+
+
+class AutoRefundTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        base = Path(self.tmp.name)
+        self.audit = base / "audit.json"
+        self.tx = base / "tx.json"
+        self.state = base / "state.json"
+        self.badge = base / "badge.json"
+        # redirect module level paths
+        ar.AUDIT_LOG_PATH = self.audit
+        ar.TX_LOG_PATH = self.tx
+        ar.STATE_PATH = self.state
+        ar.BADGE_PATH = self.badge
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_mock_error_503_triggers_refund(self):
+        result = ar.auto_refund("user1", "mock_error_503", admin_override=True)
+        self.assertEqual(result["status"], "success")
+        audit = json.loads(self.audit.read_text())
+        self.assertEqual(audit[0]["wallet"], "user1")
+        tx = json.loads(self.tx.read_text())
+        self.assertEqual(tx[0]["wallet"], "user1")
+        badge = json.loads(self.badge.read_text())
+        self.assertIn("user1", badge)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vaultfire/__init__.py
+++ b/vaultfire/__init__.py
@@ -3,5 +3,6 @@
 from . import echo
 from . import growth
 from . import satellite
+from . import refund
 
-__all__ = ["echo", "growth", "satellite"]
+__all__ = ["echo", "growth", "satellite", "refund"]

--- a/vaultfire/refund/__init__.py
+++ b/vaultfire/refund/__init__.py
@@ -1,0 +1,15 @@
+from .auto_refund import (
+    auto_refund,
+    should_refund,
+    freeze_refunds,
+    unfreeze_refunds,
+    is_frozen,
+)
+
+__all__ = [
+    "auto_refund",
+    "should_refund",
+    "freeze_refunds",
+    "unfreeze_refunds",
+    "is_frozen",
+]

--- a/vaultfire/refund/auto_refund.py
+++ b/vaultfire/refund/auto_refund.py
@@ -1,0 +1,123 @@
+"""Automated refund system for Vaultfire.
+
+DISCLAIMER:
+- Use at your own risk; uptime or results are not guaranteed.
+- Ambient data is logged only with opt-in consent.
+- Nothing here constitutes legal, medical, or financial advice.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from utils.json_io import load_json, write_json
+
+# Default log and state paths
+AUDIT_LOG_PATH = Path("refund_audit.json")
+TX_LOG_PATH = Path("simulated_tx.json")
+STATE_PATH = Path("refund_state.json")
+BADGE_PATH = Path("frontend") / "refund_badges.json"
+
+
+def is_frozen() -> bool:
+    """Return True if refunds are currently frozen."""
+    state = load_json(STATE_PATH, {"frozen": False})
+    return bool(state.get("frozen"))
+
+
+def freeze_refunds() -> None:
+    """Disable automatic refunds until unfrozen."""
+    write_json(STATE_PATH, {"frozen": True})
+
+
+def unfreeze_refunds() -> None:
+    """Enable automatic refunds."""
+    write_json(STATE_PATH, {"frozen": False})
+
+
+def should_refund(
+    *,
+    error_code: Optional[int] = None,
+    latency: Optional[float] = None,
+    failure_rate: Optional[float] = None,
+    latency_threshold: float = 3.0,
+    failure_rate_threshold: float = 0.25,
+) -> bool:
+    """Return True if conditions warrant an automatic refund."""
+    if error_code is not None and error_code >= 500:
+        return True
+    if latency is not None and latency > latency_threshold:
+        return True
+    if failure_rate is not None and failure_rate > failure_rate_threshold:
+        return True
+    return False
+
+
+def _log_audit(entry: Dict[str, Any]) -> None:
+    log = load_json(AUDIT_LOG_PATH, [])
+    log.append(entry)
+    write_json(AUDIT_LOG_PATH, log)
+
+
+def _record_tx(wallet: str, chain: str) -> None:
+    tx = load_json(TX_LOG_PATH, [])
+    tx.append(
+        {
+            "wallet": wallet,
+            "chain": chain,
+            "token": "REFUND",
+            "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+    )
+    write_json(TX_LOG_PATH, tx)
+
+
+def _issue_badge(wallet: str) -> None:
+    badges = load_json(BADGE_PATH, {})
+    badges[wallet] = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    }
+    write_json(BADGE_PATH, badges)
+
+
+def auto_refund(
+    wallet: str,
+    incident: str,
+    *,
+    chain: str = "ETH",
+    metrics: Optional[Dict[str, float]] = None,
+    admin_override: bool = False,
+) -> Dict[str, Any]:
+    """Process a refund for ``wallet`` if not frozen."""
+    if is_frozen() and not admin_override:
+        return {"status": "frozen"}
+
+    entry = {
+        "wallet": wallet,
+        "incident": incident,
+        "chain": chain,
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    if metrics:
+        entry["metrics"] = metrics
+
+    status = "success"
+    try:
+        _record_tx(wallet, chain)
+    except Exception as exc:  # pragma: no cover - unforeseen IO failure
+        entry["error"] = str(exc)
+        status = "failover"
+    entry["status"] = status
+    _log_audit(entry)
+    _issue_badge(wallet)
+    return entry
+
+
+__all__ = [
+    "auto_refund",
+    "should_refund",
+    "freeze_refunds",
+    "unfreeze_refunds",
+    "is_frozen",
+]


### PR DESCRIPTION
## Summary
- add `vaultfire/refund` package with automated refund module
- hook new refund module into main package
- test refund routing and logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a34180abc83229b69fb7dec9f7993