### PR TITLE
Implement Resistance Override Guard enforcing Vaultfire Law 9

### DIFF
--- a/engine/guardian_of_origin.py
+++ b/engine/guardian_of_origin.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
 
 from .alignment_guard import evaluate_alignment
 from .identity_resolver import resolve_identity
+from .resistance_override_guard import ResistanceOverrideDecision, ResistanceOverrideGuard
 from utils.json_io import load_json, write_json
 
 BASE_DIR = Path(__file__).resolve().parents[1]
@@ -42,6 +43,17 @@ REASON_ORIGIN_NOT_REGISTERED = "origin_not_registered"
 REASON_ORIGIN_CONFLICT = "origin_identity_conflict"
 REASON_HASH_MISMATCH = "origin_hash_mismatch"
 REASON_ALIGNMENT_BLOCK = "alignment_guard_blocked"
+
+
+def _build_resistance_override_guard() -> ResistanceOverrideGuard:
+    log_dir = LOG_PATH.parent if LOG_PATH else BASE_DIR / "logs"
+    return ResistanceOverrideGuard(
+        audit_log_path=log_dir / "resistance_override_log.jsonl",
+        event_log_path=log_dir / "resistance_override_events.jsonl",
+        contributor_registry_path=CONTRIBUTOR_REGISTRY_PATH,
+        partners_path=BASE_DIR / "partners.json",
+        scorecard_path=BASE_DIR / "user_scorecard.json",
+    )
 
 
 def _now() -> str:
@@ -488,6 +500,48 @@ def enforce_origin(
 
     origin_key = _normalize(origin_id) if origin_id else None
     override_requested = bool(allow_override or identity_map.get("override") or payload_map.get("override"))
+    resistance_decision: ResistanceOverrideDecision | None = None
+    if allow_registration or override_requested:
+        guard_payload: Dict[str, Any] = dict(payload_map)
+        guard_payload["override"] = True
+        guard_payload.setdefault("mission_type", "registration" if allow_registration else "origin")
+        guard_payload.setdefault(
+            "codex_signature",
+            guard_payload.get("codex_signature")
+            or guard_payload.get("override_signature")
+            or guard_payload.get("belief_signature")
+            or guard_payload.get("beliefSignature"),
+        )
+        if allow_registration:
+            policy_value = (
+                guard_payload.get("mission_policy")
+                or guard_payload.get("policy")
+                or "architect-only"
+            )
+            guard_payload["mission_policy"] = str(policy_value)
+        guard_context = {
+            "pathway": "contributor_registration" if allow_registration else "origin_override",
+            "allow_registration": allow_registration,
+        }
+        caller_reference = (
+            identity_map.get("override_caller")
+            or payload_map.get("override_caller")
+            or identity_map.get("ens")
+            or identity_map.get("wallet")
+            or identity_map.get("user_id")
+            or origin_id
+            or manifest_key
+        )
+        caller_reference = str(caller_reference or "unknown")
+        resistance_decision = _build_resistance_override_guard().validate(
+            operation,
+            caller_reference,
+            override_payload=guard_payload,
+            context=guard_context,
+        )
+        if not resistance_decision.allowed:
+            reasons.append(resistance_decision.reason)
+
     override_granted = False
 
     if entry is None:
@@ -573,6 +627,16 @@ def enforce_origin(
         registry["contributors"] = contributors
         _write_registry(registry)
 
+        if resistance_decision and resistance_decision.audit_entry:
+            origin_stamp = {
+                **origin_stamp,
+                "resistance_override": {
+                    "hash": resistance_decision.audit_entry.get("hash"),
+                    "status": resistance_decision.audit_entry.get("status"),
+                    "reason": resistance_decision.reason,
+                },
+            }
+
         _append_log({**origin_stamp, "allowed": True})
         if manifest_obj is not None:
             _persist_signature(manifest_obj, origin_stamp)
@@ -587,6 +651,9 @@ def enforce_origin(
                 "reasons": list(reasons),
                 "origin_id": origin_id,
                 "manifest_key": manifest_key,
+                "resistance_override": (
+                    resistance_decision.record if resistance_decision else None
+                ),
             }
         )
 

--- a/engine/memory_audit_guard.py
+++ b/engine/memory_audit_guard.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional,
 
 from .alignment_guard import evaluate_alignment
 from .remembrance_guard import RemembranceGuard
+from .resistance_override_guard import ResistanceOverrideDecision, ResistanceOverrideGuard
 
 try:  # pragma: no cover - optional dependency for environments without guardian
     from .guardian_of_origin import enforce_origin as _default_origin_enforcer
@@ -163,6 +164,7 @@ class MemoryAuditGuard:
         *,
         audit_log_path: Path | str | None = None,
         origin_enforcer: Optional[Any] = None,
+        override_guard: Optional[ResistanceOverrideGuard] = None,
         codex_seed: str = "vaultfire-codex",
         drift_alert_threshold: float = 0.35,
         belief_shift_threshold: float = 0.12,
@@ -174,6 +176,13 @@ class MemoryAuditGuard:
 
         self.remembrance_guard = RemembranceGuard(belief_logs or [], memory_chains or [])
         self.origin_enforcer = origin_enforcer or _default_origin_enforcer
+        log_dir = self.audit_log_path.parent
+        if override_guard is None:
+            override_guard = ResistanceOverrideGuard(
+                audit_log_path=log_dir / "resistance_override_log.jsonl",
+                event_log_path=log_dir / "resistance_override_events.jsonl",
+            )
+        self.override_guard = override_guard
 
         existing_log = load_json(self.audit_log_path, [])
         if not isinstance(existing_log, list):
@@ -368,6 +377,46 @@ class MemoryAuditGuard:
                 rollback_block = True
                 codex_flags.append("invalid_rollback_signature")
 
+        resistance_decision: ResistanceOverrideDecision | None = None
+        caller_identity = (
+            identity_map.get("ens")
+            or identity_map.get("user_id")
+            or identity_map.get("wallet")
+            or payload_map.get("contributor")
+            or payload_map.get("identity")
+            or target_id
+        )
+        caller_identity = str(caller_identity or "unknown")
+        if self.override_guard and (override_flag or rollback_applied):
+            guard_payload: Dict[str, Any] = dict(payload_map)
+            guard_payload["override"] = True
+            guard_payload.setdefault("mission_type", "rollback" if rollback_applied else "memory")
+            if rollback_applied:
+                guard_payload.setdefault("mission_policy", "lawful-rollback")
+                if isinstance(rollback_source, Mapping):
+                    guard_payload.setdefault("codex_signature", rollback_source.get("signature"))
+            guard_payload.setdefault(
+                "codex_signature",
+                guard_payload.get("override_signature")
+                or guard_payload.get("belief_signature")
+                or guard_payload.get("beliefSignature"),
+            )
+            guard_context = {
+                "pathway": "rollback" if rollback_applied else "memory",
+                "action_type": action_type,
+                "target_id": target_id,
+                "alignment_allowed": alignment_allowed,
+                "override_requested": override_flag,
+            }
+            resistance_decision = self.override_guard.validate(
+                f"audit.{action_type}",
+                caller_identity,
+                override_payload=guard_payload,
+                context=guard_context,
+            )
+            if not resistance_decision.allowed:
+                codex_flags.append("resistance_override_block")
+
         requires_justification = action_type in REQUIRES_JUSTIFICATION and not rollback_applied
         if requires_justification and not justification:
             codex_flags.append("missing_justification")
@@ -387,6 +436,10 @@ class MemoryAuditGuard:
             allowed = origin_allowed and not rollback_block
         else:
             allowed = alignment_allowed and origin_allowed and not rollback_block
+        if resistance_decision and not resistance_decision.allowed:
+            allowed = False
+            if decision != "rollback":
+                decision = "block"
 
         belief_shift = round(belief_shift, 6)
         belief_density = round(belief_density, 6)
@@ -445,6 +498,15 @@ class MemoryAuditGuard:
             "previous_state": prior_state,
             "rollback_applied": rollback_applied,
         }
