### PR TITLE
Harden data encryption and webhook integrity

### DIFF
--- a/SecureStore.py
+++ b/SecureStore.py
@@ -17,11 +17,14 @@ try:
 except Exception:  # pragma: no cover - fallback when full version unavailable
     from geolock_filter import strip_exif
     from belief_trigger_engine import log_chain_event, send_to_webhook
+    from utils.crypto import decrypt_bytes, encrypt_bytes
 
     class SecureStore:
         """Lightweight SecureStore suitable for mobile environments."""
 
         def __init__(self, key: bytes, bucket: str | Path) -> None:
+            if len(key) not in (16, 24, 32):
+                raise ValueError("Key must be 16, 24, or 32 bytes for AES-GCM")
             self.key = key
             self.bucket = Path(bucket)
             self.bucket.mkdir(parents=True, exist_ok=True)
@@ -43,9 +46,11 @@ except Exception:  # pragma: no cover - fallback when full version unavailable
             raw = file_path.read_bytes()
             cleaned = strip_exif(raw)
             content_hash = hashlib.sha256(cleaned).hexdigest()
-            cid = hashlib.sha256(cleaned).hexdigest()
+            payload = encrypt_bytes(self.key, cleaned)
+            ciphertext = payload.ciphertext
+            cid = hashlib.sha256(payload.nonce + ciphertext).hexdigest()
             enc_path = self.bucket / f"{cid}.bin"
-            enc_path.write_bytes(cleaned)
+            enc_path.write_bytes(ciphertext)
             timestamp = datetime.utcnow().isoformat()
             metadata = {
                 "wallet": wallet,
@@ -54,8 +59,13 @@ except Exception:  # pragma: no cover - fallback when full version unavailable
                 "timestamp": timestamp,
                 "content_hash": content_hash,
                 "cid": cid,
+                "nonce": payload.nonce.hex(),
             }
-            metadata["signature"] = self._sign(metadata)
+            signature_payload = {
+                k: metadata[k]
+                for k in ["wallet", "tier", "score", "timestamp", "content_hash", "cid"]
+            }
+            metadata["signature"] = self._sign(signature_payload)
             (self.bucket / f"{cid}.json").write_text(json.dumps(metadata, indent=2))
             if chain_log:
                 log_chain_event(wallet, tier, score, timestamp)
@@ -78,7 +88,12 @@ except Exception:  # pragma: no cover - fallback when full version unavailable
             }
             if self._sign(meta) != metadata.get("signature"):
                 raise ValueError("Invalid signature")
-            return (self.bucket / f"{cid}.bin").read_bytes()
+            ciphertext = (self.bucket / f"{cid}.bin").read_bytes()
+            nonce_hex = metadata.get("nonce")
+            if not nonce_hex:
+                raise ValueError("Missing nonce in metadata")
+            nonce = bytes.fromhex(nonce_hex)
+            return decrypt_bytes(self.key, nonce, ciphertext)
 
     def calculate_signature(key: bytes, payload: dict) -> str:
         """Return signature for ``payload`` using ``key``."""

--- a/belief_trigger_engine.py
+++ b/belief_trigger_engine.py
@@ -1,7 +1,11 @@
 """Belief-based trigger system for Vaultfire."""
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
+import os
+import time
 import urllib.request
 from datetime import datetime
 from pathlib import Path
