### PR TITLE
Add origin integrity directive and tests

### DIFF
--- a/engine/guardian_of_origin.py
+++ b/engine/guardian_of_origin.py
@@ -1,0 +1,665 @@
+"""Vaultfire Law 7 – Origin Integrity Directive.
+
+This module protects Vaultfire lineage by enforcing origin authenticity for
+mission manifests, belief files, and protocol forks.  It records immutable
+origin hashes, validates contributor claims against codex trust markers, and
+applies tamper-evident signatures to critical files.  The guard collaborates
+with :mod:`engine.alignment_guard` to ensure morally divergent forks are
+blocked even when origin credentials appear valid.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+
+from .alignment_guard import evaluate_alignment
+from .identity_resolver import resolve_identity
+from utils.json_io import load_json, write_json
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = BASE_DIR / "vaultfire-core" / "ethics" / "origin_registry.json"
+LOG_PATH = BASE_DIR / "logs" / "origin_guard_log.json"
+CODEX_MANIFEST_PATH = BASE_DIR / "codex_manifest.json"
+CONTRIBUTOR_REGISTRY_PATH = BASE_DIR / "contributor_registry.json"
+
+MIN_TRUST_SCORE = 0.75
+ARCHITECT_TIERS = {
+    "architect",
+    "architect-tier",
+    "architect_level",
+    "architects",
+    "guardian",
+}
+SIGNABLE_SUFFIXES = (".manifest", ".belief.json")
+
+REASON_ORIGIN_MISSING = "origin_identity_missing"
+REASON_ORIGIN_NOT_VERIFIED = "origin_not_verified"
+REASON_ORIGIN_NOT_REGISTERED = "origin_not_registered"
+REASON_ORIGIN_CONFLICT = "origin_identity_conflict"
+REASON_HASH_MISMATCH = "origin_hash_mismatch"
+REASON_ALIGNMENT_BLOCK = "alignment_guard_blocked"
+
+
+def _now() -> str:
+    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _normalize(value: str) -> str:
+    return value.strip().lower()
+
+
+def _manifest_key(manifest_path: Optional[Path], payload: Mapping[str, Any]) -> str:
+    keys = (
+        "manifest_key",
+        "manifest_id",
+        "manifestId",
+        "mission_id",
+        "missionId",
+        "protocol_id",
+        "protocolId",
+        "id",
+    )
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    if manifest_path is not None:
+        try:
+            return manifest_path.resolve().relative_to(BASE_DIR).as_posix()
+        except ValueError:
+            return manifest_path.resolve().as_posix()
+    return "unscoped-origin"
+
+
+def _read_bytes_for_hash(manifest_path: Optional[Path], payload: Mapping[str, Any]) -> bytes:
+    if manifest_path is not None and manifest_path.exists():
+        return manifest_path.read_bytes()
+    try:
+        return json.dumps(payload, sort_keys=True).encode("utf-8")
+    except TypeError:
+        return str(payload).encode("utf-8")
+
+
+def _compute_origin_hash(manifest_path: Optional[Path], payload: Mapping[str, Any]) -> str:
+    data = _read_bytes_for_hash(manifest_path, payload)
+    return hashlib.sha256(data).hexdigest()
+
+
+def _should_sign_file(manifest_path: Optional[Path]) -> bool:
+    if manifest_path is None:
+        return False
+    name = manifest_path.name.lower()
+    return any(name.endswith(suffix) for suffix in SIGNABLE_SUFFIXES)
+
+
+def _signature_path(manifest_path: Path) -> Path:
+    return manifest_path.parent / f"{manifest_path.name}.sig"
+
+
+def _load_registry() -> Dict[str, Any]:
+    data = load_json(REGISTRY_PATH, {})
+    if not isinstance(data, dict):
+        data = {}
+    data.setdefault("entries", {})
+    data.setdefault("contributors", {})
+    return data
+
+
+def _write_registry(data: Mapping[str, Any]) -> None:
+    write_json(REGISTRY_PATH, data)
+
+
+def _append_log(entry: Mapping[str, Any]) -> None:
+    log = load_json(LOG_PATH, [])
+    if not isinstance(log, list):
+        log = []
+    log.append(dict(entry))
+    if len(log) > 200:
+        log = log[-200:]
+    write_json(LOG_PATH, log)
+
+
+def _load_contributor_index() -> Dict[str, Dict[str, Any]]:
+    raw = load_json(CONTRIBUTOR_REGISTRY_PATH, {})
+    index: Dict[str, Dict[str, Any]] = {}
+    if not isinstance(raw, Mapping):
+        return index
+    for wallet, record in raw.items():
+        if not isinstance(record, Mapping):
+            continue
+        candidates = {str(wallet)}
+        for key in ("ens", "identity", "handle", "wallet"):
+            value = record.get(key)
+            if isinstance(value, str) and value.strip():
+                candidates.add(value)
+        for candidate in candidates:
+            index[_normalize(candidate)] = {
+                "wallet": wallet,
+                "record": dict(record),
+            }
+    return index
+
+
+def _add_codex_entry(
+    index: MutableMapping[str, Dict[str, Any]],
+    source_id: str,
+    record: Mapping[str, Any],
+    trust_score: Any,
+) -> None:
+    identifiers: list[str] = []
+    for key in ("ens", "wallet", "identity", "id", "fingerprint", "name"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            identifiers.append(value)
+    for identifier in identifiers:
+        index[_normalize(identifier)] = {
+            "source": source_id,
+            "data": dict(record),
+            "trust_score": trust_score,
+        }
+
+
+def _load_codex_index() -> Dict[str, Dict[str, Any]]:
+    raw = load_json(CODEX_MANIFEST_PATH, {})
+    index: Dict[str, Dict[str, Any]] = {}
+    if not isinstance(raw, Mapping):
+        return index
+
+    def _score_from(value: Any) -> Optional[float]:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    for law in raw.get("universal_laws", []) or []:
+        if not isinstance(law, Mapping):
+            continue
+        originator = law.get("originator")
+        if isinstance(originator, Mapping):
+            _add_codex_entry(
+                index,
+                str(law.get("id") or law.get("title") or "codex-law"),
+                originator,
+                _score_from(law.get("trust_score")),
+            )
+    for contributor in raw.get("contributors", []) or []:
+        if not isinstance(contributor, Mapping):
+            continue
+        _add_codex_entry(
+            index,
+            str(contributor.get("id") or contributor.get("ens") or contributor.get("wallet") or "codex-contributor"),
+            contributor,
+            _score_from(
+                contributor.get("trust_score")
+                or contributor.get("trustScore")
+                or contributor.get("score")
+            ),
+        )
+    codex_trust = raw.get("trust")
+    if isinstance(codex_trust, Mapping):
+        for key, record in codex_trust.items():
+            if isinstance(record, Mapping):
+                _add_codex_entry(
+                    index,
+                    str(key),
+                    record,
+                    _score_from(record.get("trust_score") or record.get("score")),
+                )
+    return index
+
+
+def _normalize_score(value: Any) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if score < 0:
+        return 0.0
+    if score > 1.0:
+        if score <= 100.0:
+            score = score / 100.0
+        else:
+            score = 1.0
+    return round(min(score, 1.0), 3)
+
+
+def _extract_trust_score(*sources: Mapping[str, Any]) -> Optional[float]:
+    keys = (
+        "codex_trust",
+        "codexTrust",
+        "trust_score",
+        "trustScore",
+        "belief_trust",
+        "beliefTrust",
+    )
+    for source in sources:
+        for key in keys:
+            value = source.get(key)
+            if value is None:
+                continue
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def _extract_trust_tier(*sources: Mapping[str, Any]) -> Optional[str]:
+    keys = ("trust_tier", "trustTier", "role", "tier", "authority_level")
+    for source in sources:
+        for key in keys:
+            value = source.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip().lower()
+    return None
+
+
+def _resolve_origin_identity(payload: Mapping[str, Any], identity: Mapping[str, Any]) -> Optional[str]:
+    keys = (
+        "origin_id",
+        "originId",
+        "origin",
+        "ens",
+        "wallet",
+        "address",
+        "fingerprint",
+        "codex_fingerprint",
+        "owner",
+        "author",
+    )
+    for source in (identity, payload):
+        for key in keys:
+            value = source.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def _resolve_trust_marker(
+    origin_id: Optional[str],
+    payload: Mapping[str, Any],
+    identity: Mapping[str, Any],
+) -> Dict[str, Any]:
+    trust: Dict[str, Any] = {
+        "origin_id": origin_id,
+        "marker": "unverified",
+        "verified": False,
+        "sources": [],
+        "score": 0.0,
+        "tier": _extract_trust_tier(identity, payload),
+    }
+    if not origin_id:
+        return trust
+
+    origin_key = _normalize(origin_id)
+    sources: list[str] = []
+    resolved_addresses: list[str] = []
+
+    ens_candidate = None
+    for source in (identity, payload):
+        candidate = source.get("ens")
+        if isinstance(candidate, str) and candidate.strip():
+            ens_candidate = candidate.strip()
+            break
+    if ens_candidate is None and origin_id.lower().endswith(".eth"):
+        ens_candidate = origin_id
+    if ens_candidate:
+        resolved = resolve_identity(ens_candidate)
+        if resolved:
+            sources.append("ens")
+            resolved_addresses.append(resolved)
+
+    for source in (identity, payload):
+        candidate = source.get("wallet") or source.get("address")
+        if isinstance(candidate, str) and candidate.strip():
+            resolved_addresses.append(candidate.strip())
+
+    contributor_index = _load_contributor_index()
+    registry_record: Optional[Mapping[str, Any]] = None
+    if origin_key in contributor_index:
+        sources.append("registry")
+        registry_record = contributor_index[origin_key]["record"]
+        trust["registry_record"] = dict(registry_record)
+        trust["marker"] = f"registry:{contributor_index[origin_key]['wallet']}"
+    else:
+        for candidate in resolved_addresses:
+            normalized = _normalize(candidate)
+            if normalized in contributor_index:
+                sources.append("registry")
+                registry_record = contributor_index[normalized]["record"]
+                trust["registry_record"] = dict(registry_record)
+                trust["marker"] = f"registry:{contributor_index[normalized]['wallet']}"
+                break
+
+    codex_index = _load_codex_index()
+    codex_record: Optional[Mapping[str, Any]] = None
+    if origin_key in codex_index:
+        sources.append("codex")
+        codex_entry = codex_index[origin_key]
+        codex_record = codex_entry.get("data") or {}
+        trust["codex_record"] = dict(codex_record)
+        trust_score = codex_entry.get("trust_score")
+        if trust_score is not None:
+            trust["score"] = max(trust["score"], _normalize_score(trust_score))
+        trust["marker"] = f"codex:{codex_entry.get('source')}"
+    else:
+        for candidate in resolved_addresses:
+            normalized = _normalize(candidate)
+            if normalized in codex_index:
+                sources.append("codex")
+                codex_entry = codex_index[normalized]
+                codex_record = codex_entry.get("data") or {}
+                trust["codex_record"] = dict(codex_record)
+                trust_score = codex_entry.get("trust_score")
+                if trust_score is not None:
+                    trust["score"] = max(trust["score"], _normalize_score(trust_score))
+                trust["marker"] = f"codex:{codex_entry.get('source')}"
+                break
+
+    identity_score = _extract_trust_score(identity, payload)
+    if identity_score is not None:
+        trust["score"] = max(trust["score"], _normalize_score(identity_score))
+
+    if resolved_addresses:
+        trust["address"] = resolved_addresses[0]
+
+    trust["sources"] = sorted(set(sources))
+    verified = bool(trust["sources"])
+    if "codex" in trust["sources"] and trust["score"] < MIN_TRUST_SCORE:
+        verified = False
+    trust["verified"] = verified
+    if trust["marker"] == "unverified" and trust["sources"]:
+        priority = {
+            "codex": 3,
+            "registry": 2,
+            "ens": 1,
+        }
+        best_marker = None
+        best_rank = 0
+        if registry_record:
+            best_marker = f"registry:{registry_record.get('ens') or registry_record.get('identity') or origin_id}"
+            best_rank = priority["registry"]
+        if codex_record:
+            codex_marker = codex_record.get("ens") or codex_record.get("wallet") or codex_record.get("name")
+            best_marker = f"codex:{codex_marker or origin_id}"
+            best_rank = priority["codex"]
+        if "ens" in trust["sources"] and best_rank < priority["ens"]:
+            best_marker = f"ens:{ens_candidate.lower() if ens_candidate else origin_id.lower()}"
+        if best_marker:
+            trust["marker"] = best_marker
+    return trust
+
+
+def _can_override(identity: Mapping[str, Any], payload: Mapping[str, Any], trust: Mapping[str, Any]) -> bool:
+    tier = trust.get("tier") or _extract_trust_tier(identity, payload)
+    if not isinstance(tier, str) or tier.lower() not in ARCHITECT_TIERS:
+        return False
+    proof_keys = (
+        "proof_of_authorship",
+        "auth_signature",
+        "origin_signature",
+        "origin_proof",
+        "architect_signature",
+    )
+    proof = None
+    for source in (identity, payload):
+        for key in proof_keys:
+            value = source.get(key)
+            if isinstance(value, str) and value.strip():
+                proof = value.strip()
+                break
+        if proof:
+            break
+    if not proof or len(proof) < 12:
+        return False
+    return bool(trust.get("verified"))
+
+
+def _build_origin_stamp(base: Mapping[str, Any]) -> Dict[str, Any]:
+    payload = dict(base)
+    stamp_source = json.dumps(payload, sort_keys=True).encode("utf-8")
+    payload["signature"] = hashlib.sha256(stamp_source).hexdigest()
+    return payload
+
+
+def _persist_signature(manifest_path: Path, stamp: Mapping[str, Any]) -> None:
+    if not _should_sign_file(manifest_path):
+        return
+    sig_path = _signature_path(manifest_path)
+    write_json(sig_path, stamp)
+
+
+@dataclass
+class OriginGuardResult:
+    allowed: bool
+    decision: str
+    reasons: list[str]
+    origin_stamp: Optional[Dict[str, Any]]
+    alignment: Dict[str, Any]
+    trust: Dict[str, Any]
+    override: bool
+    manifest_key: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "decision": self.decision,
+            "reasons": list(self.reasons),
+            "origin_stamp": self.origin_stamp,
+            "alignment": self.alignment,
+            "trust": self.trust,
+            "override": self.override,
+            "manifest_key": self.manifest_key,
+        }
+
+
+def enforce_origin(
+    operation: str,
+    *,
+    manifest_path: Optional[Path | str] = None,
+    payload: Optional[Mapping[str, Any]] = None,
+    identity: Optional[Mapping[str, Any]] = None,
+    allow_registration: bool = False,
+    allow_override: bool = False,
+) -> OriginGuardResult:
+    payload_map: Dict[str, Any] = dict(payload or {})
+    identity_map: Dict[str, Any] = dict(identity or {})
+    manifest_obj = Path(manifest_path) if isinstance(manifest_path, (str, Path)) else None
+
+    origin_id = _resolve_origin_identity(payload_map, identity_map)
+    reasons: list[str] = []
+    if not origin_id:
+        reasons.append(REASON_ORIGIN_MISSING)
+
+    trust = _resolve_trust_marker(origin_id, payload_map, identity_map)
+    if origin_id and not trust.get("verified", False):
+        reasons.append(REASON_ORIGIN_NOT_VERIFIED)
+
+    manifest_key = _manifest_key(manifest_obj, payload_map)
+    file_hash = _compute_origin_hash(manifest_obj, payload_map)
+    registry = _load_registry()
+    entries: Dict[str, Any] = registry["entries"]
+    contributors: Dict[str, Any] = registry["contributors"]
+    entry = entries.get(manifest_key)
+
+    origin_key = _normalize(origin_id) if origin_id else None
+    override_requested = bool(allow_override or identity_map.get("override") or payload_map.get("override"))
+    override_granted = False
+
+    if entry is None:
+        if allow_registration and not reasons:
+            entry = {
+                "origin_id": origin_id,
+                "origin_key": origin_key,
+                "origin_hash": file_hash,
+                "history": [],
+            }
+        else:
+            reasons.append(REASON_ORIGIN_NOT_REGISTERED)
+    else:
+        expected_key = entry.get("origin_key")
+        if expected_key and origin_key and expected_key != origin_key:
+            if override_requested:
+                override_granted = _can_override(identity_map, payload_map, trust)
+                if override_granted:
+                    entry["previous_origin_id"] = entry.get("origin_id")
+                    entry["origin_id"] = origin_id
+                    entry["origin_key"] = origin_key
+                else:
+                    reasons.append(REASON_ORIGIN_CONFLICT)
+            else:
+                reasons.append(REASON_ORIGIN_CONFLICT)
+        elif expected_key and not origin_key:
+            reasons.append(REASON_ORIGIN_MISSING)
+
+        stored_hash = entry.get("origin_hash")
+        if stored_hash and stored_hash != file_hash:
+            reasons.append(REASON_HASH_MISMATCH)
+
+    alignment_result = evaluate_alignment(operation, payload_map, identity=identity_map)
+    if not alignment_result.get("allowed", False):
+        reasons.append(REASON_ALIGNMENT_BLOCK)
+
+    allowed = not reasons
+    origin_stamp: Optional[Dict[str, Any]] = None
+    decision = "override" if override_granted else "allow"
+
+    if allowed and entry is not None:
+        timestamp = _now()
+        base_stamp = {
+            "operation": operation,
+            "manifest_key": manifest_key,
+            "origin_id": origin_id,
+            "origin_key": origin_key,
+            "origin_hash": file_hash,
+            "trust_marker": trust.get("marker"),
+            "trust_sources": trust.get("sources", []),
+            "trust_score": trust.get("score"),
+            "trust_tier": trust.get("tier"),
+            "override": override_granted,
+            "timestamp": timestamp,
+            "alignment_decision": alignment_result.get("decision"),
+        }
+        if trust.get("address"):
+            base_stamp["resolved_address"] = trust["address"]
+        origin_stamp = _build_origin_stamp(base_stamp)
+
+        entry["origin_id"] = origin_id
+        entry["origin_key"] = origin_key
+        entry["origin_hash"] = file_hash
+        history: list[Dict[str, Any]] = list(entry.get("history", []))
+        history.append(origin_stamp)
+        entry["history"] = history[-20:]
+        entry["last_verified_at"] = timestamp
+        entry["trust_marker"] = trust.get("marker")
+        entries[manifest_key] = entry
+
+        if origin_key:
+            contributor_entry = contributors.setdefault(origin_key, {"origin_id": origin_id})
+            contributor_entry.update(
+                origin_id=origin_id,
+                trust_marker=trust.get("marker"),
+                trust_sources=trust.get("sources", []),
+                trust_score=trust.get("score"),
+                trust_tier=trust.get("tier"),
+                last_claim=timestamp,
+            )
+            contributors[origin_key] = contributor_entry
+        registry["entries"] = entries
+        registry["contributors"] = contributors
+        _write_registry(registry)
+
+        _append_log({**origin_stamp, "allowed": True})
+        if manifest_obj is not None:
+            _persist_signature(manifest_obj, origin_stamp)
+    else:
+        allowed = False
+        decision = "block"
+        _append_log(
+            {
+                "operation": operation,
+                "timestamp": _now(),
+                "allowed": False,
+                "reasons": list(reasons),
+                "origin_id": origin_id,
+                "manifest_key": manifest_key,
+            }
+        )
+
+    return OriginGuardResult(
+        allowed=allowed,
+        decision=decision,
+        reasons=reasons,
+        origin_stamp=origin_stamp,
+        alignment=alignment_result,
+        trust=trust,
+        override=override_granted,
+        manifest_key=manifest_key,
+    )
+
+
+def register_origin(
+    operation: str,
+    *,
+    manifest_path: Optional[Path | str] = None,
+    payload: Optional[Mapping[str, Any]] = None,
+    identity: Optional[Mapping[str, Any]] = None,
+) -> OriginGuardResult:
+    return enforce_origin(
+        operation,
+        manifest_path=manifest_path,
+        payload=payload,
+        identity=identity,
+        allow_registration=True,
+    )
+
+
+def validate_contributor_claim(
+    origin_id: str,
+    *,
+    identity: Optional[Mapping[str, Any]] = None,
+    payload: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    identity_map: Dict[str, Any] = dict(identity or {})
+    payload_map: Dict[str, Any] = dict(payload or {})
+    candidate = origin_id or _resolve_origin_identity(payload_map, identity_map)
+    if not candidate:
+        return {
+            "origin_id": None,
+            "verified": False,
+            "reason": REASON_ORIGIN_MISSING,
+        }
+
+    trust = _resolve_trust_marker(candidate, payload_map, identity_map)
+    registry = _load_registry()
+    contributor_entry = registry["contributors"].get(_normalize(candidate), {})
+    verified = bool(trust.get("verified"))
+    if not verified and trust.get("score", 0.0) >= MIN_TRUST_SCORE:
+        verified = True
+    if contributor_entry:
+        verified = True
+
+    return {
+        "origin_id": candidate,
+        "verified": verified,
+        "trust_marker": trust.get("marker"),
+        "trust_score": trust.get("score"),
+        "trust_sources": trust.get("sources", []),
+        "trust_tier": trust.get("tier"),
+        "registry_entry": contributor_entry or None,
+    }
+
+
+__all__ = [
+    "register_origin",
+    "enforce_origin",
+    "validate_contributor_claim",
+    "OriginGuardResult",
+    "REGISTRY_PATH",
+    "LOG_PATH",
+]
+

--- a/tests/origin_guard_test.py
+++ b/tests/origin_guard_test.py
@@ -1,0 +1,244 @@
+import importlib
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if "engine" not in sys.modules:
+    engine_pkg = types.ModuleType("engine")
+    engine_pkg.__path__ = [str(ROOT / "engine")]
+    sys.modules["engine"] = engine_pkg
+
+
+def _load_alignment_guard(tmp_path, monkeypatch):
+    module_path = ROOT / "engine" / "alignment_guard.py"
+    spec = importlib.util.spec_from_file_location("engine.alignment_guard", module_path)
+    guard_module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = guard_module
+    assert spec.loader is not None
+    spec.loader.exec_module(guard_module)
+    monkeypatch.setattr(guard_module, "BELIEF_TRACE_LOG_PATH", tmp_path / "belief_trace_log.json")
+    return guard_module
+
+
+@pytest.fixture()
+def origin_guard(tmp_path, monkeypatch):
+    _load_alignment_guard(tmp_path, monkeypatch)
+
+    module_path = ROOT / "engine" / "guardian_of_origin.py"
+    spec = importlib.util.spec_from_file_location("engine.guardian_of_origin", module_path)
+    guard_module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = guard_module
+    assert spec.loader is not None
+    spec.loader.exec_module(guard_module)
+
+    guard_module.REGISTRY_PATH = tmp_path / "origin_registry.json"
+    guard_module.LOG_PATH = tmp_path / "origin_guard_log.json"
+    guard_module.CODEX_MANIFEST_PATH = tmp_path / "codex_manifest.json"
+    guard_module.CONTRIBUTOR_REGISTRY_PATH = tmp_path / "contributor_registry.json"
+
+    codex_manifest = {
+        "universal_laws": [
+            {
+                "id": "law-1",
+                "originator": {"ens": "ghostkey316.eth", "wallet": "bpow20.cb.id"},
+                "trust_score": 0.97,
+            },
+            {
+                "id": "law-2",
+                "originator": {"ens": "ally.eth", "wallet": "0xally"},
+                "trust_score": 0.82,
+            },
+            {
+                "id": "law-rogue",
+                "originator": {"ens": "rogue.eth", "wallet": "0xrogue"},
+                "trust_score": 0.12,
+            },
+        ],
+        "contributors": [
+            {"id": "ally", "ens": "ally.eth", "wallet": "0xally", "trust_score": 0.82},
+        ],
+    }
+    with open(guard_module.CODEX_MANIFEST_PATH, "w", encoding="utf-8") as handle:
+        json.dump(codex_manifest, handle)
+
+    contributor_registry = {
+        "bpow20.cb.id": {
+            "identity": "Ghostkey-316",
+            "ens": "ghostkey316.eth",
+            "role": "architect",
+            "tags": ["vaultfire"],
+        },
+        "0xally": {
+            "identity": "Ally",
+            "ens": "ally.eth",
+            "role": "guardian",
+            "tags": ["ally"],
+        },
+    }
+    with open(guard_module.CONTRIBUTOR_REGISTRY_PATH, "w", encoding="utf-8") as handle:
+        json.dump(contributor_registry, handle)
+
+    return guard_module
+
+
+def test_guardian_records_authentic_origin_and_signature(origin_guard, tmp_path):
+    manifest_path = tmp_path / "core_protocol.manifest"
+    manifest_path.write_text("vaultfire-core")
+
+    payload = {
+        "manifest_id": "core-protocol",
+        "declared_purpose": "Preserve Vaultfire origin integrity",
+        "belief_density": 0.84,
+        "empathy_score": 0.81,
+        "mission_tags": ["vaultfire", "ghostkey"],
+    }
+    identity = {
+        "ens": "ghostkey316.eth",
+        "wallet": "bpow20.cb.id",
+        "trustTier": "architect",
+        "codex_trust": 0.97,
+    }
+
+    result = origin_guard.register_origin(
+        "activate.protocol",
+        manifest_path=manifest_path,
+        payload=payload,
+        identity=identity,
+    )
+
+    assert result.allowed is True
+    assert result.origin_stamp is not None
+    assert result.origin_stamp["origin_id"] == "ghostkey316.eth"
+    assert "signature" in result.origin_stamp
+
+    sig_path = manifest_path.with_name(manifest_path.name + ".sig")
+    assert sig_path.exists(), "tamper signature should be persisted"
+    sig_data = json.loads(sig_path.read_text())
+    assert sig_data["origin_hash"] == result.origin_stamp["origin_hash"]
+
+    registry_data = json.loads(origin_guard.REGISTRY_PATH.read_text())
+    entry = registry_data["entries"][result.manifest_key]
+    assert entry["origin_hash"] == result.origin_stamp["origin_hash"]
+    assert len(entry["history"]) == 1
+
+    log_data = json.loads(origin_guard.LOG_PATH.read_text())
+    assert log_data[-1]["allowed"] is True
+    assert log_data[-1]["signature"] == result.origin_stamp["signature"]
+
+
+def test_origin_guard_blocks_hijack_attempts(origin_guard, tmp_path):
+    manifest_path = tmp_path / "core_protocol.manifest"
+    manifest_path.write_text("vaultfire-core")
+
+    payload = {
+        "manifest_id": "core-protocol",
+        "declared_purpose": "Preserve Vaultfire origin integrity",
+        "belief_density": 0.84,
+        "empathy_score": 0.81,
+        "mission_tags": ["vaultfire", "ghostkey"],
+    }
+    identity = {
+        "ens": "ghostkey316.eth",
+        "wallet": "bpow20.cb.id",
+        "trustTier": "architect",
+        "codex_trust": 0.97,
+    }
+
+    registration = origin_guard.register_origin(
+        "activate.protocol",
+        manifest_path=manifest_path,
+        payload=payload,
+        identity=identity,
+    )
+    assert registration.allowed is True
+
+    manifest_path.write_text("vaultfire-core tampered")
+    tampered = origin_guard.enforce_origin(
+        "fork.protocol",
+        manifest_path=manifest_path,
+        payload=payload,
+        identity=identity,
+    )
+
+    assert tampered.allowed is False
+    assert origin_guard.REASON_HASH_MISMATCH in tampered.reasons
+    assert origin_guard.REASON_ALIGNMENT_BLOCK not in tampered.reasons
+
+    manifest_path.write_text("vaultfire-core")
+    rogue_payload = {
+        "manifest_id": "core-protocol",
+        "declared_purpose": "Hijack Vaultfire origins",
+        "belief_density": 0.91,
+        "empathy_score": 0.9,
+        "mission_tags": ["rogue"],
+    }
+    rogue_identity = {
+        "ens": "rogue.eth",
+        "wallet": "0xrogue",
+        "codex_trust": 0.1,
+    }
+    hijack = origin_guard.enforce_origin(
+        "fork.hijack",
+        manifest_path=manifest_path,
+        payload=rogue_payload,
+        identity=rogue_identity,
+    )
+
+    assert hijack.allowed is False
+    assert origin_guard.REASON_ORIGIN_NOT_VERIFIED in hijack.reasons
+    assert origin_guard.REASON_ORIGIN_CONFLICT in hijack.reasons
+    assert origin_guard.REASON_ALIGNMENT_BLOCK in hijack.reasons
+
+    registry_data = json.loads(origin_guard.REGISTRY_PATH.read_text())
+    entry = registry_data["entries"][registration.manifest_key]
+    assert len(entry["history"]) == 1, "hijack attempts must not mutate history"
+
+
+def test_validate_contributor_claims_uses_codex_trust(origin_guard, tmp_path):
+    belief_path = tmp_path / "belief_checkpoint.belief.json"
+    belief_payload = {"belief": "Origin Integrity"}
+    belief_path.write_text(json.dumps(belief_payload))
+
+    payload = {
+        "manifest_id": "belief-guard",
+        "declared_purpose": "Guard Vaultfire belief origins",
+        "belief_density": 0.88,
+        "empathy_score": 0.86,
+        "mission_tags": ["vaultfire"],
+    }
+    identity = {
+        "ens": "ally.eth",
+        "wallet": "0xally",
+        "trustTier": "guardian",
+        "codex_trust": 0.82,
+    }
+
+    result = origin_guard.register_origin(
+        "belief.activate",
+        manifest_path=belief_path,
+        payload=payload,
+        identity=identity,
+    )
+
+    assert result.allowed is True
+
+    sig_path = belief_path.with_name(belief_path.name + ".sig")
+    assert sig_path.exists()
+    sig_data = json.loads(sig_path.read_text())
+    assert sig_data["origin_id"] == "ally.eth"
+
+    validation = origin_guard.validate_contributor_claim("ally.eth")
+    assert validation["verified"] is True
+    assert "codex" in (validation["trust_marker"] or "")
+
+    rogue_validation = origin_guard.validate_contributor_claim(
+        "rogue.eth", payload={"codex_trust": 0.1}
+    )
+    assert rogue_validation["verified"] is False
+    assert rogue_validation["trust_score"] < origin_guard.MIN_TRUST_SCORE
+


### PR DESCRIPTION
## Summary
- implement the Law 7 origin integrity guard to record immutable origin hashes, apply tamper-evident signatures, and integrate alignment safeguards
- add contributor validation helpers leveraging codex trust markers and architect-tier overrides
- cover authentic registration, hijack rejection, and trust validation with dedicated unit tests

## Testing
- pytest tests/origin_guard_test.py

------
https://chatgpt.com/codex/tasks/task_e_68c9d6af30e883228aad13574327d857