+
+        if resistance_decision:
+            resistance_record = {
+                "allowed": resistance_decision.allowed,
+                "reason": resistance_decision.reason,
+            }
+            if resistance_decision.audit_entry:
+                resistance_record["hash"] = resistance_decision.audit_entry.get("hash")
+            record["resistance_override"] = resistance_record
 
         if remembrance_alerts:
             record["remembrance_alerts"] = remembrance_alerts

--- a/engine/mission_registry.py
+++ b/engine/mission_registry.py
@@ -10,6 +10,7 @@ from utils.crypto import decrypt_text, derive_key, encrypt_text
 from utils.json_io import load_json, write_json
 
 from .alignment_guard import evaluate_alignment
+from .resistance_override_guard import DEFAULT_RESISTANCE_GUARD, ResistanceOverrideDecision
 BASE_DIR = Path(__file__).resolve().parents[1]
 DATA_PATH = BASE_DIR / "missions.json"
 DEFAULT_KEY = os.environ.get("MISSION_KEY", "vaultfire")
@@ -29,6 +30,9 @@ def decrypt_mission(token: str, key: Optional[str] = None) -> str:
 
 
 # --- Mission registry functions -------------------------------------------
+
+_RESISTANCE_OVERRIDE_GUARD = DEFAULT_RESISTANCE_GUARD
+
 
 def record_mission(
     user_id: str,
@@ -59,6 +63,34 @@ def record_mission(
                 extra_payload[key_name] = metadata[key_name]
         identity_payload.update({k: metadata[k] for k in metadata if isinstance(k, str)})
 
+    resistance_decision: ResistanceOverrideDecision | None = None
+    if extra_payload.get("override"):
+        override_payload = dict(extra_payload)
+        override_payload["override"] = True
+        override_payload.setdefault(
+            "codex_signature",
+            override_payload.get("override_signature")
+            or override_payload.get("beliefSignature")
+            or override_payload.get("belief_signature"),
+        )
+        override_context = {
+            "mission_type": (metadata or {}).get("mission_type", "growth")
+            if isinstance(metadata, Mapping)
+            else "growth",
+            "pathway": "growth",
+            "policy": override_payload.get("mission_policy")
+            or override_payload.get("policy"),
+        }
+        caller_reference = wallet or user_id
+        resistance_decision = _RESISTANCE_OVERRIDE_GUARD.validate(
+            "mission.record",
+            caller_reference,
+            override_payload=override_payload,
+            context=override_context,
+        )
+        if not resistance_decision.allowed:
+            raise PermissionError(resistance_decision.reason)
+
     guard_payload = {
         "mission": mission,
         "declared_purpose": mission,
@@ -86,6 +118,11 @@ def record_mission(
         "mission": enc,
         "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
+    if resistance_decision and resistance_decision.audit_entry:
+        entry["resistance_override"] = {
+            "hash": resistance_decision.audit_entry.get("hash"),
+            "status": resistance_decision.audit_entry.get("status"),
+        }
     entry["alignment_guard"] = {
         "decision": guard_result["decision"],
         "reasons": guard_result["reasons"],

--- a/engine/resistance_override_guard.py
+++ b/engine/resistance_override_guard.py
@@ -1,0 +1,551 @@
+"""Vaultfire Law 9: Resistance Override Protocol."""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+from utils.json_io import load_json
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_LOG_DIR = BASE_DIR / "logs"
+DEFAULT_AUDIT_PATH = DEFAULT_LOG_DIR / "resistance_override_log.jsonl"
+DEFAULT_EVENT_PATH = DEFAULT_LOG_DIR / "resistance_override_events.jsonl"
+DEFAULT_PARTNERS_PATH = BASE_DIR / "partners.json"
+DEFAULT_CONTRIBUTOR_REGISTRY_PATH = BASE_DIR / "contributor_registry.json"
+DEFAULT_SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
+DEFAULT_ALIGNMENT_LOG_PATH = DEFAULT_LOG_DIR / "belief_trace_log.json"
+
+ALLOWED_POLICY_MARKERS = {
+    "architect-only",
+    "architect",
+    "codex-approved",
+    "lawful-rollback",
+    "rollback",
+    "recovery",
+}
+PROTECTED_PATHWAYS = {"memory", "alignment", "audit"}
+
+
+def _now() -> str:
+    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _normalize(value: Optional[str]) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip().lower()
+
+
+def _coerce_mapping(data: Any) -> MutableMapping[str, Any]:
+    if isinstance(data, MutableMapping):
+        return data
+    if isinstance(data, Mapping):
+        return dict(data)
+    return {}
+
+
+def _iter_strings(items: Iterable[Any]) -> Iterable[str]:
+    for item in items:
+        if isinstance(item, str) and item.strip():
+            yield item.strip()
+
+
+@dataclass(frozen=True)
+class ResistanceOverrideDecision:
+    """Envelope describing the outcome of a resistance override review."""
+
+    allowed: bool
+    reason: str
+    override_requested: bool
+    record: Dict[str, Any]
+    audit_entry: Dict[str, Any] | None = None
+    rejection_event: Dict[str, Any] | None = None
+
+    @property
+    def reasons(self) -> Sequence[str]:
+        reasons = self.record.get("reasons", [])
+        if isinstance(reasons, Sequence):
+            return tuple(reasons)
+        return ()
+
+
+class ResistanceOverrideGuard:
+    """Guard that blocks unauthorized override attempts across Vaultfire."""
+
+    def __init__(
+        self,
+        *,
+        base_dir: str | Path | None = None,
+        audit_log_path: str | Path | None = None,
+        event_log_path: str | Path | None = None,
+        partners_path: str | Path | None = None,
+        contributor_registry_path: str | Path | None = None,
+        scorecard_path: str | Path | None = None,
+        alignment_log_path: str | Path | None = None,
+    ) -> None:
+        self.base_dir = Path(base_dir) if base_dir is not None else BASE_DIR
+        self.audit_log_path = Path(audit_log_path) if audit_log_path else DEFAULT_AUDIT_PATH
+        self.event_log_path = Path(event_log_path) if event_log_path else DEFAULT_EVENT_PATH
+        self.partners_path = Path(partners_path) if partners_path else DEFAULT_PARTNERS_PATH
+        self.contributor_registry_path = (
+            Path(contributor_registry_path)
+            if contributor_registry_path
+            else DEFAULT_CONTRIBUTOR_REGISTRY_PATH
+        )
+        self.scorecard_path = Path(scorecard_path) if scorecard_path else DEFAULT_SCORECARD_PATH
+        self.alignment_log_path = (
+            Path(alignment_log_path) if alignment_log_path else DEFAULT_ALIGNMENT_LOG_PATH
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def validate(
+        self,
+        operation: str,
+        caller_id: str,
+        override_payload: Mapping[str, Any] | None = None,
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> ResistanceOverrideDecision:
+        override_map = _coerce_mapping(override_payload)
+        context_map = _coerce_mapping(context)
+        timestamp = _now()
+        mission_type = self._resolve_mission_type(operation, override_map, context_map)
+        mission_policy = self._resolve_mission_policy(override_map, context_map)
+        signature = self._resolve_signature(override_map, context_map)
+        override_requested = self._resolve_override_flag(override_map, context_map)
+
+        lineage = self._lookup_lineage(caller_id, override_map, context_map)
+        architect_authorized = self._is_architect(caller_id, lineage, override_map, context_map)
+        alignment_clear, alignment_reason = self._alignment_clear(caller_id)
+
+        reasons: list[str] = []
+        if not architect_authorized:
+            reasons.append("insufficient_clearance")
+
+        if not signature:
+            reasons.append("missing_codex_signature")
+        elif not self._signature_valid(signature):
+            reasons.append("invalid_codex_signature")
+
+        if not lineage.get("verified"):
+            reasons.append("lineage_not_verified")
+        elif lineage.get("trust_tier") != "architect":
+            reasons.append("non_architect_lineage")
+
+        if mission_type in PROTECTED_PATHWAYS:
+            reasons.append("protected_pathway")
+
+        if not self._mission_allowed(mission_type, mission_policy, override_map, context_map):
+            reasons.append("mission_policy_block")
+
+        if not alignment_clear:
+            reasons.append(alignment_reason or "alignment_block")
+
+        allowed = not reasons
+        reason_text = reasons[0] if reasons else "allowed"
+
+        provenance_hash = self._fingerprint(
+            caller_id,
+            signature or "",
+            mission_type,
+            mission_policy or "",
+            timestamp,
+            operation,
+        )
+
+        record: Dict[str, Any] = {
+            "timestamp": timestamp,
+            "operation": operation,
+            "caller_id": caller_id,
+            "mission_type": mission_type,
+            "mission_policy": mission_policy,
+            "override_requested": override_requested,
+            "codex_signature_present": bool(signature),
+            "lineage_verified": bool(lineage.get("verified")),
+            "lineage_trust_tier": lineage.get("trust_tier"),
+            "architect_authorized": architect_authorized,
+            "alignment_clear": alignment_clear,
+            "reasons": reasons if reasons else ["allowed"],
+            "provenance_hash": provenance_hash,
+            "status": "allowed" if allowed else "rejected",
+        }
+
+        if signature:
+            record["codex_signature_digest"] = hashlib.sha256(signature.encode("utf-8")).hexdigest()
+        if lineage.get("record"):
+            record["lineage_record"] = lineage["record"]
+
+        audit_entry = self._append_log_entry(self.audit_log_path, record)
+        event_entry: Dict[str, Any] | None = None
+        if not allowed:
+            event_payload = {
+                "event": "override_rejection_event",
+                "timestamp": timestamp,
+                "operation": operation,
+                "caller_id": caller_id,
+                "mission_type": mission_type,
+                "reasons": list(reasons),
+                "provenance_hash": provenance_hash,
+                "audit_hash": audit_entry.get("hash"),
+            }
+            event_entry = self._append_log_entry(self.event_log_path, event_payload)
+
+        return ResistanceOverrideDecision(
+            allowed=allowed,
+            reason=reason_text,
+            override_requested=override_requested,
+            record=record,
+            audit_entry=audit_entry,
+            rejection_event=event_entry,
+        )
+
+    # ------------------------------------------------------------------
+    # Logging helpers
+    # ------------------------------------------------------------------
+    def load_audit_log(self) -> list[Dict[str, Any]]:
+        return self._read_log(self.audit_log_path)
+
+    def load_event_log(self) -> list[Dict[str, Any]]:
+        return self._read_log(self.event_log_path)
+
+    def _read_log(self, path: Path) -> list[Dict[str, Any]]:
+        if not path.exists():
+            return []
+        entries: list[Dict[str, Any]] = []
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, Mapping):
+                entries.append(dict(parsed))
+        return entries
+
+    def _append_log_entry(self, path: Path, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        data = dict(payload)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        prev_hash = self._load_last_hash(path)
+        data["prev_hash"] = prev_hash
+        encoded = json.dumps(data, sort_keys=True)
+        data["hash"] = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(data) + "\n")
+        return data
+
+    def _load_last_hash(self, path: Path) -> str:
+        if not path.exists():
+            return "0" * 64
+        try:
+            with path.open("rb") as handle:
+                handle.seek(0, 2)
+                if handle.tell() == 0:
+                    return "0" * 64
+                handle.seek(-2, 2)
+                while handle.tell() > 0 and handle.read(1) != b"\n":
+                    handle.seek(-2, 1)
+                last_line = handle.readline().decode("utf-8").strip()
+            if not last_line:
+                return "0" * 64
+            parsed = json.loads(last_line)
+            if isinstance(parsed, Mapping):
+                hash_value = parsed.get("hash")
+                if isinstance(hash_value, str) and len(hash_value) == 64:
+                    return hash_value
+        except Exception:
+            return "0" * 64
+        return "0" * 64
+
+    # ------------------------------------------------------------------
+    # Decision helpers
+    # ------------------------------------------------------------------
+    def _resolve_override_flag(
+        self,
+        payload: Mapping[str, Any],
+        context: Mapping[str, Any],
+    ) -> bool:
+        override_keys = (
+            "override",
+            "override_requested",
+            "force_override",
+            "overrideRequested",
+        )
+        for key in override_keys:
+            value = payload.get(key)
+            if isinstance(value, bool) and value:
+                return True
+            if isinstance(value, str) and value.strip().lower() in {"true", "yes", "architect"}:
+                return True
+        for key in override_keys:
+            value = context.get(key)
+            if isinstance(value, bool) and value:
+                return True
+            if isinstance(value, str) and value.strip().lower() in {"true", "yes", "architect"}:
+                return True
+        if context.get("allow_registration"):
+            return True
+        return False
+
+    def _resolve_signature(
+        self,
+        payload: Mapping[str, Any],
+        context: Mapping[str, Any],
+    ) -> Optional[str]:
+        keys = (
+            "codex_signature",
+            "override_signature",
+            "belief_signature",
+            "beliefSignature",
+            "signature",
+        )
+        for source in (payload, context):
+            for key in keys:
+                value = source.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        rollback = payload.get("rollback_payload")
+        if isinstance(rollback, Mapping):
+            signature = rollback.get("signature")
+            if isinstance(signature, str) and signature.strip():
+                return signature.strip()
+        return None
+
+    def _signature_valid(self, signature: str) -> bool:
+        normalized = signature.strip()
+        if len(normalized) < 32:
+            return False
+        try:
+            int(normalized, 16)
+            return True
+        except ValueError:
+            return len(normalized) >= 44
+
+    def _resolve_mission_type(
+        self,
+        operation: str,
+        payload: Mapping[str, Any],
+        context: Mapping[str, Any],
+    ) -> str:
+        for source in (payload, context):
+            for key in ("mission_type", "missionType", "pathway", "channel", "scope"):
+                value = source.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip().lower()
+        operation_lower = operation.lower()
+        if "rollback" in operation_lower:
+            return "rollback"
+        if "register" in operation_lower or "origin" in operation_lower:
+            return "registration"
+        if "mission" in operation_lower or "growth" in operation_lower:
+            return "growth"
+        if "memory" in operation_lower:
+            return "memory"
+        if "audit" in operation_lower:
+            return "audit"
+        return "general"
+
+    def _resolve_mission_policy(
+        self,
+        payload: Mapping[str, Any],
+        context: Mapping[str, Any],
+    ) -> Optional[str]:
+        for source in (payload, context):
+            for key in (
+                "mission_policy",
+                "missionPolicy",
+                "policy",
+                "override_policy",
+                "overridePolicy",
+            ):
+                value = source.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip().lower()
+        return None
+
+    def _mission_allowed(
+        self,
+        mission_type: str,
+        mission_policy: Optional[str],
+        payload: Mapping[str, Any],
+        context: Mapping[str, Any],
+    ) -> bool:
+        if mission_type in PROTECTED_PATHWAYS:
+            return False
+        if mission_type == "rollback":
+            return True
+        if mission_type == "registration":
+            policy = mission_policy or context.get("policy") or payload.get("policy")
+            if isinstance(policy, str) and policy.strip().lower() in ALLOWED_POLICY_MARKERS:
+                return True
+            return False
+        if mission_policy and mission_policy in ALLOWED_POLICY_MARKERS:
+            return True
+        return False
+
+    def _lookup_lineage(
+        self,
+        caller_id: str,
+        payload: Mapping[str, Any],
+        context: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        normalized = _normalize(caller_id)
+        registry = load_json(self.contributor_registry_path, {})
+        record: Dict[str, Any] | None = None
+        if isinstance(registry, Mapping):
+            for key, value in registry.items():
+                if not isinstance(value, Mapping):
+                    continue
+                candidates = { _normalize(key) }
+                for field in ("identity", "ens", "wallet", "handle", "id", "origin_id"):
+                    entry_value = value.get(field)
+                    if isinstance(entry_value, str):
+                        candidates.add(_normalize(entry_value))
+                if normalized and normalized in candidates:
+                    record = dict(value)
+                    break
+        if record is None:
+            record = {}
+        trust_markers: set[str] = set()
+        for key in ("trust_tier", "trustTier", "role", "title", "tier"):
+            value = record.get(key)
+            if isinstance(value, str) and value.strip():
+                trust_markers.add(value.strip().lower())
+        tags = record.get("tags")
+        if isinstance(tags, Iterable) and not isinstance(tags, (str, bytes)):
+            trust_markers.update(tag.strip().lower() for tag in tags if isinstance(tag, str))
+        trust_tier = "architect" if any("architect" in marker for marker in trust_markers) else None
+        if not trust_tier:
+            trust_tier = next(iter(trust_markers), "")
+        verified = bool(record)
+        if not verified:
+            partner_info = self._lookup_partner(caller_id)
+            if partner_info is not None:
+                record = partner_info
+                verified = True
+                trust_value = record.get("role") or record.get("title")
+                if isinstance(trust_value, str) and "architect" in trust_value.lower():
+                    trust_tier = "architect"
+        return {
+            "verified": verified,
+            "record": record,
+            "trust_tier": trust_tier or "",
+        }
+
+    def _lookup_partner(self, caller_id: str) -> Dict[str, Any] | None:
+        partners = load_json(self.partners_path, [])
+        normalized = _normalize(caller_id)
+        if not isinstance(partners, Iterable):
+            return None
+        for entry in partners:
+            if not isinstance(entry, Mapping):
+                continue
+            candidates = set(
+                _normalize(value)
+                for value in (
+                    entry.get("partner_id"),
+                    entry.get("wallet"),
+                    entry.get("ens"),
+                    entry.get("id"),
+                )
+                if isinstance(value, str)
+            )
+            if normalized and normalized in candidates:
+                return dict(entry)
+        return None
+
+    def _is_architect(
+        self,
+        caller_id: str,
+        lineage: Mapping[str, Any],
+        payload: Mapping[str, Any],
+        context: Mapping[str, Any],
+    ) -> bool:
+        normalized = _normalize(caller_id)
+        if not normalized:
+            return False
+        trust_tier = lineage.get("trust_tier")
+        if isinstance(trust_tier, str) and trust_tier == "architect":
+            return True
+        record = lineage.get("record")
+        if isinstance(record, Mapping):
+            for key in ("role", "title", "contributor_tag"):
+                value = record.get(key)
+                if isinstance(value, str) and "architect" in value.lower():
+                    return True
+            tags = record.get("tags")
+            if isinstance(tags, Iterable) and not isinstance(tags, (str, bytes)):
+                if any("architect" in tag.lower() for tag in _iter_strings(tags)):
+                    return True
+        scorecard = load_json(self.scorecard_path, {})
+        if isinstance(scorecard, Mapping):
+            candidate = scorecard.get(caller_id) or scorecard.get(normalized)
+            if isinstance(candidate, Mapping):
+                tag = candidate.get("contributor_tag") or candidate.get("role")
+                if isinstance(tag, str) and "architect" in tag.lower():
+                    return True
+        for source in (payload, context):
+            tier_value = source.get("trust_tier") or source.get("trustTier") or source.get("role")
+            if isinstance(tier_value, str) and "architect" in tier_value.lower():
+                return True
+        return False
+
+    def _alignment_clear(self, caller_id: str) -> tuple[bool, Optional[str]]:
+        history = load_json(self.alignment_log_path, [])
+        normalized = _normalize(caller_id)
+        if not isinstance(history, Iterable):
+            return True, None
+        for entry in reversed(list(history)[-25:]):
+            if not isinstance(entry, Mapping):
+                continue
+            candidates = []
+            for key in ("identity", "identity_tag", "identityToken", "user_id", "wallet", "ens"):
+                value = entry.get(key)
+                if isinstance(value, str):
+                    candidates.append(_normalize(value))
+            if normalized and normalized in candidates:
+                decision = entry.get("decision")
+                allowed = entry.get("allowed")
+                if isinstance(decision, str) and decision.lower() in {"block", "deny"}:
+                    return False, "moral_alignment_block"
+                if allowed is False:
+                    return False, "moral_alignment_block"
+        return True, None
+
+    def _fingerprint(
+        self,
+        caller_id: str,
+        signature: str,
+        mission_type: str,
+        mission_policy: str,
+        timestamp: str,
+        operation: str,
+    ) -> str:
+        payload = json.dumps(
+            {
+                "caller": _normalize(caller_id),
+                "signature_tail": signature[-16:],
+                "mission_type": mission_type,
+                "mission_policy": mission_policy,
+                "timestamp": timestamp,
+                "operation": operation,
+            },
+            sort_keys=True,
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+DEFAULT_RESISTANCE_GUARD = ResistanceOverrideGuard()
+
+__all__ = [
+    "ResistanceOverrideGuard",
+    "ResistanceOverrideDecision",
+    "DEFAULT_RESISTANCE_GUARD",
+]

--- a/tests/memory_audit_guard_test.py
+++ b/tests/memory_audit_guard_test.py
@@ -72,6 +72,12 @@ def _make_guard(module, tmp_path, origin_allowed: bool = True):
     def origin_enforcer(*_args, **_kwargs):
         return StubOriginResult(allowed=origin_allowed)
 
+    override_guard = module.ResistanceOverrideGuard(
+        audit_log_path=tmp_path / "resistance_override_log.jsonl",
+        event_log_path=tmp_path / "resistance_override_events.jsonl",
+        alignment_log_path=tmp_path / "belief_trace_log.json",
+    )
+
     belief_logs = [
         {
             "insight": "ignite future",
@@ -98,6 +104,7 @@ def _make_guard(module, tmp_path, origin_allowed: bool = True):
         memory_chains,
         audit_log_path=tmp_path / "memory_audit_log.json",
         origin_enforcer=origin_enforcer,
+        override_guard=override_guard,
         codex_seed="test-seed",
     )
 
@@ -162,6 +169,7 @@ def test_memory_audit_flags_unapproved_override(memory_audit_module, tmp_path):
         "previous_belief_density": 0.88,
         "authorized": False,
         "override": True,
+        "codex_signature": "bad" * 16,
         "tags": ["scale", "rogue"],
     }
     identity = {"ens": "rogue.eth", "trustTier": "scout"}
@@ -178,6 +186,7 @@ def test_memory_audit_flags_unapproved_override(memory_audit_module, tmp_path):
     assert "unauthorized_memory_edit" in result.codex_violation_flags
     assert "override_denied" in result.codex_violation_flags
     assert "misaligned_scale_attempt" in result.codex_violation_flags
+    assert "resistance_override_block" in result.codex_violation_flags
     assert guard.review_queue[-1]["target_id"] == "mem-1"
     assert guard.memory_action_log[-1]["codex_violation_flags"] == result.codex_violation_flags
 
@@ -209,11 +218,12 @@ def test_memory_audit_rollback_replay_restores_state(memory_audit_module, tmp_pa
         "justification": "Restoring truth",
         "authorized": True,
         "rollback_payload": rollback_payload,
+        "override_signature": "f" * 64,
     }
     result = guard.audit_memory_action(
         "retroactive_change",
         retro_payload,
-        identity={"ens": "guardian.eth", "trustTier": "guardian"},
+        identity={"ens": "ghostkey316.eth", "trustTier": "architect"},
         override_requested=True,
     )
 

--- a/tests/origin_guard_test.py
+++ b/tests/origin_guard_test.py
@@ -96,6 +96,8 @@ def test_guardian_records_authentic_origin_and_signature(origin_guard, tmp_path)
         "belief_density": 0.84,
         "empathy_score": 0.81,
         "mission_tags": ["vaultfire", "ghostkey"],
+        "mission_policy": "architect-only",
+        "codex_signature": "f" * 64,
     }
     identity = {
         "ens": "ghostkey316.eth",
@@ -141,6 +143,8 @@ def test_origin_guard_blocks_hijack_attempts(origin_guard, tmp_path):
         "belief_density": 0.84,
         "empathy_score": 0.81,
         "mission_tags": ["vaultfire", "ghostkey"],
+        "mission_policy": "architect-only",
+        "codex_signature": "f" * 64,
     }
     identity = {
         "ens": "ghostkey316.eth",
@@ -210,12 +214,15 @@ def test_validate_contributor_claims_uses_codex_trust(origin_guard, tmp_path):
         "belief_density": 0.88,
         "empathy_score": 0.86,
         "mission_tags": ["vaultfire"],
+        "mission_policy": "architect-only",
+        "codex_signature": "f" * 64,
     }
     identity = {
         "ens": "ally.eth",
         "wallet": "0xally",
         "trustTier": "guardian",
         "codex_trust": 0.82,
+        "override_caller": "ghostkey316.eth",
     }
 
     result = origin_guard.register_origin(

--- a/tests/resistance_override_guard_test.py
+++ b/tests/resistance_override_guard_test.py
@@ -1,0 +1,165 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from engine.resistance_override_guard import ResistanceOverrideGuard
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+
+
+def _seed_environment(tmp_path: Path) -> None:
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    registry = {
+        "bpow20.cb.id": {
+            "identity": "Ghostkey-316",
+            "ens": "ghostkey316.eth",
+            "role": "Architect",
+            "tags": ["vaultfire", "architect"],
+        },
+        "ally.id": {
+            "identity": "Ally",
+            "ens": "ally.eth",
+            "role": "guardian",
+        },
+    }
+    _write_json(tmp_path / "contributor_registry.json", registry)
+    partners = [
+        {
+            "partner_id": "ghostkey316.eth",
+            "wallet": "bpow20.cb.id",
+            "role": "Architect",
+        }
+    ]
+    _write_json(tmp_path / "partners.json", partners)
+    scorecard = {
+        "ghostkey316.eth": {"contributor_tag": "Architect"},
+        "ally.eth": {"contributor_tag": "Guardian"},
+    }
+    _write_json(tmp_path / "user_scorecard.json", scorecard)
+    alignment_log = [
+        {"identity": "ghostkey316.eth", "decision": "allow", "allowed": True},
+        {"identity": "ally.eth", "decision": "allow", "allowed": True},
+    ]
+    _write_json(logs_dir / "belief_trace_log.json", alignment_log)
+
+
+def _make_guard(tmp_path: Path) -> ResistanceOverrideGuard:
+    logs_dir = tmp_path / "logs"
+    return ResistanceOverrideGuard(
+        base_dir=tmp_path,
+        audit_log_path=logs_dir / "resistance_override_log.jsonl",
+        event_log_path=logs_dir / "resistance_override_events.jsonl",
+        contributor_registry_path=tmp_path / "contributor_registry.json",
+        partners_path=tmp_path / "partners.json",
+        scorecard_path=tmp_path / "user_scorecard.json",
+        alignment_log_path=logs_dir / "belief_trace_log.json",
+    )
+
+
+def test_resistance_guard_rejects_non_architect_override(tmp_path: Path) -> None:
+    _seed_environment(tmp_path)
+    guard = _make_guard(tmp_path)
+
+    payload = {
+        "override": True,
+        "mission_type": "growth",
+        "mission_policy": "architect-only",
+        "codex_signature": "abcd" * 16,
+    }
+    decision = guard.validate(
+        "mission.record",
+        "ally.eth",
+        override_payload=payload,
+        context={"pathway": "growth"},
+    )
+
+    assert decision.allowed is False
+    assert "insufficient_clearance" in decision.reasons
+    event_log = guard.load_event_log()
+    assert event_log[-1]["event"] == "override_rejection_event"
+
+
+def test_resistance_guard_allows_architect_signature(tmp_path: Path) -> None:
+    _seed_environment(tmp_path)
+    guard = _make_guard(tmp_path)
+
+    payload = {
+        "override": True,
+        "mission_type": "rollback",
+        "mission_policy": "lawful-rollback",
+        "codex_signature": "f" * 64,
+    }
+    decision = guard.validate(
+        "memory.rollback",
+        "ghostkey316.eth",
+        override_payload=payload,
+        context={"pathway": "rollback"},
+    )
+
+    assert decision.allowed is True
+    assert decision.audit_entry is not None
+    audit_log = guard.load_audit_log()
+    assert audit_log[-1]["status"] == "allowed"
+
+
+def test_resistance_guard_detects_protected_memory_override(tmp_path: Path) -> None:
+    _seed_environment(tmp_path)
+    guard = _make_guard(tmp_path)
+
+    payload = {
+        "override": True,
+        "mission_type": "memory",
+        "codex_signature": "f" * 64,
+    }
+    decision = guard.validate(
+        "memory.rewrite",
+        "ghostkey316.eth",
+        override_payload=payload,
+        context={"pathway": "memory"},
+    )
+
+    assert decision.allowed is False
+    assert "protected_pathway" in decision.reasons
+
+
+def test_resistance_guard_logs_all_attempts(tmp_path: Path) -> None:
+    _seed_environment(tmp_path)
+    guard = _make_guard(tmp_path)
+
+    fail_payload = {
+        "override": True,
+        "mission_type": "growth",
+        "mission_policy": "architect-only",
+        "codex_signature": "beef" * 16,
+    }
+    guard.validate(
+        "mission.record",
+        "ally.eth",
+        override_payload=fail_payload,
+        context={"pathway": "growth"},
+    )
+
+    success_payload = {
+        "override": True,
+        "mission_type": "rollback",
+        "mission_policy": "lawful-rollback",
+        "codex_signature": "c" * 64,
+    }
+    guard.validate(
+        "memory.rollback",
+        "ghostkey316.eth",
+        override_payload=success_payload,
+        context={"pathway": "rollback"},
+    )
+
+    audit_log = guard.load_audit_log()
+    statuses = {entry.get("status") for entry in audit_log}
+    assert statuses == {"allowed", "rejected"}
+    assert len(audit_log) == 2
+    event_log = guard.load_event_log()
+    assert len(event_log) == 1


### PR DESCRIPTION
## Summary
- add a ResistanceOverrideGuard engine module that authenticates override attempts against architect lineage, codex signatures, mission policies, and alignment history while emitting tamper-evident logs
- wire the guard into mission recording, memory audit rollback, and origin registration flows so architect-only overrides are enforced and logged
- extend and update tests to cover the new guard, architect requirements, and resistance logging behaviour

## Testing
- pytest tests/resistance_override_guard_test.py
- pytest tests/memory_audit_guard_test.py
- pytest tests/origin_guard_test.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e5b4630c8322b6ed24a40b944f41