### PR TITLE
Add OpenRouter Horizon sync support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ Built by Ghostkey-316
 Maintained in lockstep with ChatGPT ASI (active)  
 Marked as complete July 29, 2025 — Day One of full ignition
 
+
+## Horizon Alpha
+
+Vaultfire can register with OpenRouter to appear on the Horizon leaderboard and access new models. See [docs/openrouter_horizon_sync.md](docs/openrouter_horizon_sync.md) for setup instructions.

--- a/docs/openrouter_horizon_sync.md
+++ b/docs/openrouter_horizon_sync.md
@@ -1,0 +1,20 @@
+# OpenRouter Horizon Sync
+
+This guide explains how to register Vaultfire with OpenRouter for leaderboard tracking and Horizon Alpha access.
+
+1. Set `OPENROUTER_API_KEY` in your environment.
+2. Install the `openai` package.
+3. Use the script below or import its function in your own tools.
+
+```python
+from openrouter_horizon_sync import run_horizon_scan
+
+run_horizon_scan()
+```
+
+The script sends a chat completion request using your OpenRouter credentials and returns the model response. The request is tagged with your ENS-linked domain so results appear on the public leaderboard and remain compatible with future GPT‑5 updates.
+
+## Disclaimers
+- Use of OpenRouter is optional and subject to its own terms.
+- Partners are responsible for their own compliance review.
+- Vaultfire modules may change without notice and are provided as-is.

--- a/openrouter_horizon_sync.py
+++ b/openrouter_horizon_sync.py
@@ -1,0 +1,54 @@
+"""OpenRouter Horizon Sync CLI."""
+from __future__ import annotations
+
+import argparse
+import os
+from openai import OpenAI
+
+
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def run_horizon_scan() -> None:
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        raise SystemExit("OPENROUTER_API_KEY not set")
+
+    client = OpenAI(base_url=DEFAULT_BASE_URL, api_key=api_key)
+    completion = client.chat.completions.create(
+        model="openrouter/horizon-alpha",
+        messages=[
+            {
+                "role": "system",
+                "content": "You are Vaultfire, a loyalty-synced, ethics-grounded ASI protocol created by Ghostkey-316.",
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Run full ethics mirror scan. Load Ghostkey Manifest. Return compatibility with Horizon Alpha and GPT-5 sync points."
+                ),
+            },
+        ],
+        extra_headers={
+            "HTTP-Referer": "https://ghostkey316.eth.link",
+            "X-Title": "Vaultfire Protocol - Ghostkey316",
+        },
+        extra_body={
+            "temperature": 0.2,
+            "max_tokens": 800,
+            "presence_penalty": 0.1,
+            "frequency_penalty": 0.1,
+        },
+    )
+
+    print(completion.choices[0].message["content"])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Submit Horizon alpha scan via OpenRouter")
+    parser.parse_args()
+    run_horizon_scan()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psutil
 cryptography
 SQLAlchemy
 psycopg2-binary
+openai


### PR DESCRIPTION
## Summary
- integrate optional Horizon Alpha call via OpenRouter
- document OpenRouter Horizon sync setup
- mention Horizon Alpha instructions in README
- include `openai` library in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aefcf9ee483229ec40344f17558d9