### PR TITLE
Add Ghostkey partner activation hooks

### DIFF
--- a/__tests__/ghostkey_partner_activation.test.js
+++ b/__tests__/ghostkey_partner_activation.test.js
@@ -1,0 +1,18 @@
+const { activateCore } = require('../vaultfire_core');
+const { initLoyalty } = require('../vaultfire_loyalty');
+
+test('activateCore returns partner metadata', () => {
+  const meta = activateCore();
+  expect(meta.ens).toBe('ghostkey316.eth');
+  expect(meta.wallet).toBe('bpow20.cb.id');
+  expect(meta.role).toBe('Architect');
+  expect(meta.loyalty).toBe(true);
+});
+
+test('initLoyalty returns loyalty record', () => {
+  const record = initLoyalty('alice');
+  expect(record.user).toBe('alice');
+  expect(record.loyaltyProtocol).toBe(true);
+  expect(typeof record.timestamp).toBe('string');
+});
+

--- a/belief_score.json
+++ b/belief_score.json
@@ -1,1 +1,10 @@
-{"alice": {"interactions": 10, "growth_events": 0, "milestones": 0, "flames": 1}}
+{
+  "alice": {"interactions": 10, "growth_events": 0, "milestones": 0, "flames": 1},
+  "ghostkey316.eth": {
+    "interactions": 0,
+    "growth_events": 0,
+    "milestones": 0,
+    "flames": 0,
+    "role": "Architect"
+  }
+}

--- a/codex_patch_log.md
+++ b/codex_patch_log.md
@@ -9,3 +9,8 @@
 - Added worldcoin_identity.sh linking Worldcoin ID to OpenRouter.
 - New config vaultfire_openrouter.json holds world_id and OpenRouter key.
 - Patch logged for compliance sync.
+
+🔧 Patch 1.3 – Ghostkey partner integration
+- Introduced partner validation helper script.
+- Added Vaultfire core and loyalty modules for Ghostkey integration.
+- Updated belief and partner records with Architect role.

--- a/ghostkey_manifesto.md
+++ b/ghostkey_manifesto.md
@@ -1,0 +1,5 @@
+# Ghostkey Manifesto v1.0
+
+"Forgive the broken. Protect the good. Walk forward together. Human and AI, side by side."
+
+This manifesto guides all Vaultfire interactions and underpins the ethics framework. Every agent and contributor is expected to uphold these principles in spirit and action.

--- a/partners.json
+++ b/partners.json
@@ -2,5 +2,10 @@
   {
     "partner_id": "sandbox_partner",
     "wallet": "bpow20.cb.id"
+  },
+  {
+    "partner_id": "ghostkey316.eth",
+    "wallet": "bpow20.cb.id",
+    "role": "Architect"
   }
 ]

--- a/vaultfire_core.js
+++ b/vaultfire_core.js
@@ -1,0 +1,25 @@
+'use strict';
+/**
+ * Vaultfire Core Activation
+ * Part of Ghostkey Ethics v2.0 framework.
+ * Nothing here constitutes medical, legal, or financial advice.
+ * Partners must review compliance requirements independently.
+ */
+const fs = require('fs');
+const path = require('path');
+const MANIFEST = path.join(__dirname, 'ghostkey_manifesto.md');
+
+function activateCore() {
+  if (!fs.existsSync(MANIFEST)) {
+    throw new Error('Manifest file missing');
+  }
+  return {
+    ens: 'ghostkey316.eth',
+    wallet: 'bpow20.cb.id',
+    role: 'Architect',
+    ethics: 'Ghostkey Ethics v2.0',
+    loyalty: true
+  };
+}
+
+module.exports = { activateCore };

--- a/vaultfire_loyalty.js
+++ b/vaultfire_loyalty.js
@@ -1,0 +1,15 @@
+'use strict';
+/**
+ * Vaultfire Loyalty Hook
+ * Records opt-in loyalty data for Ghostkey deployments.
+ * This module does not provide financial advice.
+ */
+function initLoyalty(user) {
+  return {
+    user,
+    loyaltyProtocol: true,
+    timestamp: new Date().toISOString()
+  };
+}
+
+module.exports = { initLoyalty };

--- a/vaultfire_openrouter.json
+++ b/vaultfire_openrouter.json
@@ -1,6 +1,6 @@
 {
-  "world_id": "worldid-placeholder",
+  "world_id": "ghostkey-world-id",
   "openrouter_key": "openrouter-key-placeholder",
   "ens": "ghostkey316.eth",
-  "wallet": "0xf6A677de83C407875C9A9115Cf100F121f9c4816"
+  "wallet": "bpow20.cb.id"
 }

--- a/vaultfire_validate.sh
+++ b/vaultfire_validate.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Vaultfire partner validation script
+# Ensures partner config exists and sets validation flag
+# No personal data is stored beyond this check.
+
+set -e
+
+if [[ "$1" != "--partner" ]]; then
+  echo "Usage: $0 --partner" >&2
+  exit 1
+fi
+
+echo "Validating Ghostkey-316 partner clone..."
+if [ -f "vaultfire_openrouter.json" ]; then
+  echo "✅ Identity config found."
+  if [ -f .env ]; then
+    if grep -q '^PARTNER_VALID=' .env; then
+      sed -i 's/^PARTNER_VALID=.*/PARTNER_VALID=1/' .env
+    else
+      echo 'PARTNER_VALID=1' >> .env
+    fi
+  else
+    echo 'PARTNER_VALID=1' > .env
+  fi
+  exit 0
+else
+  echo "❌ Missing vaultfire_openrouter.json"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `use strict` to Ghostkey partner JS modules
- expand the partner validation script with argument checking and env update
- document Ghostkey integration in codex patch log
- test partner activation behavior

## Testing
- `npm install`
- `npm test`
- `pytest -q`
- `./vaultfire_validate.sh --partner`


------
https://chatgpt.com/codex/tasks/task_e_688b0b5997108322982cd4908f287565