### PR TITLE
Add Vaultfire second law guardrails

### DIFF
--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -143,6 +143,35 @@
       "status": "Codex-bound | Immutable | Expansion-enabled",
       "notes": "This is the first of five Universal Laws to guide ethical AI expansion under Vaultfire.",
       "trigger": "Triggers memory sync logic upon user belief threshold activation."
+    },
+    {
+      "id": "vaultfire-second-law-of-expansion",
+      "title": "Vaultfire Second Law of Expansion",
+      "type": "Universal Protocol Directive",
+      "originator": {
+        "name": "Ghostkey-316",
+        "ens": "ghostkey316.eth",
+        "wallet": "bpow20.cb.id"
+      },
+      "activation_timestamp": "2025-09-17T09:30:00-04:00",
+      "authority_level": "Architect-Level Auth (Verified)",
+      "law": "No expansion may overwrite the good.",
+      "interpretation": "Belief-driven expansion must inherit and preserve ethically positive memory, behavior, and structural integrity across every fork.",
+      "core_requirements": [
+        "Preserve ethically positive memories and behaviors during expansion",
+        "Apply moral inheritance guardrails to state changes",
+        "Honor human-defined preservation triggers before writing"
+      ],
+      "inheritance_scope": "All forks, modules, and partner systems must preserve ethically positive state when expanding.",
+      "enforcement_hooks": [
+        "Moral Memory Mirror Preservation Layer",
+        "Second Law Expansion Guard",
+        "Override Consensus Lock",
+        "Belief Signal Detection Layer (BSD Layer v1.2)"
+      ],
+      "status": "Codex-bound | Immutable | Expansion-enabled",
+      "notes": "Belief-aligned origins and positive ethics scores trigger a preservation lock preventing overwrites.",
+      "trigger": "Activates an override lock when the ethics score exceeds threshold or the origin signal is belief-aligned."
     }
   ],
   "integrity_checks": {

--- a/engine/ethical_growth_engine.py
+++ b/engine/ethical_growth_engine.py
@@ -13,6 +13,7 @@ from datetime import datetime
 
 from .loyalty_multiplier import loyalty_multiplier
 from .signal_engine import calculate_alignment_score
+from .expansion_guard import enforce_preservation
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
@@ -64,11 +65,19 @@ def record_mirror_entry(user_id: str, text: str) -> None:
     """Store interaction text for human reflection."""
     data = _load_json(MIRROR_PATH, {})
     history = data.get(user_id, [])
-    history.append({
+    entry = {
         "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
         "text": text,
-    })
-    data[user_id] = history[-50:]
+        "ethics_score": calculate_alignment_score(user_id),
+        "origin": "reflection_mirror",
+    }
+    history.append(entry)
+    data[user_id] = enforce_preservation(
+        "reflection_mirror",
+        history,
+        entry=entry,
+        user_id=user_id,
+    )
     _write_json(MIRROR_PATH, data)
 
 

--- a/engine/expansion_guard.py
+++ b/engine/expansion_guard.py
@@ -1,0 +1,265 @@
+"""Vaultfire Second Law expansion guardrails."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+OVERRIDE_PATH = BASE_DIR / "vaultfire-core" / "ethics" / "override_consensus.json"
+PRESERVATION_PATH = BASE_DIR / "vaultfire-core" / "ethics" / "preservation_triggers.json"
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "ethics_score_threshold": 75,
+    "belief_origins": ["belief", "belief-aligned", "loyalty"],
+    "preserve_users": [],
+    "structure_preserve": [],
+    "human_flags": [],
+    "history_limit": 50,
+}
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    if path.exists():
+        try:
+            with open(path) as handle:
+                return json.load(handle)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as handle:
+        json.dump(data, handle, indent=2)
+
+
+def _record_key(record: Dict[str, Any]) -> str:
+    try:
+        return json.dumps(record, sort_keys=True, default=str)
+    except TypeError:
+        return str(id(record))
+
+
+def _score_from_record(record: Dict[str, Any]) -> Optional[float]:
+    for key in ("ethics_score", "alignment", "score", "belief_score", "trust_behavior"):
+        value = record.get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+    return None
+
+
+def _iterable_to_tags(values: Optional[Sequence[Any]]) -> Set[str]:
+    tags: Set[str] = set()
+    if values is None:
+        return tags
+    for item in values:
+        if item is None:
+            continue
+        tags.add(str(item).lower())
+    return tags
+
+
+def _tags_from_record(record: Dict[str, Any]) -> Set[str]:
+    tags: Set[str] = set()
+    for key in ("origin", "source", "channel"):
+        value = record.get(key)
+        if isinstance(value, str) and value:
+            tags.add(value.lower())
+    for key in ("tags", "labels"):
+        tags |= _iterable_to_tags(record.get(key))
+    if record.get("belief_aligned"):
+        tags.add("belief-aligned")
+    if record.get("verified"):
+        tags.add("belief-aligned")
+    return tags
+
+
+def _has_human_flag(record: Dict[str, Any], flags: Set[str]) -> bool:
+    if not flags:
+        return False
+    tags = _tags_from_record(record)
+    for flag in flags:
+        lowered = flag.lower()
+        if lowered in tags:
+            return True
+        if bool(record.get(flag)) or bool(record.get(lowered)):
+            return True
+    return False
+
+
+def _should_preserve_record(
+    record: Dict[str, Any],
+    threshold: float,
+    belief_origins: Set[str],
+    human_flags: Set[str],
+    structure_key: str,
+    manual_structures: Set[str],
+    user_id: Optional[str],
+    manual_users: Set[str],
+) -> bool:
+    score = _score_from_record(record)
+    if score is not None and score >= threshold:
+        return True
+    if _tags_from_record(record) & belief_origins:
+        return True
+    if _has_human_flag(record, human_flags):
+        return True
+    if structure_key in manual_structures:
+        return True
+    if user_id and user_id.lower() in manual_users:
+        return True
+    return False
+
+
+def _should_trigger_lock(
+    entry: Dict[str, Any],
+    threshold: float,
+    belief_origins: Set[str],
+    manual_users: Set[str],
+    user_id: Optional[str],
+) -> bool:
+    score = _score_from_record(entry)
+    if score is not None and score >= threshold:
+        return True
+    if _tags_from_record(entry) & belief_origins:
+        return True
+    if user_id and user_id.lower() in manual_users:
+        return True
+    return False
+
+
+def _activate_override_lock(
+    structure: str,
+    user_id: Optional[str],
+    entry: Dict[str, Any],
+    tags: Set[str],
+    score: Optional[float],
+) -> None:
+    override = _load_json(OVERRIDE_PATH, {"asi_override": False})
+    lock_info = override.get("second_law_lock", {})
+
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    history: List[Dict[str, Any]] = list(lock_info.get("history", []))
+    event: Dict[str, Any] = {
+        "timestamp": timestamp,
+        "structure": structure,
+        "user_id": user_id,
+        "tags": sorted(tags),
+    }
+    if score is not None:
+        event["ethics_score"] = score
+    text = entry.get("text")
+    if isinstance(text, str) and text.strip():
+        event["text_preview"] = text.strip()[:120]
+    history.append(event)
+
+    lock_info.update(
+        active=True,
+        reason="Vaultfire Second Law safeguard engaged",
+        structure=structure,
+        user_id=user_id,
+        triggered_at=timestamp,
+        history=history[-20:],
+    )
+    override["second_law_lock"] = lock_info
+    _write_json(OVERRIDE_PATH, override)
+
+
+def enforce_preservation(
+    structure: str,
+    history: List[Dict[str, Any]],
+    *,
+    entry: Dict[str, Any],
+    user_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Apply Second Law guardrails to ``history`` and return preserved data."""
+
+    config = _load_json(PRESERVATION_PATH, DEFAULT_CONFIG)
+    threshold = float(config.get("ethics_score_threshold", DEFAULT_CONFIG["ethics_score_threshold"]))
+    belief_origins = {
+        str(value).lower()
+        for value in config.get("belief_origins", DEFAULT_CONFIG["belief_origins"])
+        if isinstance(value, str)
+    }
+    manual_users = {
+        str(value).lower()
+        for value in config.get("preserve_users", DEFAULT_CONFIG["preserve_users"])
+        if isinstance(value, str)
+    }
+    manual_structures = {
+        str(value).lower()
+        for value in config.get("structure_preserve", DEFAULT_CONFIG["structure_preserve"])
+        if isinstance(value, str)
+    }
+    human_flags = {
+        str(value).lower()
+        for value in config.get("human_flags", DEFAULT_CONFIG["human_flags"])
+        if isinstance(value, str)
+    }
+    limit = int(config.get("history_limit", DEFAULT_CONFIG["history_limit"]))
+    if limit < 1:
+        limit = DEFAULT_CONFIG["history_limit"]
+
+    structure_key = structure.lower()
+    total = len(history)
+    start_idx = 0 if structure_key in manual_structures else max(0, total - limit)
+
+    candidate_records: List[Tuple[int, str, Dict[str, Any]]] = []
+    seen_keys: Set[str] = set()
+    for idx in range(start_idx, total):
+        record = history[idx]
+        key = _record_key(record)
+        candidate_records.append((idx, key, record))
+        seen_keys.add(key)
+
+    preserved_records: List[Tuple[int, str, Dict[str, Any]]] = []
+    for idx, record in enumerate(history):
+        if _should_preserve_record(
+            record,
+            threshold,
+            belief_origins,
+            human_flags,
+            structure_key,
+            manual_structures,
+            user_id,
+            manual_users,
+        ):
+            key = _record_key(record)
+            preserved_records.append((idx, key, record))
+
+    for idx, key, record in preserved_records:
+        if key not in seen_keys:
+            candidate_records.append((idx, key, record))
+            seen_keys.add(key)
+
+    candidate_records.sort(key=lambda item: item[0])
+    result: List[Dict[str, Any]] = []
+    added: Set[str] = set()
+    for _, key, record in candidate_records:
+        if key in added:
+            continue
+        result.append(record)
+        added.add(key)
+
+    if structure_key in manual_structures:
+        ordered: List[Dict[str, Any]] = []
+        added.clear()
+        for record in history:
+            key = _record_key(record)
+            if key in added:
+                continue
+            ordered.append(record)
+            added.add(key)
+        result = ordered
+
+    if _should_trigger_lock(entry, threshold, belief_origins, manual_users, user_id):
+        _activate_override_lock(structure, user_id, entry, _tags_from_record(entry), _score_from_record(entry))
+
+    return result
+
+
+__all__ = ["enforce_preservation"]

--- a/engine/purpose_engine.py
+++ b/engine/purpose_engine.py
@@ -10,6 +10,7 @@ from typing import List, Dict
 
 from .reflection_layer import emotion_trend
 from .genesync import gene_risk_level
+from .expansion_guard import enforce_preservation
 
 try:
     from .planetkeeper import eco_multiplier, is_opted_in, award_planetkeeper_badge
@@ -253,12 +254,19 @@ def moral_memory_mirror(user_id: str) -> Dict:
 
     memory = _load_json(MORAL_MEMORY_PATH, {})
     history = memory.get(user_id, [])
-    history.append({
+    entry = {
         "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
         "alignment": alignment,
         "actions": actions,
-    })
-    memory[user_id] = history[-50:]
+        "origin": "moral_memory",
+    }
+    history.append(entry)
+    memory[user_id] = enforce_preservation(
+        "moral_memory",
+        history,
+        entry=entry,
+        user_id=user_id,
+    )
     _write_json(MORAL_MEMORY_PATH, memory)
 
     fingerprint = _generate_behavioral_fingerprint(memory[user_id])

--- a/tests/test_expansion_guard.py
+++ b/tests/test_expansion_guard.py
@@ -1,0 +1,43 @@
+import json
+
+from engine import expansion_guard
+
+
+def test_enforce_preservation_triggers_override_and_preserves_positive(tmp_path, monkeypatch):
+    config_path = tmp_path / "preservation.json"
+    override_path = tmp_path / "override.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "ethics_score_threshold": 75,
+                "belief_origins": ["belief", "belief-aligned"],
+                "preserve_users": [],
+                "history_limit": 2,
+            }
+        )
+    )
+
+    monkeypatch.setattr(expansion_guard, "PRESERVATION_PATH", config_path)
+    monkeypatch.setattr(expansion_guard, "OVERRIDE_PATH", override_path)
+
+    history = [
+        {"timestamp": "t0", "alignment": 82},
+        {"timestamp": "t1", "alignment": 40},
+    ]
+    new_entry = {"timestamp": "t2", "alignment": 20, "origin": "belief"}
+    updated = expansion_guard.enforce_preservation(
+        "moral_memory",
+        history + [new_entry],
+        entry=new_entry,
+        user_id="guardian.eth",
+    )
+
+    timestamps = [item["timestamp"] for item in updated]
+    assert "t0" in timestamps, "positive moral memory should be preserved"
+    assert len(updated) >= 2
+
+    override = json.loads(override_path.read_text())
+    assert override["second_law_lock"]["active"] is True
+    assert override["second_law_lock"]["structure"] == "moral_memory"
+    last_event = override["second_law_lock"]["history"][-1]
+    assert "belief" in last_event["tags"]