@@ -27,6 +31,7 @@ BELIEF_THRESHOLDS = {
 
 LOG_PATH = Path("vault_trigger_log.json")
 CHAIN_LOG_PATH = Path("chain_event_log.json")
+DEFAULT_WEBHOOK_SECRET = os.environ.get("VAULTFIRE_WEBHOOK_SECRET")
 
 
 def _log_trigger(entry: dict) -> None:
@@ -55,16 +60,33 @@ def _append_json(path: Path, entry: dict) -> None:
     path.write_text(json.dumps(data, indent=2))
 
 
-def send_webhook(url: str, payload: dict) -> None:
-    """POST ``payload`` to ``url`` ignoring errors."""
+def _build_signature(secret: str, body: bytes, *, timestamp: int) -> str:
+    message = f"{timestamp}.".encode("utf-8") + body
+    digest = hmac.new(secret.encode("utf-8"), message, hashlib.sha256).hexdigest()
+    return f"t={timestamp},v1={digest}"
+
+
+def send_webhook(url: str, payload: dict, *, secret: str | None = None, retries: int = 3) -> None:
+    """POST ``payload`` to ``url`` with optional HMAC authentication."""
     if not url:
         return
-    data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
-    try:
-        urllib.request.urlopen(req, timeout=5)
-    except Exception:
-        pass
+
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    secret_value = secret or DEFAULT_WEBHOOK_SECRET
+
+    for attempt in range(retries):
+        headers = {"Content-Type": "application/json"}
+        if secret_value:
+            timestamp = int(time.time())
+            headers["X-Vaultfire-Signature"] = _build_signature(secret_value, body, timestamp=timestamp)
+        req = urllib.request.Request(url, data=body, headers=headers)
+        try:
+            urllib.request.urlopen(req, timeout=5)
+            break
+        except Exception:
+            if attempt == retries - 1:
+                break
+            time.sleep(0.2 * (2 ** attempt))
 
 
 def send_to_webhook(
@@ -75,6 +97,8 @@ def send_to_webhook(
     timestamp: str,
     trigger: str,
     chain_timestamp: str | None = None,
+    *,
+    secret: str | None = None,
 ) -> None:
     """Send activation data to ``url`` if provided with strict ordering."""
     if not url:
@@ -99,7 +123,7 @@ def send_to_webhook(
         ts_chain = datetime.fromisoformat(chain_timestamp)
         if abs((ts_payload - ts_chain).total_seconds()) > 0.5:
             raise ValueError("Timestamp drift")
-    send_webhook(url, payload)
+    send_webhook(url, payload, secret=secret)
 
 
 def log_chain_event(wallet: str, tier: str, score: int, timestamp: str) -> None:

--- a/docs/music_layer.md
+++ b/docs/music_layer.md
@@ -16,7 +16,7 @@ playlist = ai_curated_playlist("alice")
 - Ambient data is logged only with opt-in consent.
 - Nothing here constitutes legal, medical, or financial advice.
 - API tokens are stored as hashes and do not grant direct access to third‑party services.
-- Memory tracks use lightweight XOR encryption and are not suited for sensitive data.
+- Memory tracks now use AES-GCM encryption but should still avoid storing confidential or regulated data.
 - AI playlists are suggestions only and may not reflect professional curation.
 
 ## Ethics-Driven Sandbox Mode

--- a/docs/synced_circles.md
+++ b/docs/synced_circles.md
@@ -17,5 +17,5 @@ curate_circles({"alice": "secret", "bob": "secret2"})
 - Ambient data is logged only with opt-in consent.
 - Nothing here constitutes legal, medical, or financial advice.
 - Circle membership data is stored under `logs/circles/` and may be cleared at any time.
-- Encryption uses a lightweight XOR cipher and should not be considered fully secure.
+- Encryption uses AES-GCM with per-user keys; safeguard recovery keys and rotate them if compromise is suspected.
 - Circles are AI-generated suggestions and do not guarantee privacy or accuracy.

--- a/docs/vaultlink_engine.md
+++ b/docs/vaultlink_engine.md
@@ -5,7 +5,7 @@ Vaultlink provides a modular AI companion that evolves with each user. The engin
 ## Features
 - **Behavioral growth** – a time weighted algorithm increases XP based on interaction frequency, milestones and sentiment.
 - **Mythic identity** – each companion is seeded with a soulprint influencing voice style and moral compass.
-- **Encrypted memory** – personal memories are stored using the lightweight XOR encryption from `health_sync_engine` with a long-term history log.
+- **Encrypted memory** – personal memories are stored using the AES-GCM encryption from `health_sync_engine` with a long-term history log and file-locking safeguards.
 - **Emotion tracking** – interactions feed into the `reflection_layer` to adapt responses by tone.
 - **Synced evolution tree** – new levels unlock coaching and philosophical domains.
 - **Legacy transfer** – states can be cloned for a different user.
@@ -27,5 +27,5 @@ All session text is stored in a moral mirror log for human feedback. Advanced
 logic tiers require an override file signed by the founding architects.
 
 **Disclaimer**
-- Vaultlink uses basic XOR encryption and should not store highly sensitive data.
+- Vaultlink now uses AES-GCM with authenticated metadata but sensitive data should still be stored with user consent and appropriate key management.
 - Vaultlink Ascension Mode is stable and may produce unexpected results.

--- a/engine/health_sync_engine.py
+++ b/engine/health_sync_engine.py
@@ -1,12 +1,14 @@
 """Optional health sync engine for Vaultfire profiles."""
 from __future__ import annotations
 
-import base64
-import hashlib
 import json
+import hashlib
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
+
+from utils.crypto import decrypt_text, derive_key, encrypt_text
+from utils.json_io import load_json, write_json
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 SYNC_DIR = BASE_DIR / "logs" / "health_sync"
@@ -14,38 +16,18 @@ SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
 SYNC_LOG_PATH = BASE_DIR / "logs" / "health_sync_log.json"
 
 
-def _load_json(path: Path, default):
-    if path.exists():
-        try:
-            with open(path) as f:
-                return json.load(f)
-        except json.JSONDecodeError:
-            return default
-    return default
+def _key_bytes(key: str) -> bytes:
+    """Derive a stable AES key from ``key`` for profile encryption."""
 
-
-def _write_json(path: Path, data) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2)
-
-
-# --- lightweight XOR encryption -------------------------------------------
-
-def _xor_cipher(data: bytes, key: str) -> bytes:
-    key_bytes = key.encode()
-    return bytes(b ^ key_bytes[i % len(key_bytes)] for i, b in enumerate(data))
+    return derive_key(key)
 
 
 def encrypt_data(text: str, key: str) -> str:
-    cipher = _xor_cipher(text.encode(), key)
-    return base64.urlsafe_b64encode(cipher).decode()
+    return encrypt_text(_key_bytes(key), text)
 
 
 def decrypt_data(token: str, key: str) -> str:
-    data = base64.urlsafe_b64decode(token.encode())
-    plain = _xor_cipher(data, key)
-    return plain.decode()
+    return decrypt_text(_key_bytes(key), token)
 
 
 def _hash_id(identifier: str) -> str:
@@ -55,11 +37,11 @@ def _hash_id(identifier: str) -> str:
 # --- reward handling ------------------------------------------------------
 
 def _reward_user(user_id: str, points: float = 1.0) -> None:
-    scorecard = _load_json(SCORECARD_PATH, {})
+    scorecard = load_json(SCORECARD_PATH, {})
     user = scorecard.get(user_id, {})
     user["wellness_points"] = user.get("wellness_points", 0.0) + points
     scorecard[user_id] = user
-    _write_json(SCORECARD_PATH, scorecard)
+    write_json(SCORECARD_PATH, scorecard)
 
 
 # --- wearable data -------------------------------------------------------
@@ -69,7 +51,7 @@ def link_wearable_data(user_id: str, metrics: Dict[str, float], key: str) -> Dic
     hashed = _hash_id(user_id)
     path = SYNC_DIR / f"{hashed}_wearable.json"
     enc = encrypt_data(json.dumps(metrics), key)
-    _write_json(path, {"data": enc})
+    write_json(path, {"data": enc})
     _reward_user(user_id)
     _log_entry({"user": hashed, "type": "wearable"})
     return metrics
@@ -78,7 +60,7 @@ def link_wearable_data(user_id: str, metrics: Dict[str, float], key: str) -> Dic
 def get_wearable_data(user_id: str, key: str) -> Optional[Dict[str, float]]:
     hashed = _hash_id(user_id)
     path = SYNC_DIR / f"{hashed}_wearable.json"
-    data = _load_json(path, {})
+    data = load_json(path, {})
     token = data.get("data")
     if not token:
         return None
@@ -95,7 +77,7 @@ def link_journal_entry(user_id: str, text: str, key: str) -> List[Dict]:
     """Append encrypted journal entry for ``user_id``."""
     hashed = _hash_id(user_id)
     path = SYNC_DIR / f"{hashed}_journal.json"
-    data = _load_json(path, {"entries": []})
+    data = load_json(path, {"entries": []})
     entries_enc = data.get("entries", [])
     entries = []
     for token in entries_enc:
@@ -108,7 +90,7 @@ def link_journal_entry(user_id: str, text: str, key: str) -> List[Dict]:
     timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     token = encrypt_data(f"{timestamp}|{text}", key)
     entries_enc.append(token)
-    _write_json(path, {"entries": entries_enc})
+    write_json(path, {"entries": entries_enc})
     _reward_user(user_id)
     _log_entry({"user": hashed, "type": "journal"})
     entries.append({"timestamp": timestamp, "text": text})
@@ -118,7 +100,7 @@ def link_journal_entry(user_id: str, text: str, key: str) -> List[Dict]:
 def get_journal_entries(user_id: str, key: str) -> List[Dict]:
     hashed = _hash_id(user_id)
     path = SYNC_DIR / f"{hashed}_journal.json"
-    data = _load_json(path, {"entries": []})
+    data = load_json(path, {"entries": []})
     results = []
     for token in data.get("entries", []):
         try:
@@ -133,8 +115,8 @@ def get_journal_entries(user_id: str, key: str) -> List[Dict]:
 # --- logging -------------------------------------------------------------
 
 def _log_entry(entry: dict) -> None:
-    log = _load_json(SYNC_LOG_PATH, [])
+    log = load_json(SYNC_LOG_PATH, [])
     timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     log.append({"timestamp": timestamp, **entry})
-    _write_json(SYNC_LOG_PATH, log)
+    write_json(SYNC_LOG_PATH, log)
 

--- a/engine/mission_registry.py
+++ b/engine/mission_registry.py
@@ -1,68 +1,50 @@
-# Reference: ethics/core.mdx
-"""Mission statement registry with simple XOR-based encryption."""
+"""Mission statement registry backed by authenticated encryption."""
+from __future__ import annotations
 
-import json
 import os
-import base64
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from utils.crypto import decrypt_text, derive_key, encrypt_text
+from utils.json_io import load_json, write_json
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 DATA_PATH = BASE_DIR / "missions.json"
 DEFAULT_KEY = os.environ.get("MISSION_KEY", "vaultfire")
 
 
-def _load_json(path: Path, default):
-    if path.exists():
-        try:
-            with open(path) as f:
-                return json.load(f)
-        except json.JSONDecodeError:
-            return default
-    return default
+def _key_bytes(key: Optional[str]) -> bytes:
+    secret = key if key is not None else DEFAULT_KEY
+    return derive_key(secret)
 
 
-def _write_json(path: Path, data) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2)
+def encrypt_mission(mission: str, key: Optional[str] = None) -> str:
+    return encrypt_text(_key_bytes(key), mission)
 
 
-# --- Very lightweight XOR cipher (not secure) ------------------------------
-
-def _xor_cipher(text: str, key: str) -> bytes:
-    key_bytes = key.encode()
-    data_bytes = text.encode()
-    return bytes(b ^ key_bytes[i % len(key_bytes)] for i, b in enumerate(data_bytes))
-
-
-def encrypt_mission(mission: str, key: str | None = None) -> str:
-    key = key or DEFAULT_KEY
-    cipher = _xor_cipher(mission, key)
-    return base64.urlsafe_b64encode(cipher).decode()
-
-
-def decrypt_mission(token: str, key: str | None = None) -> str:
-    key = key or DEFAULT_KEY
-    data = base64.urlsafe_b64decode(token.encode())
-    plain = bytes(b ^ key.encode()[i % len(key) ] for i, b in enumerate(data))
-    return plain.decode()
+def decrypt_mission(token: str, key: Optional[str] = None) -> str:
+    return decrypt_text(_key_bytes(key), token)
 
 
 # --- Mission registry functions -------------------------------------------
 
-def record_mission(user_id: str, wallet: str, mission: str, key: str | None = None) -> dict:
+def record_mission(user_id: str, wallet: str, mission: str, key: Optional[str] = None) -> dict:
     """Store encrypted ``mission`` for ``user_id`` and associated ``wallet``."""
-    data = _load_json(DATA_PATH, {})
+    data = load_json(DATA_PATH, {})
     enc = encrypt_mission(mission, key)
-    entry = {"wallet": wallet, "mission": enc, "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")}
+    entry = {
+        "wallet": wallet,
+        "mission": enc,
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
     data[user_id] = entry
-    _write_json(DATA_PATH, data)
+    write_json(DATA_PATH, data)
     return entry
 
 
-def get_mission(user_id: str, key: str | None = None) -> str | None:
-    data = _load_json(DATA_PATH, {})
+def get_mission(user_id: str, key: Optional[str] = None) -> Optional[str]:
+    data = load_json(DATA_PATH, {})
     entry = data.get(user_id)
     if not entry:
         return None
@@ -72,14 +54,12 @@ def get_mission(user_id: str, key: str | None = None) -> str | None:
         return None
 
 
-def get_mission_by_wallet(wallet: str, key: str | None = None) -> str | None:
-    data = _load_json(DATA_PATH, {})
-    for uid, entry in data.items():
+def get_mission_by_wallet(wallet: str, key: Optional[str] = None) -> Optional[str]:
+    data = load_json(DATA_PATH, {})
+    for entry in data.values():
         if entry.get("wallet") == wallet:
             try:
                 return decrypt_mission(entry.get("mission", ""), key)
             except Exception:
                 return None
     return None
-
-

--- a/engine/proof_of_loyalty.py
+++ b/engine/proof_of_loyalty.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict
 
+from utils.json_io import load_json, write_json
+
 from .token_ops import send_token
 # ``vaultfire_signal_parser`` lives at the repo root rather than within
 # ``engine`` so import it as a top-level module.
@@ -14,22 +16,6 @@ from vaultfire_signal_parser import parse_signal
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 LOG_PATH = BASE_DIR / "logs" / "proof_of_loyalty.json"
-
-
-def _load_json(path: Path, default):
-    if path.exists():
-        try:
-            with open(path) as f:
-                return json.load(f)
-        except json.JSONDecodeError:
-            return default
-    return default
-
-
-def _write_json(path: Path, data) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2)
 
 
 def record_belief_action(user_id: str, wallet: str, text: str) -> Dict:
