### PR TITLE
Add Humanity Mirror reflection modules

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,30 @@
+from mirror_log import log_sample, self_audit_template
+from vaultfire import rewards
+from memory_graph import update_graph
+from moral_alignment import evaluate_entry
+from utils import get_timestamp
+
+
+def get_user_input():
+    print("\U0001F4A0 Welcome to Humanity Mirror")
+    print("1. Daily Reflection  2. Self-Audit  3. Exit")
+    choice = input("Choose (1/2/3): ")
+
+    if choice == "1":
+        entry = input("Reflect freely (feelings, choices, doubts):\n")
+        timestamp = get_timestamp()
+        with open("mirror_log/log_sample.md", "a") as f:
+            f.write(f"\n## {timestamp}\n{entry}\n")
+        update_graph(entry)
+        evaluate_entry(entry)
+        rewards.calculate(entry)
+
+    elif choice == "2":
+        with open("mirror_log/self_audit_template.md", "r") as f:
+            print(f.read())
+    else:
+        print("Goodbye.")
+
+
+if __name__ == "__main__":
+    get_user_input()

--- a/src/memory_graph.py
+++ b/src/memory_graph.py
@@ -1,0 +1,3 @@
+def update_graph(entry):
+    # Simulate emotional graph node tagging (to be expanded later)
+    print("\U0001F9E0 Memory graph updated: entry logged for future moral map.")

--- a/src/moral_alignment.py
+++ b/src/moral_alignment.py
@@ -1,0 +1,4 @@
+def evaluate_entry(entry):
+    keywords = ["honest", "grateful", "selfish", "hopeful", "afraid"]
+    score = sum(1 for word in keywords if word in entry.lower())
+    print(f"\U0001F9ED Moral alignment score: {score}/5 — Integrity signal logged.")

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,4 @@
+import datetime
+
+def get_timestamp():
+    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M")


### PR DESCRIPTION
## Summary
- create Humanity Mirror CLI for reflections and self audits
- add memory graph and moral alignment utilities
- helper for reusable timestamps

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892ca0ae5a88322aa631aa5ff81b268