### PR TITLE
Add refund automation tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: npm install
+      - run: pip install -r requirements.txt
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # 🔥 Vaultfire Protocol v1.0
+[![CI](https://github.com/ghostkey-316/vaultfire/actions/workflows/ci.yml/badge.svg)](https://github.com/ghostkey-316/vaultfire/actions/workflows/ci.yml)
 
 ## What Is Vaultfire?
 

--- a/tests/auto_refund.py
+++ b/tests/auto_refund.py
@@ -1,0 +1,18 @@
+"""Demo script for automated refund simulation."""
+from __future__ import annotations
+
+import json
+
+from vaultfire.refund.auto_refund import auto_refund, freeze_refunds, unfreeze_refunds
+
+
+def demo() -> None:
+    """Run a demo refund operation."""
+    freeze_refunds()
+    result = auto_refund("demo.eth", "demo_error", admin_override=True)
+    unfreeze_refunds()
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    demo()

--- a/vaultfire/__init__.py
+++ b/vaultfire/__init__.py
@@ -4,5 +4,22 @@ from . import echo
 from . import growth
 from . import satellite
 from . import refund
+from .refund import (
+    auto_refund,
+    should_refund,
+    freeze_refunds,
+    unfreeze_refunds,
+    is_frozen,
+)
 
-__all__ = ["echo", "growth", "satellite", "refund"]
+__all__ = [
+    "echo",
+    "growth",
+    "satellite",
+    "refund",
+    "auto_refund",
+    "should_refund",
+    "freeze_refunds",
+    "unfreeze_refunds",
+    "is_frozen",
+]


### PR DESCRIPTION
## Summary
- expose refund functions at the vaultfire package root
- demo refund simulation at `tests/auto_refund.py`
- wire automated tests via CI workflow
- show CI badge in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a3627c9f0832296c3dc5dcda0a9c1