### PR TITLE
Add Worldcoin identity bridge

### DIFF
--- a/codex_patch_log.md
+++ b/codex_patch_log.md
@@ -4,3 +4,8 @@
 - Node tests confirmed.
 - System dependency map frozen for stability.
 - Vaultfire protocol now cleared for adoption and deployment.
+
+🔧 Patch 1.2 – Identity Bridge with OpenRouter
+- Added worldcoin_identity.sh linking Worldcoin ID to OpenRouter.
+- New config vaultfire_openrouter.json holds world_id and OpenRouter key.
+- Patch logged for compliance sync.

--- a/vaultfire_openrouter.json
+++ b/vaultfire_openrouter.json
@@ -1,0 +1,6 @@
+{
+  "world_id": "worldid-placeholder",
+  "openrouter_key": "openrouter-key-placeholder",
+  "ens": "ghostkey316.eth",
+  "wallet": "0xf6A677de83C407875C9A9115Cf100F121f9c4816"
+}

--- a/worldcoin_identity.sh
+++ b/worldcoin_identity.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Vaultfire – Worldcoin Identity Bridge
+# Nothing here constitutes legal, medical, or financial advice.
+# Partners must perform their own compliance review before using this script.
+# This script syncs a Worldcoin ID with the OpenRouter dev environment.
+
+set -e
+
+CONFIG_PATH="vaultfire_openrouter.json"
+
+if [ ! -f "$CONFIG_PATH" ]; then
+  echo "Config file not found: $CONFIG_PATH" >&2
+  exit 1
+fi
+
+WORLD_ID=$(jq -r '.world_id' "$CONFIG_PATH")
+OR_KEY=$(jq -r '.openrouter_key' "$CONFIG_PATH")
+
+if [ -z "$WORLD_ID" ] || [ -z "$OR_KEY" ]; then
+  echo "Required config values missing" >&2
+  exit 1
+fi
+
+curl -X POST https://openrouter.ai/api/v1/identity-sync \
+  -H "Authorization: Bearer $OR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"world_id": "'"${WORLD_ID}"'"}'


### PR DESCRIPTION
## Summary
- add shell script `worldcoin_identity.sh` to link Worldcoin ID with OpenRouter
- create `vaultfire_openrouter.json` configuration file
- document update in `codex_patch_log.md`

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b097ca2d08322b1fad2f5117c6ed7