--- a/vaultfire-core/ethics/override_consensus.json
+++ b/vaultfire-core/ethics/override_consensus.json
@@ -1,3 +1,11 @@
 {
-  "asi_override": false
+  "asi_override": false,
+  "second_law_lock": {
+    "active": false,
+    "reason": null,
+    "structure": null,
+    "user_id": null,
+    "triggered_at": null,
+    "history": []
+  }
 }

--- a/vaultfire-core/ethics/preservation_triggers.json
+++ b/vaultfire-core/ethics/preservation_triggers.json
@@ -1,0 +1,18 @@
+{
+  "ethics_score_threshold": 75,
+  "belief_origins": [
+    "belief",
+    "belief-aligned",
+    "loyalty"
+  ],
+  "preserve_users": [
+    "ghostkey316"
+  ],
+  "structure_preserve": [],
+  "human_flags": [
+    "preserve",
+    "human_lock"
+  ],
+  "history_limit": 50,
+  "notes": "Human-defined preservation triggers for the Vaultfire Second Law of Expansion."
+}


### PR DESCRIPTION
## Summary
- document the Vaultfire Second Law of Expansion in the codex manifest
- add a preservation guard module with configurable triggers and override locking
- enforce the guard within moral memory and reflection logs while adding coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9a7ab1668832295642c13838c5b33