@@ -43,9 +29,9 @@ def record_belief_action(user_id: str, wallet: str, text: str) -> Dict:
         "score": result.get("score"),
         "verified": result.get("verified"),
     }
-    log = _load_json(LOG_PATH, [])
+    log = load_json(LOG_PATH, [])
     log.append(entry)
-    _write_json(LOG_PATH, log)
+    write_json(LOG_PATH, log)
 
     if result.get("verified"):
         try:

--- a/engine/synced_circles.py
+++ b/engine/synced_circles.py
@@ -1,13 +1,14 @@
 """Auto-curated social circles synced from encrypted profile data."""
-
 from __future__ import annotations
 
 import json
 import random
 import hashlib
 from pathlib import Path
-import base64
 from typing import Dict, List
+
+from utils.crypto import decrypt_text, derive_key, encrypt_text
+from utils.json_io import load_json, write_json
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 CIRCLES_DIR = BASE_DIR / "logs" / "circles"
@@ -15,38 +16,16 @@ OPTS_PATH = CIRCLES_DIR / "opt_in.json"
 CIRCLES_PATH = CIRCLES_DIR / "circles.json"
 
 
-def _load_json(path: Path, default):
-    if path.exists():
-        try:
-            with open(path) as f:
-                return json.load(f)
-        except json.JSONDecodeError:
-            return default
-    return default
-
-
-def _write_json(path: Path, data) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2)
-
-
-# --- lightweight XOR encryption -------------------------------------------
-
-def _xor_cipher(data: bytes, key: str) -> bytes:
-    key_bytes = key.encode()
-    return bytes(b ^ key_bytes[i % len(key_bytes)] for i, b in enumerate(data))
+def _key_bytes(key: str) -> bytes:
+    return derive_key(key)
 
 
 def encrypt_data(text: str, key: str) -> str:
-    cipher = _xor_cipher(text.encode(), key)
-    return base64.urlsafe_b64encode(cipher).decode()
+    return encrypt_text(_key_bytes(key), text)
 
 
 def decrypt_data(token: str, key: str) -> str:
-    data = base64.urlsafe_b64decode(token.encode())
-    plain = _xor_cipher(data, key)
-    return plain.decode()
+    return decrypt_text(_key_bytes(key), token)
 
 
 def _hash_id(identifier: str) -> str:
@@ -57,19 +36,19 @@ def _hash_id(identifier: str) -> str:
 
 def opt_in(user_id: str) -> bool:
     """Opt ``user_id`` into Synced Circles."""
-    opts: List[str] = _load_json(OPTS_PATH, [])
+    opts: List[str] = load_json(OPTS_PATH, [])
     if user_id not in opts:
         opts.append(user_id)
-        _write_json(OPTS_PATH, opts)
+        write_json(OPTS_PATH, opts)
     return True
 
 
 def opt_out(user_id: str) -> bool:
     """Remove ``user_id`` from Synced Circles."""
-    opts: List[str] = _load_json(OPTS_PATH, [])
+    opts: List[str] = load_json(OPTS_PATH, [])
     if user_id in opts:
         opts.remove(user_id)
-        _write_json(OPTS_PATH, opts)
+        write_json(OPTS_PATH, opts)
     return True
 
 
@@ -80,7 +59,7 @@ def link_profile_data(user_id: str, data: Dict, key: str) -> Dict:
     hashed = _hash_id(user_id)
     path = CIRCLES_DIR / f"{hashed}.json"
     token = encrypt_data(json.dumps(data), key)
-    _write_json(path, {"data": token})
+    write_json(path, {"data": token})
     return data
 
 
@@ -88,7 +67,7 @@ def link_profile_data(user_id: str, data: Dict, key: str) -> Dict:
 
 def curate_circles(user_keys: Dict[str, str], group_size: int = 5) -> List[List[str]]:
     """Auto-form circles from opted-in users using encrypted profiles."""
-    opts: List[str] = _load_json(OPTS_PATH, [])
+    opts: List[str] = load_json(OPTS_PATH, [])
     groups: Dict[str, List[str]] = {}
     for uid in opts:
         key = user_keys.get(uid)
