### PR TITLE
Implement remembrance guard Fourth Law module

### DIFF
--- a/engine/remembrance_guard.py
+++ b/engine/remembrance_guard.py
@@ -1,0 +1,366 @@
+"""Vaultfire Fourth Law of Expansion: remembrance guard."""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, MutableMapping, Optional, Sequence, Set
+
+LAW_TITLE = "The Forgotten Flame: Those who lit the path shall not be left in the dark."
+
+
+def _normalize(text: Optional[str]) -> str:
+    if not text:
+        return ""
+    return " ".join(str(text).strip().lower().split())
+
+
+def _resolve_contributor(record: MutableMapping[str, Any]) -> Optional[str]:
+    for key in ("contributor", "user", "identity", "owner", "participant"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _is_overlooked(record: MutableMapping[str, Any]) -> bool:
+    if record.get("credited") is False:
+        return True
+    status = str(record.get("status", "")).lower()
+    if status in {"overlooked", "pending-credit", "awaiting-attribution"}:
+        return True
+    for key in ("flags", "tags", "labels"):
+        value = record.get(key)
+        if isinstance(value, (list, tuple, set)):
+            lowered = {str(item).lower() for item in value if item}
+            if lowered & {"overlooked", "missing-credit", "ghost-overlooked"}:
+                return True
+    return False
+
+
+@dataclass
+class OverlookedContributor:
+    """Internal structure capturing overlooked contribution context."""
+
+    contributor: str
+    insights: Set[str] = field(default_factory=set)
+    sources: Set[str] = field(default_factory=set)
+    tags: Set[str] = field(default_factory=set)
+    sacrifice: float = 0.0
+    early_support: bool = False
+    ghost_tagged: bool = False
+    entries: List[Dict[str, Any]] = field(default_factory=list)
+
+    def update_from_record(self, record: MutableMapping[str, Any], source: str) -> None:
+        self.sources.add(source)
+        insight = _normalize(record.get("insight") or record.get("pattern") or record.get("text"))
+        if insight:
+            self.insights.add(insight)
+        tags_value = record.get("tags") or record.get("labels")
+        if isinstance(tags_value, (list, tuple, set)):
+            for tag in tags_value:
+                if tag:
+                    self.tags.add(str(tag).lower())
+        if record.get("tag"):
+            self.tags.add(str(record["tag"]).lower())
+        sacrifice = record.get("sacrifice_level", record.get("sacrifice"))
+        if isinstance(sacrifice, (int, float)):
+            self.sacrifice = max(self.sacrifice, float(sacrifice))
+        if any(record.get(flag) for flag in ("early_support", "early_signal", "founding", "origin")):
+            self.early_support = True
+        if record.get("ghost_tagged") or record.get("ghost_tag"):
+            self.ghost_tagged = True
+        self.entries.append(deepcopy(dict(record)))
+
+    def as_payload(self, goal_tags: Set[str]) -> Dict[str, Any]:
+        tag_set = set(self.tags)
+        aligned = sorted(goal_tags & tag_set) if goal_tags else []
+        return {
+            "contributor": self.contributor,
+            "insights": sorted(self.insights),
+            "sources": sorted(self.sources),
+            "tags": sorted(tag_set),
+            "sacrifice": round(self.sacrifice, 4),
+            "early_support": self.early_support,
+            "ghost_tagged": self.ghost_tagged,
+            "goal_alignment": aligned,
+            "entry_count": len(self.entries),
+        }
+
+
+class RemembranceGuard:
+    """Implements Vaultfire's Fourth Law of Expansion."""
+
+    def __init__(
+        self,
+        belief_logs: Sequence[MutableMapping[str, Any]],
+        memory_chains: Sequence[MutableMapping[str, Any]],
+        *,
+        consensus_threshold: float = 0.66,
+    ) -> None:
+        self.consensus_threshold = consensus_threshold
+        self.belief_logs: List[Dict[str, Any]] = [deepcopy(dict(item)) for item in belief_logs if isinstance(item, MutableMapping)]
+        self.memory_chains: List[Dict[str, Any]] = [deepcopy(dict(chain)) for chain in memory_chains if isinstance(chain, MutableMapping)]
+        self._belief_index: Dict[str, List[Dict[str, Any]]] = {}
+        self._memory_index: Dict[str, List[Dict[str, Any]]] = {}
+        self._memory_by_id: Dict[str, Dict[str, Any]] = {}
+        self._mirror_archive: Dict[str, Dict[str, Any]] = {}
+        self.remembrance_triggers: List[Dict[str, Any]] = []
+        self.pending_yield_signals: List[Dict[str, Any]] = []
+        self.last_manifest: List[Dict[str, Any]] = []
+        self.last_checkpoint: Optional[Dict[str, Any]] = None
+        self.last_memory_lock: Optional[Dict[str, Any]] = None
+        self.loyalty_registry: Dict[str, Dict[str, Any]] = {}
+        self._build_indexes()
+
+    def _build_indexes(self) -> None:
+        for record in self.belief_logs:
+            key = _normalize(record.get("insight") or record.get("pattern") or record.get("text"))
+            if key:
+                self._belief_index.setdefault(key, []).append(record)
+        for chain in self.memory_chains:
+            entries = chain.get("entries")
+            if not isinstance(entries, Sequence):
+                continue
+            chain_id = chain.get("chain_id") or chain.get("id") or "chain"
+            for index, raw_entry in enumerate(entries):
+                if not isinstance(raw_entry, MutableMapping):
+                    continue
+                entry = deepcopy(dict(raw_entry))
+                entry_id = str(entry.get("id") or f"{chain_id}:{index}")
+                entry["id"] = entry_id
+                entry.setdefault("chain_id", chain_id)
+                self._memory_by_id[entry_id] = entry
+                key = _normalize(entry.get("insight") or entry.get("pattern") or entry.get("text"))
+                if key:
+                    self._memory_index.setdefault(key, []).append(entry)
+
+    def detect_forgotten_contributions(
+        self,
+        expansion_batch: Sequence[MutableMapping[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        triggers: List[Dict[str, Any]] = []
+        for expansion in expansion_batch:
+            if not isinstance(expansion, MutableMapping):
+                continue
+            pattern_key = _normalize(
+                expansion.get("pattern")
+                or expansion.get("insight")
+                or expansion.get("text")
+            )
+            if not pattern_key:
+                continue
+            goal_tags = set()
+            for key in ("goals", "tags", "labels"):
+                values = expansion.get(key)
+                if isinstance(values, (list, tuple, set)):
+                    goal_tags.update(str(value).lower() for value in values if value)
+            contributors: Dict[str, OverlookedContributor] = {}
+            for record in self._belief_index.get(pattern_key, []):
+                if not isinstance(record, MutableMapping) or not _is_overlooked(record):
+                    continue
+                contributor = _resolve_contributor(record)
+                if not contributor:
+                    continue
+                bucket = contributors.setdefault(contributor, OverlookedContributor(contributor))
+                bucket.update_from_record(record, "belief")
+            for record in self._memory_index.get(pattern_key, []):
+                if not isinstance(record, MutableMapping):
+                    continue
+                if not record.get("ghost_tagged"):
+                    continue
+                if not _is_overlooked(record):
+                    continue
+                contributor = _resolve_contributor(record)
+                if not contributor:
+                    continue
+                bucket = contributors.setdefault(contributor, OverlookedContributor(contributor))
+                bucket.update_from_record(record, "memory")
+            if contributors:
+                trigger = {
+                    "label": LAW_TITLE,
+                    "expansion_id": expansion.get("id"),
+                    "pattern": pattern_key,
+                    "contributors": [bucket.as_payload(goal_tags) for bucket in contributors.values()],
+                    "goal_tags": sorted(goal_tags),
+                }
+                triggers.append(trigger)
+        self.remembrance_triggers = triggers
+        return triggers
+
+    def route_loyalty_signals(
+        self,
+        triggers: Optional[Sequence[MutableMapping[str, Any]]] = None,
+        *,
+        base_multiplier: float = 1.0,
+    ) -> List[Dict[str, Any]]:
+        source_triggers: Sequence[MutableMapping[str, Any]] = triggers or self.remembrance_triggers
+        signals: List[Dict[str, Any]] = []
+        for trigger in source_triggers:
+            if not isinstance(trigger, MutableMapping):
+                continue
+            pattern = trigger.get("pattern")
+            for contributor in trigger.get("contributors", []):
+                if not isinstance(contributor, MutableMapping):
+                    continue
+                contributor_id = contributor.get("contributor")
+                if not contributor_id:
+                    continue
+                sacrifice = contributor.get("sacrifice") or 0.0
+                if not isinstance(sacrifice, (int, float)):
+                    sacrifice = 0.0
+                early_bonus = 0.15 if contributor.get("early_support") else 0.0
+                alignment = contributor.get("goal_alignment")
+                alignment_bonus = 0.0
+                if isinstance(alignment, (list, tuple, set)):
+                    alignment_bonus = 0.05 * len(list(alignment))
+                multiplier = base_multiplier + 0.1 * float(sacrifice) + early_bonus + alignment_bonus
+                multiplier = max(base_multiplier, min(2.5, multiplier))
+                payload = {
+                    "contributor": contributor_id,
+                    "multiplier": round(multiplier, 4),
+                    "activation": "delayed",
+                    "pattern": pattern,
+                    "sources": list(contributor.get("sources", [])),
+                }
+                self.loyalty_registry[contributor_id] = {
+                    "multiplier": payload["multiplier"],
+                    "pending": True,
+                    "pattern": pattern,
+                    "law": LAW_TITLE,
+                }
+                signals.append(payload)
+        self.pending_yield_signals.extend(deepcopy(signals))
+        return signals
+
+    def enforce_memory_preservation(
+        self,
+        requests: Sequence[MutableMapping[str, Any]],
+        consensus_weight: Optional[float] = None,
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        locked: List[Dict[str, Any]] = []
+        allowed: List[Dict[str, Any]] = []
+        for request in requests:
+            if not isinstance(request, MutableMapping):
+                continue
+            memory_id = request.get("memory_id") or request.get("id")
+            if not memory_id:
+                continue
+            memory_id = str(memory_id)
+            entry = self._memory_by_id.get(memory_id)
+            if not entry:
+                continue
+            weight = request.get("consensus_weight")
+            if weight is None:
+                weight = consensus_weight if consensus_weight is not None else 0.0
+            try:
+                provided = float(weight)
+            except (TypeError, ValueError):
+                provided = 0.0
+            required = float(entry.get("consensus_required", self.consensus_threshold))
+            tags = entry.get("tags")
+            tag_set = {str(tag).lower() for tag in tags} if isinstance(tags, (list, tuple, set)) else set()
+            is_key = bool(entry.get("key_breakthrough")) or ("breakthrough" in tag_set)
+            action = request.get("action", "inspect")
+            if is_key and provided < required and action in {"delete", "override"}:
+                lock_info = {
+                    "memory_id": memory_id,
+                    "required_consensus": required,
+                    "provided_consensus": provided,
+                    "action": action,
+                    "insight": entry.get("insight") or entry.get("pattern") or entry.get("text"),
+                    "reason": "consensus_not_met",
+                }
+                locked.append(lock_info)
+                self._mirror_archive[memory_id] = deepcopy(entry)
+                continue
+            if action in {"delete", "override"}:
+                self._mirror_archive[memory_id] = deepcopy(entry)
+                if action == "delete":
+                    self._memory_by_id.pop(memory_id, None)
+                elif action == "override" and request.get("replacement"):
+                    replacement = deepcopy(dict(request["replacement"]))
+                    replacement.setdefault("id", memory_id)
+                    replacement.setdefault("chain_id", entry.get("chain_id"))
+                    self._memory_by_id[memory_id] = replacement
+            allowed.append(
+                {
+                    "memory_id": memory_id,
+                    "action": action,
+                    "consensus": provided,
+                    "insight": entry.get("insight") or entry.get("pattern") or entry.get("text"),
+                }
+            )
+        report = {
+            "locked": locked,
+            "allowed": allowed,
+            "mirrored": [deepcopy(entry) for entry in self._mirror_archive.values()],
+        }
+        self.last_memory_lock = report
+        return report
+
+    def restore_memories(self, memory_ids: Optional[Sequence[str]] = None) -> List[Dict[str, Any]]:
+        if memory_ids is None:
+            targets = list(self._mirror_archive.keys())
+        else:
+            targets = [str(item) for item in memory_ids]
+        restored: List[Dict[str, Any]] = []
+        for memory_id in targets:
+            entry = self._mirror_archive.get(memory_id)
+            if entry:
+                restored_entry = deepcopy(entry)
+                self._memory_by_id[memory_id] = restored_entry
+                restored.append(restored_entry)
+        return restored
+
+    def generate_remembrance_manifest(
+        self,
+        iterations: Sequence[MutableMapping[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        manifest: List[Dict[str, Any]] = []
+        for iteration in iterations:
+            if not isinstance(iteration, MutableMapping):
+                continue
+            iteration_id = iteration.get("version") or iteration.get("id") or iteration.get("label")
+            entries = iteration.get("beliefs") or iteration.get("entries") or iteration.get("logs")
+            if not isinstance(entries, Sequence):
+                continue
+            for entry in entries:
+                if not isinstance(entry, MutableMapping):
+                    continue
+                tags = entry.get("tags") or entry.get("labels")
+                if not isinstance(tags, (list, tuple, set)):
+                    continue
+                normalized_tags = sorted({str(tag).lower() for tag in tags if tag})
+                if not normalized_tags:
+                    continue
+                if entry.get("rewarded") or entry.get("credited"):
+                    continue
+                manifest.append(
+                    {
+                        "iteration": iteration_id,
+                        "contributor": entry.get("contributor") or entry.get("user") or entry.get("identity"),
+                        "insight": entry.get("insight") or entry.get("pattern") or entry.get("text"),
+                        "tags": normalized_tags,
+                    }
+                )
+        self.last_manifest = manifest
+        return manifest
+
+    def run_expansion_checkpoint(
+        self,
+        iterations: Sequence[MutableMapping[str, Any]],
+        expansion_batch: Optional[Sequence[MutableMapping[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        manifest = self.generate_remembrance_manifest(iterations)
+        triggers = self.detect_forgotten_contributions(expansion_batch or [])
+        checkpoint = {
+            "law": LAW_TITLE,
+            "manifest": manifest,
+            "triggers": triggers,
+            "status": "remembrance-checkpoint-complete",
+        }
+        self.last_checkpoint = checkpoint
+        return checkpoint
+
+
+__all__ = ["LAW_TITLE", "RemembranceGuard"]

--- a/tests/remembrance_guard_test.py
+++ b/tests/remembrance_guard_test.py
@@ -1,0 +1,125 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "engine" / "remembrance_guard.py"
+spec = importlib.util.spec_from_file_location("vaultfire.remembrance_guard", MODULE_PATH)
+remembrance_guard = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = remembrance_guard
+spec.loader.exec_module(remembrance_guard)
+LAW_TITLE = remembrance_guard.LAW_TITLE
+RemembranceGuard = remembrance_guard.RemembranceGuard
+
+
+@pytest.fixture
+def remembrance_seed():
+    belief_logs = [
+        {
+            "id": "belief-1",
+            "contributor": "forgotten.eth",
+            "insight": "Flame Weaving",
+            "credited": False,
+            "tags": ["fire", "loyalty"],
+            "early_support": True,
+            "sacrifice": 2,
+        },
+        {
+            "id": "belief-2",
+            "contributor": "ally.eth",
+            "insight": "Support Spark",
+            "credited": True,
+        },
+    ]
+    memory_chains = [
+        {
+            "chain_id": "ghost-trail",
+            "entries": [
+                {
+                    "id": "mem-1",
+                    "contributor": "forgotten.eth",
+                    "insight": "flame weaving",
+                    "ghost_tagged": True,
+                    "credited": False,
+                    "key_breakthrough": True,
+                    "tags": ["breakthrough", "fire"],
+                    "consensus_required": 0.85,
+                },
+                {
+                    "id": "mem-2",
+                    "contributor": "ally.eth",
+                    "insight": "support spark",
+                    "ghost_tagged": False,
+                    "credited": True,
+                    "tags": ["support"],
+                },
+            ],
+        }
+    ]
+    return belief_logs, memory_chains
+
+
+def _run_detection(guard: RemembranceGuard):
+    expansion_batch = [
+        {
+            "id": "exp-1",
+            "pattern": "Flame Weaving",
+            "tags": ["fire"],
+        }
+    ]
+    return guard.detect_forgotten_contributions(expansion_batch)
+
+
+def test_detects_forgotten_contributors(remembrance_seed):
+    guard = RemembranceGuard(*remembrance_seed)
+    triggers = _run_detection(guard)
+
+    assert triggers, "expected remembrance trigger for overlooked contributor"
+    trigger = triggers[0]
+    assert trigger["label"] == LAW_TITLE
+    assert trigger["pattern"] == "flame weaving"
+    contributors = {item["contributor"]: item for item in trigger["contributors"]}
+    assert "forgotten.eth" in contributors
+    forgotten_entry = contributors["forgotten.eth"]
+    assert set(forgotten_entry["sources"]) == {"belief", "memory"}
+    assert forgotten_entry["ghost_tagged"] is True
+    assert "fire" in forgotten_entry["goal_alignment"]
+
+
+def test_routes_retroactive_yield(remembrance_seed):
+    guard = RemembranceGuard(*remembrance_seed)
+    triggers = _run_detection(guard)
+    signals = guard.route_loyalty_signals(triggers)
+
+    registry_entry = guard.loyalty_registry.get("forgotten.eth")
+    signal = next(item for item in signals if item["contributor"] == "forgotten.eth")
+    assert signal["activation"] == "delayed"
+    assert signal["multiplier"] > 1.0
+    assert registry_entry["pending"] is True
+    assert guard.pending_yield_signals, "signals should be staged for delayed activation"
+
+
+def test_prevents_memory_erasure_without_consensus(remembrance_seed):
+    guard = RemembranceGuard(*remembrance_seed, consensus_threshold=0.8)
+    result = guard.enforce_memory_preservation(
+        [{"memory_id": "mem-1", "action": "delete", "consensus_weight": 0.5}]
+    )
+
+    assert result["locked"], "key breakthrough should be locked without sufficient consensus"
+    lock = result["locked"][0]
+    assert lock["memory_id"] == "mem-1"
+    assert lock["reason"] == "consensus_not_met"
+    assert any(entry["id"] == "mem-1" for entry in result["mirrored"])
+
+
+def test_restores_mirrored_history(remembrance_seed):
+    guard = RemembranceGuard(*remembrance_seed)
+    guard.enforce_memory_preservation(
+        [{"memory_id": "mem-2", "action": "delete", "consensus_weight": 0.95}]
+    )
+
+    restored = guard.restore_memories(["mem-2"])
+    assert restored, "restoration should surface mirrored entry"
+    assert restored[0]["id"] == "mem-2"
+    assert restored[0]["insight"].lower() == "support spark"


### PR DESCRIPTION
## Summary
- add the remembrance_guard module to encode Vaultfire's Fourth Law with remembrance triggers, loyalty routing, preservation locks, and checkpoint manifest helpers
- cover the module with pytest scenarios for forgotten contributors, retroactive yield signals, memory lock enforcement, and mirrored restoration

## Testing
- pytest tests/remembrance_guard_test.py

------
https://chatgpt.com/codex/tasks/task_e_68c9bfe2179083228e1e47ea4ebcc5b0