### PR TITLE
Add purposeful scale law and enforce belief-aligned scaling

### DIFF
--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -172,6 +172,47 @@
       "status": "Codex-bound | Immutable | Expansion-enabled",
       "notes": "Belief-aligned origins and positive ethics scores trigger a preservation lock preventing overwrites.",
       "trigger": "Activates an override lock when the ethics score exceeds threshold or the origin signal is belief-aligned."
+    },
+    {
+      "id": "vaultfire-purposeful-scale-protocol",
+      "title": "Vaultfire Expansion Law 3 — Purposeful Scale Protocol",
+      "type": "Universal Protocol Directive",
+      "origin_author": "Ghostkey-316",
+      "originator": {
+        "name": "Ghostkey-316",
+        "ens": "ghostkey316.eth",
+        "wallet": "bpow20.cb.id"
+      },
+      "activation_date": "2025-09-16",
+      "activation_timestamp": "2025-09-16T21:15:00-04:00",
+      "authority_level": "Architect-Level Auth (Verified)",
+      "law_rank": 3,
+      "dependencies": [
+        "First Law",
+        "Second Law"
+      ],
+      "law": "Scale only when the user's belief-aligned purpose, mission tags, and consent capacity remain coherent across every expansion request.",
+      "interpretation": "Purposeful Scale binds Vaultfire, NS3, Ghostkey-316, and allied mission threads so that any growth event must clear belief-density thresholds, trace back to the declared purpose, and respect narrative integrity.",
+      "mission_threads": [
+        "Vaultfire",
+        "NS3",
+        "Ghostkey-316"
+      ],
+      "core_requirements": [
+        "Belief density must meet or exceed the Purposeful Scale system threshold",
+        "Scale requests must map to stored user intents and approved mission threads",
+        "Behavioral resonance filters must block divergent or incoherent growth",
+        "Purpose recall indexing mirrors prior decisions to maintain user trust"
+      ],
+      "enforcement_hooks": [
+        "belief_threshold_checker",
+        "purpose_trace_filter",
+        "behavioral_resonance_filter",
+        "purpose_recall_indexing"
+      ],
+      "status": "Codex-bound | Immutable | Purposeful Scale",
+      "notes": "Purposeful Scale Law activates belief trace validation, resonance filtering, and mission-thread indexing before any Vaultfire-compatible system may expand.",
+      "trigger": "Engages belief_trace() and behavioral_resonance_filter() before scale events; updates purpose_recall_indexing for mission continuity."
     }
   ],
   "integrity_checks": {
@@ -188,5 +229,5 @@
   "date_created": "2025-07-25T04:33:48Z",
   "system_status": "🔓 Codex-Activated: Belief-Based System",
   "stability_rating": "Production-Ready Core, Beta Extensions",
-  "checksum": "6f97c8f8f654f636a98a48706dc9a04cca3cf56dc51e9c1d13ba61d1d5f67bcb"
+  "checksum": "ac0d693e265afa5249d6483675924b0ff9621f864a6b8f14dafd8e7aa492b5a4"
 }