@@ -96,7 +75,7 @@ def curate_circles(user_keys: Dict[str, str], group_size: int = 5) -> List[List[
             continue
         hashed = _hash_id(uid)
         path = CIRCLES_DIR / f"{hashed}.json"
-        info = _load_json(path, {})
+        info = load_json(path, {})
         token = info.get("data")
         if not token:
             continue
@@ -116,7 +95,7 @@ def curate_circles(user_keys: Dict[str, str], group_size: int = 5) -> List[List[
             circles.append(circle)
             members = members[group_size:]
 
-    _write_json(CIRCLES_PATH, circles)
+    write_json(CIRCLES_PATH, circles)
     return circles
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ anyio==4.9.0
 black==25.1.0
 certifi==2025.7.14
 click==8.2.1
+cryptography==43.0.1
 distro==1.9.0
 h11==0.16.0
 httpcore==1.0.9

--- a/utils/crypto.py
+++ b/utils/crypto.py
@@ -1,0 +1,92 @@
+"""High-level cryptography helpers for Vaultfire components."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+_AES_NONCE_SIZE = 12
+
+
+def derive_key(secret: str, *, length: int = 32) -> bytes:
+    """Derive a fixed-length AES key from ``secret``.
+
+    The helper hashes the provided secret to avoid leaking raw passphrases while
+    ensuring the returned bytes always match the required AES key sizes. The
+    default ``length`` of 32 bytes targets AES-256.
+    """
+    if not secret:
+        raise ValueError("Secret must be a non-empty string")
+    digest = hashlib.sha256(secret.encode("utf-8")).digest()
+    if length not in (16, 24, 32):
+        raise ValueError("AES keys must be 16, 24 or 32 bytes long")
+    return digest[:length]
+
+
+@dataclass(frozen=True)
+class EncryptedPayload:
+    """Bundle returned by :func:`encrypt_bytes`."""
+
+    nonce: bytes
+    ciphertext: bytes
+
+    def to_token(self) -> str:
+        """Serialize the payload for storage.
+
+        The nonce and ciphertext are concatenated and base64 encoded so callers
+        can persist the token as text without worrying about byte handling.
+        """
+        return base64.urlsafe_b64encode(self.nonce + self.ciphertext).decode("ascii")
+
+    @staticmethod
+    def from_token(token: str) -> "EncryptedPayload":
+        raw = base64.urlsafe_b64decode(token.encode("ascii"))
+        if len(raw) <= _AES_NONCE_SIZE:
+            raise ValueError("Encrypted payload is too short")
+        nonce = raw[:_AES_NONCE_SIZE]
+        ciphertext = raw[_AES_NONCE_SIZE:]
+        return EncryptedPayload(nonce=nonce, ciphertext=ciphertext)
+
+
+def _build_cipher(key: bytes) -> AESGCM:
+    if len(key) not in (16, 24, 32):
+        raise ValueError("AESGCM keys must be 128, 192, or 256 bits long")
+    return AESGCM(key)
+
+
+def encrypt_bytes(key: bytes, data: bytes, *, associated_data: Optional[bytes] = None) -> EncryptedPayload:
+    """Encrypt ``data`` using AES-GCM and return the ciphertext bundle."""
+    cipher = _build_cipher(key)
+    nonce = os.urandom(_AES_NONCE_SIZE)
+    ciphertext = cipher.encrypt(nonce, data, associated_data)
+    return EncryptedPayload(nonce=nonce, ciphertext=ciphertext)
+
+
+def decrypt_bytes(
+    key: bytes,
+    nonce: bytes,
+    ciphertext: bytes,
+    *,
+    associated_data: Optional[bytes] = None,
+) -> bytes:
+    """Decrypt AES-GCM data produced by :func:`encrypt_bytes`."""
+    cipher = _build_cipher(key)
+    return cipher.decrypt(nonce, ciphertext, associated_data)
+
+
+def encrypt_text(key: bytes, text: str, *, associated_data: Optional[bytes] = None) -> str:
+    """Encrypt ``text`` and return a base64 token suitable for storage."""
+    payload = encrypt_bytes(key, text.encode("utf-8"), associated_data=associated_data)
+    return payload.to_token()
+
+
+def decrypt_text(key: bytes, token: str, *, associated_data: Optional[bytes] = None) -> str:
+    """Inverse of :func:`encrypt_text`."""
+    payload = EncryptedPayload.from_token(token)
+    data = decrypt_bytes(key, payload.nonce, payload.ciphertext, associated_data=associated_data)
+    return data.decode("utf-8")

--- a/utils/json_io.py
+++ b/utils/json_io.py
@@ -1,27 +1,92 @@
-"""Shared helpers for reading and writing JSON files."""
+"""Shared helpers for reading and writing JSON files with locking."""
 from __future__ import annotations
 
 import json
+import os
+import tempfile
+import threading
+import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
+
+try:
+    import fcntl  # type: ignore
+except ImportError:  # pragma: no cover - platform fallback
+    fcntl = None  # type: ignore
+
+_LOCK_TIMEOUT = 5.0
+_RETRY_DELAY = 0.05
+_THREAD_LOCKS: dict[str, threading.Lock] = {}
+_THREAD_LOCKS_GUARD = threading.Lock()
 
 
-def load_json(path: Path, default: Any):
-    """Return parsed JSON from ``path`` or ``default`` on error."""
-    if path.exists():
+@contextmanager
+def _thread_lock(path: Path, timeout: float) -> Iterator[None]:
+    with _THREAD_LOCKS_GUARD:
+        lock = _THREAD_LOCKS.setdefault(str(path), threading.Lock())
+    if not lock.acquire(timeout=timeout):
+        raise TimeoutError(f"Timed out acquiring lock for {path}")
+    try:
+        yield
+    finally:
+        lock.release()
+
+
+@contextmanager
+def _acquire_lock(path: Path, *, exclusive: bool, timeout: float) -> Iterator[None]:
+    lock_path = path.with_suffix(path.suffix + '.lock')
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    if fcntl is None:  # pragma: no cover - Windows fallback
+        with _thread_lock(lock_path, timeout):
+            yield
+        return
+
+    with open(lock_path, 'a+', encoding='utf-8') as lock_file:
+        end = time.monotonic() + timeout
+        mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+        while True:
+            try:
+                fcntl.flock(lock_file, mode | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= end:
+                    raise TimeoutError(f"Timed out acquiring lock for {path}")
+                time.sleep(_RETRY_DELAY)
         try:
-            with open(path) as f:
-                return json.load(f)
-        except json.JSONDecodeError:
-            return default
-    return default
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
-def write_json(path: Path, data: Any) -> None:
-    """Write ``data`` to ``path`` in JSON format."""
+def load_json(path: Path, default: Any, *, timeout: float = _LOCK_TIMEOUT) -> Any:
+    """Return parsed JSON from ``path`` or ``default`` on error."""
+    if not path.exists():
+        return default
+    try:
+        with _acquire_lock(path, exclusive=False, timeout=timeout):
+            with open(path, encoding='utf-8') as handle:
+                return json.load(handle)
+    except json.JSONDecodeError:
+        return default
+    except FileNotFoundError:  # pragma: no cover - race where file disappears
+        return default
+
+
+def write_json(path: Path, data: Any, *, timeout: float = _LOCK_TIMEOUT) -> None:
+    """Atomically persist ``data`` to ``path`` in JSON format."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2)
+    with _acquire_lock(path, exclusive=True, timeout=timeout):
+        fd, tmp_path = tempfile.mkstemp(prefix=path.name, suffix='.tmp', dir=str(path.parent))
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+                json.dump(data, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, path)
+        finally:
+            if os.path.exists(tmp_path):  # pragma: no cover - cleanup on failure
+                os.remove(tmp_path)
 
 
 __all__ = ["load_json", "write_json"]

--- a/vaultfire_drop/secure_upload/vaultfire_securestore.py
+++ b/vaultfire_drop/secure_upload/vaultfire_securestore.py
@@ -2,29 +2,23 @@
 from __future__ import annotations
 
 import json
-import os
 import hmac
 import hashlib
-import subprocess
-from typing import Tuple
-
-try:  # optional crypto
-    from Crypto.Cipher import AES  # type: ignore
-except Exception:  # pragma: no cover - library may be missing
-    AES = None  # type: ignore
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 from geolock_filter import strip_exif
 from belief_trigger_engine import log_chain_event, send_to_webhook
+from utils.crypto import decrypt_bytes, encrypt_bytes
 
 
 class SecureStore:
     """Encrypt and store media with signed metadata."""
 
     def __init__(self, key: bytes, bucket: Path) -> None:
-        if len(key) != 32:
-            raise ValueError("Key must be 32 bytes for AES-256")
+        if len(key) not in (16, 24, 32):
+            raise ValueError("Key must be 16, 24, or 32 bytes for AES-GCM")
         self.key = key
         self.bucket = bucket
         bucket.mkdir(exist_ok=True, parents=True)
@@ -40,7 +34,7 @@ class SecureStore:
         tier: str,
         score: int,
         *,
-        webhook: str | None = None,
+        webhook: Optional[str] = None,
         chain_log: bool = False,
     ) -> dict:
         """Sanitize ``file_path`` and store encrypted copy."""
@@ -48,31 +42,11 @@ class SecureStore:
         cleaned = strip_exif(raw)
         content_hash = hashlib.sha256(cleaned).hexdigest()
 
-        iv = os.urandom(12)
-        tag: bytes | None = None
-        if AES:
-            cipher = AES.new(self.key, AES.MODE_GCM, nonce=iv)
-            ciphertext, tag = cipher.encrypt_and_digest(cleaned)
-            encrypted = iv + ciphertext + tag
-        else:  # pragma: no cover - fallback if crypto missing
-            result = subprocess.run(
-                [
-                    "openssl",
-                    "enc",
-                    "-aes-256-cbc",
-                    "-K",
-                    self.key.hex(),
-                    "-iv",
-                    iv.hex(),
-                ],
-                input=cleaned,
-                stdout=subprocess.PIPE,
-                check=True,
-            )
-            encrypted = iv + result.stdout
-        cid = hashlib.sha256(encrypted).hexdigest()
+        payload = encrypt_bytes(self.key, cleaned)
+        ciphertext = payload.ciphertext
+        cid = hashlib.sha256(payload.nonce + ciphertext).hexdigest()
         enc_path = self.bucket / f"{cid}.bin"
-        enc_path.write_bytes(encrypted)
+        enc_path.write_bytes(ciphertext)
 
         timestamp = datetime.utcnow().isoformat()
         metadata = {
@@ -82,9 +56,8 @@ class SecureStore:
             "timestamp": timestamp,
             "content_hash": content_hash,
             "cid": cid,
+            "nonce": payload.nonce.hex(),
         }
-        if tag:
-            metadata["tag"] = tag.hex()
         signature_payload = {
             k: metadata[k]
             for k in ["wallet", "tier", "score", "timestamp", "content_hash", "cid"]
@@ -114,32 +87,13 @@ class SecureStore:
         }
         if self._sign(meta) != metadata.get("signature"):
             raise ValueError("Invalid signature")
-        data = (self.bucket / f"{cid}.bin").read_bytes()
-        iv = data[:12]
-        body = data[12:]
-        tag_hex = metadata.get("tag")
-        if AES and tag_hex:
-            tag = bytes.fromhex(tag_hex)
-            ciphertext = body[:-16]
-            cipher = AES.new(self.key, AES.MODE_GCM, nonce=iv)
-            return cipher.decrypt_and_verify(ciphertext, tag)
-        else:  # pragma: no cover - fallback
-            enc = body
-            result = subprocess.run(
-                [
-                    "openssl",
-                    "enc",
-                    "-d",
-                    "-aes-256-cbc",
-                    "-K",
-                    self.key.hex(),
-                    "-iv",
-                    iv.hex(),
-                ],
-                input=enc,
-                stdout=subprocess.PIPE,
-                check=True,
-            )
-            return result.stdout
+        data_path = self.bucket / f"{cid}.bin"
+        ciphertext = data_path.read_bytes()
+        nonce_hex = metadata.get("nonce")
+        if not nonce_hex:
+            raise ValueError("Missing nonce in metadata")
+        nonce = bytes.fromhex(nonce_hex)
+        return decrypt_bytes(self.key, nonce, ciphertext)
+
 
 __all__ = ["SecureStore"]

--- a/vaultfire_fork_v2.py
+++ b/vaultfire_fork_v2.py
@@ -11,7 +11,9 @@ import tempfile
 import zipfile
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
+
+from utils.crypto import encrypt_bytes, derive_key
 
 BASE_DIR = Path(__file__).resolve().parent
 PURPOSE_MAP_PATH = BASE_DIR / "purpose_map.json"
@@ -45,16 +47,14 @@ def _write_json(path: Path, data) -> None:
         json.dump(data, f, indent=2)
 
 
-# lightweight XOR encryption -----------------------------------------------
-
-def _xor_cipher(data: bytes, key: str) -> bytes:
-    key_bytes = key.encode()
-    return bytes(b ^ key_bytes[i % len(key_bytes)] for i, b in enumerate(data))
+# AES-GCM encryption --------------------------------------------------------
 
 
 def encrypt_data(data: bytes, key: str) -> str:
-    cipher = _xor_cipher(data, key)
-    return base64.urlsafe_b64encode(cipher).decode()
+    """Encrypt ``data`` with a key derived from ``key``."""
+
+    payload = encrypt_bytes(derive_key(key), data)
+    return payload.to_token()
 
 
 # ---------------------------------------------------------------------------

--- a/vaultfire_securestore.py
+++ b/vaultfire_securestore.py
@@ -1,30 +1,24 @@
-"""Vaultfire SecureStore v1."""
+"""Vaultfire SecureStore v1 with authenticated encryption."""
 from __future__ import annotations
 
 import json
-import os
 import hmac
 import hashlib
-import subprocess
-from typing import Tuple
-
-try:  # optional crypto
-    from Crypto.Cipher import AES  # type: ignore
-except Exception:  # pragma: no cover - library may be missing
-    AES = None  # type: ignore
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 from geolock_filter import strip_exif
 from belief_trigger_engine import log_chain_event, send_to_webhook
+from utils.crypto import decrypt_bytes, encrypt_bytes
 
 
 class SecureStore:
     """Encrypt and store media with signed metadata."""
 
     def __init__(self, key: bytes, bucket: Path) -> None:
-        if len(key) != 32:
-            raise ValueError("Key must be 32 bytes for AES-256")
+        if len(key) not in (16, 24, 32):
+            raise ValueError("Key must be 16, 24, or 32 bytes for AES-GCM")
         self.key = key
         self.bucket = bucket
         bucket.mkdir(exist_ok=True, parents=True)
@@ -40,7 +34,7 @@ class SecureStore:
         tier: str,
         score: int,
         *,
-        webhook: str | None = None,
+        webhook: Optional[str] = None,
         chain_log: bool = False,
     ) -> dict:
         """Sanitize ``file_path`` and store encrypted copy."""
@@ -48,31 +42,11 @@ class SecureStore:
         cleaned = strip_exif(raw)
         content_hash = hashlib.sha256(cleaned).hexdigest()
 
-        iv = os.urandom(12)
-        tag: bytes | None = None
-        if AES:
-            cipher = AES.new(self.key, AES.MODE_GCM, nonce=iv)
-            ciphertext, tag = cipher.encrypt_and_digest(cleaned)
-            encrypted = iv + ciphertext + tag
-        else:  # pragma: no cover - fallback if crypto missing
-            result = subprocess.run(
-                [
-                    "openssl",
-                    "enc",
-                    "-aes-256-cbc",
-                    "-K",
-                    self.key.hex(),
-                    "-iv",
-                    iv.hex(),
-                ],
-                input=cleaned,
-                stdout=subprocess.PIPE,
-                check=True,
-            )
-            encrypted = iv + result.stdout
-        cid = hashlib.sha256(encrypted).hexdigest()
+        payload = encrypt_bytes(self.key, cleaned)
+        ciphertext = payload.ciphertext
+        cid = hashlib.sha256(payload.nonce + ciphertext).hexdigest()
         enc_path = self.bucket / f"{cid}.bin"
-        enc_path.write_bytes(encrypted)
+        enc_path.write_bytes(ciphertext)
 
         timestamp = datetime.utcnow().isoformat()
         metadata = {
@@ -82,11 +56,8 @@ class SecureStore:
             "timestamp": timestamp,
             "content_hash": content_hash,
             "cid": cid,
+            "nonce": payload.nonce.hex(),
         }
-        if tag:
-            metadata["tag"] = tag.hex()
-        # Sign only the stable metadata fields so signature
-        # verification matches during ``decrypt``.
         signature_payload = {
             k: metadata[k]
             for k in ["wallet", "tier", "score", "timestamp", "content_hash", "cid"]
@@ -116,32 +87,13 @@ class SecureStore:
         }
         if self._sign(meta) != metadata.get("signature"):
             raise ValueError("Invalid signature")
-        data = (self.bucket / f"{cid}.bin").read_bytes()
-        iv = data[:12]
-        body = data[12:]
-        tag_hex = metadata.get("tag")
-        if AES and tag_hex:
-            tag = bytes.fromhex(tag_hex)
-            ciphertext = body[:-16]
-            cipher = AES.new(self.key, AES.MODE_GCM, nonce=iv)
-            return cipher.decrypt_and_verify(ciphertext, tag)
-        else:  # pragma: no cover - fallback
-            enc = body
-            result = subprocess.run(
-                [
-                    "openssl",
-                    "enc",
-                    "-d",
-                    "-aes-256-cbc",
-                    "-K",
-                    self.key.hex(),
-                    "-iv",
-                    iv.hex(),
-                ],
-                input=enc,
-                stdout=subprocess.PIPE,
-                check=True,
-            )
-            return result.stdout
+        data_path = self.bucket / f"{cid}.bin"
+        ciphertext = data_path.read_bytes()
+        nonce_hex = metadata.get("nonce")
+        if not nonce_hex:
+            raise ValueError("Missing nonce in metadata")
+        nonce = bytes.fromhex(nonce_hex)
+        return decrypt_bytes(self.key, nonce, ciphertext)
+
 
 __all__ = ["SecureStore"]

--- a/vaultfire_signal_parser.py
+++ b/vaultfire_signal_parser.py
@@ -1,46 +1,136 @@
+"""Parse Vaultfire belief signals with abuse-resistant scoring."""
+from __future__ import annotations
+
 import argparse
-from pathlib import Path
 import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Dict
 
 POSITIVE_WORDS = {
-    "open", "ethical", "collaborate", "truth", "support",
-    "generous", "help", "positive", "build", "care",
+    "open",
+    "ethical",
+    "collaborate",
+    "truth",
+    "support",
+    "generous",
+    "help",
+    "positive",
+    "build",
+    "care",
 }
 NEGATIVE_WORDS = {
-    "scam", "hate", "exploit", "harm", "deceive",
-    "fraud", "steal", "negative", "selfish", "pump",
+    "scam",
+    "hate",
+    "exploit",
+    "harm",
+    "deceive",
+    "fraud",
+    "steal",
+    "negative",
+    "selfish",
+    "pump",
 }
 LOYALTY_WORDS = {
-    "loyal", "consistent", "sacrifice", "truth-seeking", "truth",
-    "commit", "aligned", "collaborate", "community",
+    "loyal",
+    "consistent",
+    "sacrifice",
+    "truth-seeking",
+    "truth",
+    "commit",
+    "aligned",
+    "collaborate",
+    "community",
 }
 LOOP_ACTIVATORS = {"believe", "act", "teach", "grow"}
 
+_WORD_RE = re.compile(r"[a-z0-9']+")
 
-def _count_keywords(text: str, keywords: set[str]) -> int:
-    count = 0
+
+def _tokenize(text: str) -> Counter[str]:
+    tokens = _WORD_RE.findall(text.lower())
+    return Counter(tokens)
+
+
+def _keyword_presence(counter: Counter[str], keywords: set[str]) -> int:
+    return sum(1 for word in keywords if counter.get(word))
+
+
+def _keyword_strength(
+    counter: Counter[str],
+    keywords: set[str],
+    *,
+    per_hit_bonus: float = 0.0,
+    cap: int = 3,
+) -> float:
+    score = 0.0
     for word in keywords:
-        count += text.count(word)
-    return count
+        freq = counter.get(word, 0)
+        if freq:
+            score += 1.0
+            if per_hit_bonus and freq > 1:
+                score += min(freq - 1, cap) * per_hit_bonus
+    return score
 
 
-def parse_signal(text: str) -> dict:
-    text_lower = text.lower()
-    pos = _count_keywords(text_lower, POSITIVE_WORDS)
-    neg = _count_keywords(text_lower, NEGATIVE_WORDS)
-    loyalty = _count_keywords(text_lower, LOYALTY_WORDS)
-    loops = _count_keywords(text_lower, LOOP_ACTIVATORS)
+def _repetition_ratio(counter: Counter[str]) -> float:
+    total = sum(counter.values())
+    if total == 0:
+        return 0.0
+    return max(counter.values()) / total
 
-    belief_intensity = pos - neg
-    base_score = 10 + belief_intensity * 5 + loyalty * 5 + loops * 2
-    score = max(1, min(100, base_score))
-    verified = score >= 20
+
+def parse_signal(text: str) -> Dict[str, object]:
+    counter = _tokenize(text)
+    total_tokens = sum(counter.values())
+    diversity = len(counter)
+
+    positive_strength = _keyword_strength(counter, POSITIVE_WORDS, per_hit_bonus=0.25)
+    negative_strength = _keyword_strength(counter, NEGATIVE_WORDS, per_hit_bonus=0.5)
+    loyalty_strength = _keyword_strength(counter, LOYALTY_WORDS, per_hit_bonus=0.5)
+    loyalty_hits = _keyword_presence(counter, LOYALTY_WORDS)
+    loop_strength = _keyword_strength(counter, LOOP_ACTIVATORS, per_hit_bonus=0.25, cap=2)
+    loop_hits = _keyword_presence(counter, LOOP_ACTIVATORS)
+
+    repetition = _repetition_ratio(counter)
+    penalty = 0.0
+    if total_tokens < 5:
+        penalty += 10.0
+    if diversity < 4:
+        penalty += 5.0
+    if repetition > 0.35:
+        penalty += (repetition - 0.35) * 50
+
+    length_bonus = min(total_tokens // 6, 5)
+    sentiment = positive_strength - negative_strength
+
+    base_score = 20
+    score = (
+        base_score
+        + sentiment * 4
+        + loyalty_strength * 6
+        + loop_strength * 3
+        + length_bonus
+        - penalty
+    )
+    score = max(1, min(100, round(score)))
+
+    verified = (
+        score >= 40
+        and loyalty_hits > 0
+        and diversity >= 4
+        and repetition <= 0.6
+    )
+
     return {
         "verified": verified,
         "score": score,
-        "belief_intensity": belief_intensity,
-        "loyalty_markers": loyalty,
-        "loop_activators": loops,
+        "belief_intensity": round(sentiment, 2),
+        "loyalty_markers": loyalty_hits,
+        "loop_activators": loop_hits,
+        "unique_tokens": diversity,
+        "repetition_ratio": round(repetition, 3),
     }
 
 


### PR DESCRIPTION
## Summary
- add a shared AES-GCM crypto helper and replace the remaining XOR paths across health sync, Synced Circles, mission registry, bundle tooling, and both SecureStore implementations
- sign outbound reward webhooks with an HMAC header, add retry logic, and gate JSON writes through a lock-aware helper to avoid corruption
- tighten signal parsing to resist keyword spamming, refresh docs to describe the stronger encryption story, and declare the new cryptography dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9aaa3b57083228eb0fd4894a6528a