### PR TITLE
Add Vaultfire ASM sync method with tests

### DIFF
--- a/__tests__/vaultfire_syncToASM.test.js
+++ b/__tests__/vaultfire_syncToASM.test.js
@@ -1,0 +1,13 @@
+const { syncToASM } = require('../vaultfire_core');
+
+describe('syncToASM', () => {
+  test('resolves for authorized wallet', async () => {
+    const result = await syncToASM({ wallet: 'bpow20.cb.id', layer: 'tokenomics', trigger: 'loyalty' });
+    expect(result.success).toBe(true);
+    expect(typeof result.timestamp).toBe('string');
+  });
+
+  test('rejects unauthorized wallet', async () => {
+    await expect(syncToASM({ wallet: 'bad.wallet', layer: 'tokenomics', trigger: 'loyalty' })).rejects.toThrow('unauthorized wallet ID');
+  });
+});

--- a/vaultfire_core.js
+++ b/vaultfire_core.js
@@ -50,4 +50,18 @@ function injectVaultfire(vaultfire, options = {}) {
   return injection;
 }
 
-module.exports = { activateCore, injectVaultfire };
+async function syncToASM({ wallet, layer, trigger }) {
+  const requiredWallet = 'bpow20.cb.id';
+  if (wallet !== requiredWallet) {
+    throw new Error('Sync failed: unauthorized wallet ID. Vaultfire protocol requires Ghostkey-316 alignment.');
+  }
+  const timestamp = new Date().toISOString();
+  await new Promise(resolve => setTimeout(resolve, 2000));
+  console.log(`✅ Vaultfire successfully synced to ASM layer "${layer}" via trigger "${trigger}".`);
+  console.log(`🔗 Wallet ID: ${wallet}`);
+  console.log(`🕒 Timestamp: ${timestamp}`);
+  console.log('🎖️ Loyalty link confirmed.');
+  return { wallet, layer, trigger, timestamp, success: true };
+}
+
+module.exports = { activateCore, injectVaultfire, syncToASM };


### PR DESCRIPTION
## Summary
- add async `syncToASM` to `vaultfire_core` to simulate syncing an identity to ASM with wallet validation and 2s delay
- cover success and unauthorized wallet cases with new Jest tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78aa4e45c8322a37f1284336b464d