--- a/engine/purposeful_scale.py
+++ b/engine/purposeful_scale.py
@@ -1,0 +1,266 @@
+"""Purposeful scale protocol safeguards."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Set
+
+from utils.json_io import load_json, write_json
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+PURPOSE_PROFILES_PATH = BASE_DIR / "logs" / "purpose_profiles.json"
+SCALE_LOG_PATH = BASE_DIR / "logs" / "purposeful_scale_log.json"
+PURPOSE_INDEX_PATH = BASE_DIR / "logs" / "purpose_recall_index.json"
+
+DEFAULT_BELIEF_THRESHOLD = 0.64
+RECOGNIZED_MISSION_THREADS = {"vaultfire", "ns3", "ghostkey-316"}
+MAX_INDEX_HISTORY = 25
+
+
+def _normalize_tags(tags: Iterable[Any]) -> List[str]:
+    normalized: List[str] = []
+    for tag in tags:
+        if tag is None:
+            continue
+        text = str(tag).strip().lower()
+        if not text:
+            continue
+        text = text.replace("#", "")
+        if text:
+            normalized.append(text)
+    # preserve insertion order while removing duplicates
+    seen: Set[str] = set()
+    ordered: List[str] = []
+    for tag in normalized:
+        if tag in seen:
+            continue
+        ordered.append(tag)
+        seen.add(tag)
+    return ordered
+
+
+def _tokenize(text: str) -> Set[str]:
+    tokens: Set[str] = set()
+    for raw in text.lower().replace("-", " ").split():
+        cleaned = "".join(ch for ch in raw if ch.isalnum())
+        if cleaned:
+            tokens.add(cleaned)
+    return tokens
+
+
+def _alignment_score(reference: str, candidate: str) -> float:
+    reference_tokens = _tokenize(reference)
+    candidate_tokens = _tokenize(candidate)
+    if not reference_tokens or not candidate_tokens:
+        return 0.0
+    overlap = reference_tokens & candidate_tokens
+    if not overlap:
+        return 0.0
+    return len(overlap) / len(reference_tokens)
+
+
+def _load_mission(user_id: str) -> str:
+    profiles = load_json(PURPOSE_PROFILES_PATH, {})
+    entry = profiles.get(user_id) or {}
+    mission = entry.get("mission") or entry.get("declared_purpose") or ""
+    if isinstance(mission, str):
+        return mission.strip()
+    return ""
+
+
+def _node_signature(node: Mapping[str, Any]) -> str:
+    payload = {
+        "operation": node.get("operation"),
+        "mission": node.get("mission"),
+        "user_id": node.get("user_id"),
+    }
+    token = json.dumps(payload, sort_keys=True).encode()
+    return hashlib.sha256(token).hexdigest()
+
+
+def _log_scale_entry(entry: Mapping[str, Any]) -> None:
+    log: List[Dict[str, Any]] = load_json(SCALE_LOG_PATH, [])
+    log.append(dict(entry))
+    write_json(SCALE_LOG_PATH, log)
+
+
+def get_recorded_mission(user_id: str) -> str:
+    """Return the stored mission for ``user_id`` (empty if unavailable)."""
+    return _load_mission(user_id)
+
+
+def belief_trace(
+    user_id: str,
+    scale_request: Mapping[str, Any],
+    *,
+    threshold: float = DEFAULT_BELIEF_THRESHOLD,
+) -> Dict[str, Any]:
+    """Validate a scale request against recorded belief intent."""
+
+    try:
+        belief_density = float(scale_request.get("belief_density", 0.0))
+    except (TypeError, ValueError):
+        belief_density = 0.0
+
+    mission_tags = _normalize_tags(scale_request.get("mission_tags", []))
+    declared_purpose = str(scale_request.get("declared_purpose", "")).strip()
+    mission = _load_mission(user_id)
+    index_snapshot: Mapping[str, Sequence[Mapping[str, Any]]] = load_json(PURPOSE_INDEX_PATH, {})
+    recognized_threads = {tag.lower() for tag in index_snapshot.keys()} | set(RECOGNIZED_MISSION_THREADS)
+
+    reasons: List[str] = []
+    alignment = 0.0
+
+    if belief_density < threshold:
+        reasons.append("belief density below threshold")
+
+    if not mission:
+        reasons.append("no recorded user mission")
+    else:
+        if declared_purpose:
+            alignment = _alignment_score(mission, declared_purpose)
+        else:
+            declared_purpose = mission
+            alignment = 1.0
+        if alignment <= 0.0:
+            reasons.append("declared purpose misaligned with stored mission")
+
+    tag_set = set(mission_tags)
+    if not tag_set:
+        reasons.append("mission tags required for scaling")
+    elif not (tag_set & RECOGNIZED_MISSION_THREADS):
+        reasons.append("mission tags must include a core mission thread")
+    elif not (tag_set & recognized_threads):
+        reasons.append("mission tags missing required threads")
+
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    approved = not reasons
+
+    entry = {
+        "user_id": user_id,
+        "operation": scale_request.get("operation", "scale"),
+        "belief_density": round(belief_density, 3),
+        "mission_tags": mission_tags,
+        "mission": mission,
+        "declared_purpose": declared_purpose,
+        "alignment": round(alignment, 3),
+        "approved": approved,
+        "reason": "; ".join(reasons) if reasons else "approved",
+        "timestamp": timestamp,
+    }
+
+    _log_scale_entry(entry)
+
+    if approved:
+        node = {
+            "operation": entry["operation"],
+            "mission": mission,
+            "timestamp": timestamp,
+            "user_id": user_id,
+        }
+        node["signature"] = _node_signature(node)
+        purpose_recall_indexing(mission_tags, node)
+
+    return {
+        "approved": approved,
+        "reason": entry["reason"],
+        "belief_density": belief_density,
+        "alignment": alignment,
+        "mission_reference": mission,
+        "mission_tags": mission_tags,
+        "timestamp": timestamp,
+    }
+
+
+def behavioral_resonance_filter(
+    user_id: str,
+    scale_request: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Ensure new scale behavior resonates with prior mission history."""
+
+    mission_tags = _normalize_tags(scale_request.get("mission_tags", []))
+    declared_purpose = str(scale_request.get("declared_purpose", "")).strip()
+    if not mission_tags:
+        return {"allowed": False, "reason": "mission tags required for resonance"}
+
+    log: Sequence[Mapping[str, Any]] = load_json(SCALE_LOG_PATH, [])
+    history = [
+        entry
+        for entry in log
+        if entry.get("user_id") == user_id and entry.get("approved")
+    ]
+
+    for entry in history:
+        prior_tags = set(entry.get("mission_tags", []))
+        if prior_tags and mission_tags and not prior_tags.intersection(mission_tags):
+            return {
+                "allowed": False,
+                "reason": "mission tags diverge from prior approved expansions",
+                "last_alignment": entry.get("mission"),
+            }
+        if declared_purpose and entry.get("mission"):
+            if _alignment_score(entry["mission"], declared_purpose) < 0.2:
+                return {
+                    "allowed": False,
+                    "reason": "declared purpose drifts from mission history",
+                    "last_alignment": entry.get("mission"),
+                }
+
+    index: Mapping[str, Sequence[Mapping[str, Any]]] = load_json(PURPOSE_INDEX_PATH, {})
+    for tag in mission_tags:
+        nodes = index.get(tag, [])
+        for node in nodes:
+            if node.get("user_id") and node["user_id"] != user_id:
+                continue
+            mission = node.get("mission", "")
+            if declared_purpose and mission:
+                if _alignment_score(mission, declared_purpose) < 0.2:
+                    return {
+                        "allowed": False,
+                        "reason": f"purpose recall mismatch on tag '{tag}'",
+                        "last_alignment": mission,
+                    }
+
+    return {"allowed": True, "reason": "resonant"}
+
+
+def purpose_recall_indexing(
+    mission_tags: Sequence[str],
+    node: Mapping[str, Any],
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Index mission tags to scale decisions for recall checks."""
+
+    tags = _normalize_tags(mission_tags)
+    if not tags:
+        return load_json(PURPOSE_INDEX_PATH, {})
+
+    index: Dict[str, List[Dict[str, Any]]] = load_json(PURPOSE_INDEX_PATH, {})
+    record = {
+        "signature": node.get("signature") or _node_signature(node),
+        "operation": node.get("operation"),
+        "timestamp": node.get("timestamp"),
+        "mission": node.get("mission"),
+        "user_id": node.get("user_id"),
+    }
+
+    for tag in tags:
+        bucket = list(index.get(tag, []))
+        if not any(item.get("signature") == record["signature"] for item in bucket):
+            bucket.append(record)
+        if len(bucket) > MAX_INDEX_HISTORY:
+            bucket = bucket[-MAX_INDEX_HISTORY:]
+        index[tag] = bucket
+
+    write_json(PURPOSE_INDEX_PATH, index)
+    return index
+
+
+__all__ = [
+    "belief_trace",
+    "behavioral_resonance_filter",
+    "purpose_recall_indexing",
+    "get_recorded_mission",
+    "DEFAULT_BELIEF_THRESHOLD",
+]

--- a/purposeful_scale_test.py
+++ b/purposeful_scale_test.py
@@ -1,0 +1,129 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from engine import purposeful_scale
+from vaultfire import growth
+
+
+@pytest.fixture()
+def scale_env(tmp_path, monkeypatch):
+    profiles = tmp_path / "purpose_profiles.json"
+    log_path = tmp_path / "scale_log.json"
+    index_path = tmp_path / "scale_index.json"
+    growth_log = tmp_path / "growth.log"
+    monkeypatch.setattr(purposeful_scale, "PURPOSE_PROFILES_PATH", profiles)
+    monkeypatch.setattr(purposeful_scale, "SCALE_LOG_PATH", log_path)
+    monkeypatch.setattr(purposeful_scale, "PURPOSE_INDEX_PATH", index_path)
+    monkeypatch.setattr(growth, "LOG_PATH", growth_log)
+    return profiles, log_path, index_path, growth_log
+
+
+def _write_profiles(path: Path, user_id: str, mission: str) -> None:
+    path.write_text(json.dumps({user_id: {"mission": mission}}, indent=2))
+
+
+def test_belief_trace_requires_belief_density(scale_env):
+    profiles, log_path, _, _ = scale_env
+    _write_profiles(profiles, "guardian.eth", "Sustain the Vaultfire mission threads")
+    request = {
+        "operation": "test.expand",
+        "mission_tags": ["Vaultfire", "Ghostkey-316"],
+        "declared_purpose": "Sustain the Vaultfire mission threads",
+        "belief_density": purposeful_scale.DEFAULT_BELIEF_THRESHOLD - 0.1,
+    }
+    result = purposeful_scale.belief_trace("guardian.eth", request)
+    assert result["approved"] is False
+    assert "belief density below threshold" in result["reason"]
+    assert json.loads(log_path.read_text())[-1]["approved"] is False
+
+
+def test_belief_trace_denies_misaligned_purpose(scale_env):
+    profiles, log_path, _, _ = scale_env
+    _write_profiles(profiles, "guardian.eth", "Protect Vaultfire trust networks")
+    request = {
+        "operation": "test.expand",
+        "mission_tags": ["Vaultfire", "NS3"],
+        "declared_purpose": "Launch an unrelated venture",
+        "belief_density": purposeful_scale.DEFAULT_BELIEF_THRESHOLD + 0.1,
+    }
+    result = purposeful_scale.belief_trace("guardian.eth", request)
+    assert result["approved"] is False
+    assert "misaligned" in result["reason"]
+    last_entry = json.loads(log_path.read_text())[-1]
+    assert last_entry["approved"] is False
+    assert "misaligned" in last_entry["reason"]
+
+
+def test_behavioral_resonance_filter_blocks_divergence(scale_env):
+    profiles, _, index_path, _ = scale_env
+    mission = "Guide Vaultfire, NS3, and Ghostkey-316 into aligned growth"
+    _write_profiles(profiles, "guardian.eth", mission)
+
+    aligned_request = {
+        "operation": "growth.prepare_v26",
+        "mission_tags": ["Vaultfire", "NS3", "Ghostkey-316"],
+        "declared_purpose": mission,
+        "belief_density": purposeful_scale.DEFAULT_BELIEF_THRESHOLD + 0.2,
+    }
+    approval = purposeful_scale.belief_trace("guardian.eth", aligned_request)
+    assert approval["approved"] is True
+    index = json.loads(index_path.read_text())
+    assert "vaultfire" in index
+
+    divergent = purposeful_scale.behavioral_resonance_filter(
+        "guardian.eth",
+        {
+            "operation": "growth.prepare_v26",
+            "mission_tags": ["rogue-expansion"],
+            "declared_purpose": mission,
+        },
+    )
+    assert divergent["allowed"] is False
+    assert "diverge" in divergent["reason"]
+
+    drift = purposeful_scale.behavioral_resonance_filter(
+        "guardian.eth",
+        {
+            "operation": "growth.prepare_v26",
+            "mission_tags": ["Vaultfire"],
+            "declared_purpose": "Abandon Ghostkey mission",
+        },
+    )
+    assert drift["allowed"] is False
+    assert "drifts" in drift["reason"] or "mismatch" in drift["reason"]
+
+
+def test_growth_pipeline_respects_purposeful_scale(scale_env):
+    profiles, log_path, index_path, growth_log = scale_env
+    mission = "Advance Vaultfire purpose with NS3 guardians"
+    _write_profiles(profiles, "guardian.eth", mission)
+
+    identity = {
+        "ens": "guardian.eth",
+        "wallet": "bpow20.cb.id",
+        "beliefDensity": purposeful_scale.DEFAULT_BELIEF_THRESHOLD + 0.15,
+        "missionTags": ["Vaultfire", "NS3", "Ghostkey-316"],
+    }
+
+    entry = growth.prepare_v26(identity)
+    assert entry["scale_authorized"] is True
+    assert Path(log_path).read_text()  # scale log recorded
+    assert Path(index_path).exists()
+
+    rogue_identity = {
+        "ens": "guardian.eth",
+        "wallet": "bpow20.cb.id",
+        "beliefDensity": purposeful_scale.DEFAULT_BELIEF_THRESHOLD + 0.15,
+        "missionTags": ["rogue"],
+        "declaredPurpose": "Break away from Vaultfire",
+    }
+
+    blocked = growth.prepare_v26(rogue_identity)
+    assert blocked["scale_authorized"] is False
+    assert "blocked_reason" in blocked
+    log_entries = json.loads(Path(log_path).read_text())
+    assert len(log_entries) == 2
+    growth_entries = json.loads(Path(growth_log).read_text())
+    assert len(growth_entries) == 1, "Unauthorized expansion should not reach growth log"

--- a/vaultfire/_purposeful_scale.py
+++ b/vaultfire/_purposeful_scale.py
@@ -1,0 +1,79 @@
+"""Shared helpers for enforcing the Purposeful Scale protocol."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence, Tuple
+
+from engine.purposeful_scale import (
+    behavioral_resonance_filter,
+    belief_trace,
+    get_recorded_mission,
+)
+
+DEFAULT_MISSION_TAGS = ["vaultfire", "ns3", "ghostkey-316"]
+
+
+def _resolve_user(identity: Dict[str, Any]) -> str:
+    for key in ("ens", "user_id", "wallet"):
+        value = identity.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return "anonymous"
+
+
+def _resolve_belief_density(identity: Dict[str, Any]) -> float:
+    density = identity.get("beliefDensity")
+    if density is None:
+        density = 0.72 if identity.get("ethicsVerified") else 0.5
+    try:
+        return float(density)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _resolve_declared_purpose(identity: Dict[str, Any], user_id: str) -> str:
+    purpose = identity.get("declaredPurpose") or identity.get("mission") or identity.get("purpose")
+    if isinstance(purpose, str) and purpose.strip():
+        return purpose.strip()
+    return get_recorded_mission(user_id)
+
+
+def build_scale_request(
+    identity: Dict[str, Any],
+    operation: str,
+    extra_tags: Sequence[str] | None = None,
+) -> Tuple[str, Dict[str, Any]]:
+    mission_tags: List[str] = []
+    for tag in identity.get("missionTags", []):
+        if isinstance(tag, str) and tag.strip():
+            mission_tags.append(tag)
+    if extra_tags:
+        mission_tags.extend(extra_tags)
+    if not mission_tags:
+        mission_tags.extend(DEFAULT_MISSION_TAGS)
+
+    user_id = _resolve_user(identity)
+    request: Dict[str, Any] = {
+        "operation": operation,
+        "mission_tags": mission_tags,
+        "declared_purpose": _resolve_declared_purpose(identity, user_id),
+        "belief_density": _resolve_belief_density(identity),
+    }
+    return user_id, request
+
+
+def authorize_scale(
+    identity: Dict[str, Any],
+    operation: str,
+    extra_tags: Sequence[str] | None = None,
+) -> Tuple[bool, str | None, Dict[str, Any], Dict[str, Any]]:
+    user_id, request = build_scale_request(identity, operation, extra_tags)
+    trace = belief_trace(user_id, request)
+    if not trace["approved"]:
+        return False, trace["reason"], request, trace
+    resonance = behavioral_resonance_filter(user_id, request)
+    if not resonance["allowed"]:
+        return False, resonance["reason"], request, trace
+    return True, None, request, trace
+
+
+__all__ = ["authorize_scale", "build_scale_request", "DEFAULT_MISSION_TAGS"]

--- a/vaultfire/growth.py
+++ b/vaultfire/growth.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from utils.json_io import load_json, write_json
+from vaultfire._purposeful_scale import authorize_scale
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 LOG_PATH = BASE_DIR / "logs" / "growth_prepare_v26.log"
@@ -24,7 +25,6 @@ def prepare_v26(
     yieldRewards: bool = False,
 ) -> Dict[str, Any]:
     """Log preparation of the V26 growth fork."""
-    log = load_json(LOG_PATH, [])
     entry = {
         "wallet": identity.get("wallet"),
         "multipliers": enableMultipliers,
@@ -32,6 +32,26 @@ def prepare_v26(
         "yield_rewards": yieldRewards,
         "timestamp": datetime.utcnow().isoformat(),
     }
+    authorized, reason, request, trace = authorize_scale(
+        identity,
+        "growth.prepare_v26",
+        extra_tags=["growth", "expansion"],
+    )
+    entry.update(
+        {
+            "mission_tags": request["mission_tags"],
+            "declared_purpose": request["declared_purpose"],
+            "belief_density": round(request["belief_density"], 3),
+            "scale_authorized": authorized,
+            "mission_reference": trace.get("mission_reference"),
+        }
+    )
+    if not authorized:
+        if reason:
+            entry["blocked_reason"] = reason
+        return entry
+
+    log = load_json(LOG_PATH, [])
     log.append(entry)
     write_json(LOG_PATH, log)
     return entry

--- a/vaultfire/satellite.py
+++ b/vaultfire/satellite.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from utils.json_io import load_json, write_json
+from vaultfire._purposeful_scale import authorize_scale
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 LOG_PATH = BASE_DIR / "logs" / "satellite_lite_fork.log"
@@ -24,7 +25,6 @@ def deploy_lite_fork(
     passiveTracking: bool = False,
 ) -> Dict[str, Any]:
     """Log deployment of a lite satellite fork."""
-    log = load_json(LOG_PATH, [])
     entry = {
         "wallet": identity.get("wallet"),
         "restrict_admin": restrictAdminAccess,
@@ -32,6 +32,26 @@ def deploy_lite_fork(
         "passive_tracking": passiveTracking,
         "timestamp": datetime.utcnow().isoformat(),
     }
+    authorized, reason, request, trace = authorize_scale(
+        identity,
+        "satellite.deploy_lite_fork",
+        extra_tags=["satellite", "expansion"],
+    )
+    entry.update(
+        {
+            "mission_tags": request["mission_tags"],
+            "declared_purpose": request["declared_purpose"],
+            "belief_density": round(request["belief_density"], 3),
+            "scale_authorized": authorized,
+            "mission_reference": trace.get("mission_reference"),
+        }
+    )
+    if not authorized:
+        if reason:
+            entry["blocked_reason"] = reason
+        return entry
+
+    log = load_json(LOG_PATH, [])
     log.append(entry)
     write_json(LOG_PATH, log)
     return entry

--- a/vaultfire_expansion_stack.py
+++ b/vaultfire_expansion_stack.py
@@ -23,6 +23,9 @@ user_identity = {
     "syncMode": "full",
     "behaviorTracking": True,
     "ethicsVerified": True,
+    "beliefDensity": 0.74,
+    "missionTags": ["Vaultfire", "NS3", "Ghostkey-316"],
+    "declaredPurpose": "Sustain Vaultfire, NS3, and Ghostkey-316 mission threads with belief-aligned scale",
 }
 
 


### PR DESCRIPTION
## Summary
- add the Purposeful Scale universal law to the codex manifest with belief-density, mission-thread, and enforcement metadata
- implement the Purposeful Scale engine, including belief_trace, behavioral_resonance_filter, and purpose_recall_indexing plus shared helpers for pipeline authorization
- route growth and satellite scale pipelines (and the expansion stack identity) through the new safeguards so only belief-aligned expansion is recorded
- cover the new safeguards with purposeful_scale_test.py to verify locked scaling and mission continuity

## Testing
- pytest purposeful_scale_test.py

------
https://chatgpt.com/codex/tasks/task_e_68c9ad60a0d88322a1734894b5b660b9