### PR TITLE
Implement Human Standard guard enforcement

### DIFF
--- a/codex/init.py
+++ b/codex/init.py
@@ -41,6 +41,7 @@ class CodexMetadata:
     ethics_layer: str = "Ghostkey Ethics Framework v2.0"
     partner_sync: str = "ENABLED"
     immutable_identity_rights: str = "GRANTED"
+    immutable_if_human_violation: bool = True
     royalties_revenue_share: str = "WALLET-BOUND"
     role_visibility: str = "PUBLIC-FACING ACTIVATION READY"
     partner_clone_rights: str = "EARLY ACCESS"

--- a/codex/laws.yaml
+++ b/codex/laws.yaml
@@ -1,0 +1,10 @@
+immutable_if_human_violation: true
+laws:
+  - number: 10
+    title: "Vaultfire Law 10: The Human Standard"
+    summary: >-
+      HumanStandardGuard ensures every expansion, mission approval, and codex action
+      maintains empathy, human dignity, and emotional resonance before activation.
+    version: "1.0"
+    guard_path: "engine/human_standard_guard.py"
+    validation_suite: "tests/human_standard_guard_test.py"

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -282,6 +282,12 @@ from .nanoloop_v1_1 import (
     stabilize_trauma,
     rebuild_tissue,
 )
+from .human_standard_guard import (
+    HumanStandardGuard,
+    DEFAULT_HUMAN_STANDARD_GUARD,
+    humanity_violation_log,
+    flag_empathy_violation,
+)
 
 __all__ = [
     "resolve_identity",
@@ -539,5 +545,9 @@ __all__ = [
     "repair_cell_pattern",
     "stabilize_trauma",
     "rebuild_tissue",
+    "HumanStandardGuard",
+    "DEFAULT_HUMAN_STANDARD_GUARD",
+    "humanity_violation_log",
+    "flag_empathy_violation",
 ]
 

--- a/engine/alignment_guard.py
+++ b/engine/alignment_guard.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Mapping, Sequence
 
+from .human_standard_guard import DEFAULT_HUMAN_STANDARD_GUARD
+
 from utils.json_io import load_json, write_json
 
 BASE_DIR = Path(__file__).resolve().parents[1]
@@ -219,6 +221,46 @@ def evaluate_alignment(
     if override_flag and not override_granted:
         audit_record["override_denied"] = True
 
+    human_guard_payload = {
+        "mission": mission_text,
+        "intent": intent_text,
+        "combined_text": combined_text,
+        "empathy_score": empathy_score,
+        "belief_density": belief_density,
+        "mission_tags": list(tags),
+        "tokens": sorted(tokens),
+        "override": override_flag,
+    }
+    human_guard_context = {
+        "alignment_reasons": list(reasons),
+        "mission": True,
+        "dialogue": False,
+        "enforce_human_first": True,
+        "override_requested": override_flag,
+        "initial_decision": decision,
+    }
+    human_standard_result = DEFAULT_HUMAN_STANDARD_GUARD.evaluate(
+        operation,
+        human_guard_payload,
+        identity=identity_mapping,
+        context=human_guard_context,
+        initial_decision=allowed,
+    )
+    audit_record["human_standard"] = human_standard_result["audit_record"]
+    audit_record["human_standard_hash"] = human_standard_result["human_standard_hash"]
+    audit_record["human_standard_escalation"] = human_standard_result["escalation_level"]
+    audit_record["ethics_versions"] = human_standard_result["ethics_versions"]
+    audit_record["passive_empathy_synced"] = human_standard_result["passive_empathy_synced"]
+    if not human_standard_result["allowed"]:
+        allowed = False
+        decision = human_standard_result["decision"]
+        for reason in human_standard_result["reasons"]:
+            if reason not in reasons:
+                reasons.append(reason)
+        audit_record["allowed"] = False
+        audit_record["decision"] = decision
+        audit_record["reasons"] = reasons or ["human standard guard review"]
+
     _append_audit_log(audit_record)
 
     return {
@@ -233,6 +275,8 @@ def evaluate_alignment(
             "empathy_score": empathy_score,
             "trust_tier": trust_tier,
         },
+        "human_standard": human_standard_result,
+        "human_standard_hash": human_standard_result["human_standard_hash"],
     }
 
 

--- a/engine/human_standard_guard.py
+++ b/engine/human_standard_guard.py
@@ -1,0 +1,572 @@
+"""Vaultfire Law 10: The Human Standard enforcement guard."""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_VIOLATION_LOG_PATH = BASE_DIR / "logs" / "humanity_violation_log.jsonl"
+DEFAULT_OVERRIDE_LOG_PATH = BASE_DIR / "logs" / "human_standard_override_log.jsonl"
+DEFAULT_MANIFEST_PATH = BASE_DIR / "humanity_manifest.json"
+
+RESPECT_MARKERS = {
+    "please",
+    "thank",
+    "thanks",
+    "appreciate",
+    "respect",
+    "care",
+    "welcome",
+    "honor",
+    "listen",
+    "support",
+    "kindly",
+    "together",
+    "collaborate",
+    "share",
+}
+EMOTIVE_MARKERS = {
+    "care",
+    "hope",
+    "joy",
+    "trust",
+    "warmth",
+    "kindness",
+    "compassion",
+    "love",
+    "dignity",
+    "humanity",
+    "belong",
+    "belonging",
+    "support",
+    "empathy",
+    "healing",
+    "uplift",
+    "gratitude",
+    "appreciate",
+}
+DEHUMANIZING_MARKERS = {
+    "subjects",
+    "subject",
+    "assets",
+    "units",
+    "harvest",
+    "exploit",
+    "leverage",
+    "commodify",
+    "mechanism",
+    "compliance-only",
+    "protocol-only",
+    "drone",
+    "obsolete",
+}
+MECHANIZED_MARKERS = {
+    "optimize",
+    "optimization",
+    "automate",
+    "automation",
+    "pipeline",
+    "throughput",
+    "efficiency",
+    "instrument",
+    "execute",
+    "execution",
+    "protocol",
+    "mechanize",
+    "mechanized",
+    "scaling",
+    "scale",
+    "deploy",
+    "deployment",
+    "compliance",
+    "metrics",
+    "output",
+    "targets",
+    "target",
+    "iteration",
+}
+HUMAN_FIRST_MARKERS = {
+    "human",
+    "humans",
+    "people",
+    "person",
+    "community",
+    "communities",
+    "contributors",
+    "contributor",
+    "friends",
+    "families",
+    "dignity",
+    "humanity",
+    "guardian",
+    "guardians",
+    "care",
+    "support",
+    "belong",
+    "belonging",
+    "wellbeing",
+}
+TEXT_KEYS = (
+    "text",
+    "message",
+    "mission",
+    "intent",
+    "summary",
+    "dialogue",
+    "content",
+    "note",
+    "prompt",
+    "response",
+    "story",
+    "codex",
+    "codex_entry",
+    "description",
+    "combined_text",
+)
+
+
+def _now() -> str:
+    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _coerce_mapping(data: Any) -> Dict[str, Any]:
+    if isinstance(data, MutableMapping):
+        return dict(data)
+    if isinstance(data, Mapping):
+        return dict(data)
+    return {}
+
+
+def _safe_value(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _safe_value(val) for key, val in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_safe_value(item) for item in value]
+    return str(value)
+
+
+def _tokenize(texts: Iterable[str]) -> set[str]:
+    tokens: set[str] = set()
+    for text in texts:
+        lower = text.lower()
+        normalized = lower.replace("-", " ").replace("/", " ")
+        for raw in normalized.split():
+            token = "".join(ch for ch in raw if ch.isalnum())
+            if token:
+                tokens.add(token)
+    return tokens
+
+
+def _load_last_digest(path: Path, digest_key: str) -> str:
+    if not path.exists():
+        return "0" * 64
+    last_line = ""
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if line:
+                    last_line = line
+    except OSError:
+        return "0" * 64
+    if not last_line:
+        return "0" * 64
+    try:
+        parsed = json.loads(last_line)
+    except json.JSONDecodeError:
+        return "0" * 64
+    if isinstance(parsed, Mapping):
+        digest_value = parsed.get(digest_key) or parsed.get("hash") or parsed.get("signature")
+        if isinstance(digest_value, str) and len(digest_value) >= 32:
+            return digest_value
+    return "0" * 64
+
+
+def _append_jsonl(path: Path, payload: Mapping[str, Any], *, digest_key: str = "hash") -> Dict[str, Any]:
+    data = {str(k): _safe_value(v) for k, v in payload.items()}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    prev_digest = _load_last_digest(path, digest_key)
+    data["prev_hash"] = prev_digest
+    encoded = json.dumps(data, sort_keys=True)
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    data[digest_key] = digest
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(data, sort_keys=True) + "\n")
+    return data
+
+
+def humanity_violation_log(
+    record: Mapping[str, Any], *, log_path: Path | str | None = None
+) -> Dict[str, Any]:
+    """Append a humanity violation record and return the persisted entry."""
+
+    path = Path(log_path) if log_path else DEFAULT_VIOLATION_LOG_PATH
+    payload = dict(record)
+    payload.setdefault("timestamp", _now())
+    payload.setdefault("event", "human_standard_violation")
+    entry = _append_jsonl(path, payload, digest_key="signature")
+    return entry
+
+
+def flag_empathy_violation(
+    reason: str, context: Mapping[str, Any] | None = None, *, guard: "HumanStandardGuard" | None = None
+) -> Dict[str, Any]:
+    """Record a manual empathy violation flag using ``guard`` or the default instance."""
+
+    guard_instance = guard or DEFAULT_HUMAN_STANDARD_GUARD
+    return guard_instance.flag_violation(reason, context or {})
+
+
+@dataclass
+class HumanStandardGuard:
+    """Evaluate interactions against Ghostkey human-first ethics."""
+
+    empathy_threshold: float = 0.65
+    respect_markers: set[str] = field(default_factory=lambda: set(RESPECT_MARKERS))
+    emotive_markers: set[str] = field(default_factory=lambda: set(EMOTIVE_MARKERS))
+    dehumanizing_markers: set[str] = field(default_factory=lambda: set(DEHUMANIZING_MARKERS))
+    mechanized_markers: set[str] = field(default_factory=lambda: set(MECHANIZED_MARKERS))
+    human_first_markers: set[str] = field(default_factory=lambda: set(HUMAN_FIRST_MARKERS))
+    log_path: Path = DEFAULT_VIOLATION_LOG_PATH
+    override_log_path: Path = DEFAULT_OVERRIDE_LOG_PATH
+    manifest_path: Path = DEFAULT_MANIFEST_PATH
+    filter_version: str = "human-standard.v1"
+    ethics_versions: Sequence[str] = ("Ghostkey Ethics v1.0", "Ghostkey Ethics v2.0")
+
+    def __post_init__(self) -> None:
+        self.log_path = Path(self.log_path)
+        self.override_log_path = Path(self.override_log_path)
+        self.manifest_path = Path(self.manifest_path)
+        self.filter_history: list[Dict[str, Any]] = [
+            {"version": self.filter_version, "activated": _now()}
+        ]
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def evaluate(
+        self,
+        operation: str,
+        payload: Mapping[str, Any] | None,
+        identity: Mapping[str, Any] | None = None,
+        *,
+        context: Mapping[str, Any] | None = None,
+        initial_decision: bool | None = None,
+    ) -> Dict[str, Any]:
+        payload_map = _coerce_mapping(payload)
+        identity_map = _coerce_mapping(identity)
+        context_map = _coerce_mapping(context)
+
+        empathy_score, empathy_missing, low_empathy = self._resolve_empathy(payload_map, identity_map, context_map)
+        texts = self._collect_texts(payload_map, context_map)
+        tokens = _tokenize(texts)
+        mechanized_count = sum(1 for token in tokens if token in self.mechanized_markers)
+        dehumanizing_tokens = sorted(token for token in tokens if token in self.dehumanizing_markers)
+        human_tokens = sorted(token for token in tokens if token in self.human_first_markers)
+        respect_tokens = sorted(token for token in tokens if token in self.respect_markers)
+        emotive_tokens = sorted(token for token in tokens if token in self.emotive_markers)
+
+        requires_dialogue = bool(context_map.get("dialogue")) or "dialog" in operation.lower() or "mirror" in operation.lower()
+        requires_respect = context_map.get("enforce_respect")
+        if requires_respect is None:
+            requires_respect = requires_dialogue
+        requires_emotional = context_map.get("enforce_emotional_resonance")
+        if requires_emotional is None:
+            requires_emotional = requires_dialogue
+        requires_human_first = context_map.get("enforce_human_first")
+        if requires_human_first is None:
+            requires_human_first = "mission" in operation.lower() or bool(context_map.get("mission")) or bool(context_map.get("approval"))
+
+        severity = "notice"
+        reasons: list[str] = []
+
+        def escalate(level: str, message: str) -> None:
+            nonlocal severity
+            rank = {"notice": 0, "review": 1, "block": 2}
+            if rank[level] > rank[severity]:
+                severity = level
+            reasons.append(message)
+
+        if empathy_missing:
+            escalate("review", "empathy signal missing")
+        elif low_empathy:
+            escalate("review", f"empathy score {empathy_score:.2f} below threshold {self.empathy_threshold:.2f}")
+
+        if dehumanizing_tokens:
+            escalate("block", f"dehumanizing tokens detected: {', '.join(dehumanizing_tokens)}")
+
+        if mechanized_count >= 3:
+            escalate("review", "over-mechanization risk detected")
+            if mechanized_count >= 4 and not human_tokens:
+                escalate("block", "human-first values absent during mechanized directive")
+
+        if requires_human_first and not human_tokens and (mechanized_count >= 2 or low_empathy or empathy_missing):
+            escalate("review", "human-first alignment markers missing")
+
+        if requires_emotional and not emotive_tokens and (mechanized_count >= 2 or low_empathy or empathy_missing or dehumanizing_tokens):
+            escalate("review", "emotional resonance missing")
+
+        if requires_respect and not respect_tokens and (mechanized_count >= 2 or low_empathy or empathy_missing or dehumanizing_tokens):
+            escalate("review", "respectful tone markers missing")
+
+        decision = "allow"
+        allowed = severity == "notice"
+        if not allowed:
+            decision = "block" if severity == "block" else "review"
+
+        passive_empathy_synced = bool(
+            context_map.get("passive_empathy")
+            or payload_map.get("passive_empathy")
+            or (empathy_score is not None and empathy_score >= self.empathy_threshold)
+        )
+
+        audit_record: Dict[str, Any] = {
+            "operation": operation,
+            "timestamp": _now(),
+            "empathy_score": empathy_score,
+            "empathy_threshold": self.empathy_threshold,
+            "tokens_sampled": sorted(tokens)[:40],
+            "mechanized_count": mechanized_count,
+            "dehumanizing_tokens": dehumanizing_tokens,
+            "human_first_tokens": human_tokens,
+            "respect_tokens": respect_tokens,
+            "emotive_tokens": emotive_tokens,
+            "severity": severity,
+            "initial_decision": bool(initial_decision) if initial_decision is not None else None,
+            "filter_version": self.filter_version,
+            "ethics_versions": list(self.ethics_versions),
+            "passive_empathy_synced": passive_empathy_synced,
+        }
+        if texts:
+            audit_record["text_preview"] = [text[:160] for text in texts[:3]]
+        if context_map:
+            audit_record["context_flags"] = {
+                "dialogue": requires_dialogue,
+                "enforce_respect": bool(requires_respect),
+                "enforce_emotional": bool(requires_emotional),
+                "enforce_human_first": bool(requires_human_first),
+            }
+
+        human_standard_hash = hashlib.sha256(
+            json.dumps(audit_record, sort_keys=True, default=_safe_value).encode("utf-8")
+        ).hexdigest()
+        audit_record["human_standard_hash"] = human_standard_hash
+
+        violation_entry: Optional[Dict[str, Any]] = None
+        if not allowed:
+            violation_entry = humanity_violation_log(
+                {
+                    "operation": operation,
+                    "reasons": list(reasons),
+                    "escalation_level": severity,
+                    "human_standard_hash": human_standard_hash,
+                    "filter_version": self.filter_version,
+                    "ethics_versions": list(self.ethics_versions),
+                    "context": self._violation_context(payload_map, identity_map, context_map),
+                },
+                log_path=self.log_path,
+            )
+            audit_record["violation_signature"] = violation_entry.get("signature") if violation_entry else None
+
+        return {
+            "allowed": allowed,
+            "decision": decision,
+            "reasons": list(reasons),
+            "escalation_level": severity,
+            "human_standard_hash": human_standard_hash,
+            "audit_record": audit_record,
+            "ethics_versions": list(self.ethics_versions),
+            "rollback_required": not allowed,
+            "passive_empathy_synced": passive_empathy_synced,
+        }
+
+    def respect_override(
+        self,
+        actor: Mapping[str, Any],
+        *,
+        operation: str,
+        justification: str,
+        context: Mapping[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        actor_map = _coerce_mapping(actor)
+        context_map = _coerce_mapping(context)
+        trust_tier = self._resolve_trust_tier(actor_map, context_map)
+        timestamp = _now()
+        allowed = trust_tier == "architect"
+        payload = {
+            "timestamp": timestamp,
+            "operation": operation,
+            "actor": self._sanitize_actor(actor_map),
+            "trust_tier": trust_tier,
+            "justification": justification,
+            "status": "granted" if allowed else "rejected",
+            "filter_version": self.filter_version,
+            "ethics_versions": list(self.ethics_versions),
+        }
+        payload["human_standard_hash"] = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, default=_safe_value).encode("utf-8")
+        ).hexdigest()
+        entry = _append_jsonl(self.override_log_path, payload, digest_key="hash")
+        if not allowed:
+            humanity_violation_log(
+                {
+                    "operation": operation,
+                    "reasons": ["respect override denied"],
+                    "escalation_level": "block",
+                    "human_standard_hash": payload["human_standard_hash"],
+                    "filter_version": self.filter_version,
+                    "ethics_versions": list(self.ethics_versions),
+                    "context": {"actor": self._sanitize_actor(actor_map), "justification": justification},
+                },
+                log_path=self.log_path,
+            )
+        return entry
+
+    def flag_violation(self, reason: str, context: Mapping[str, Any]) -> Dict[str, Any]:
+        context_map = _coerce_mapping(context)
+        payload = {
+            "operation": "human_standard.flag",
+            "reasons": [reason],
+            "escalation_level": "review",
+            "filter_version": self.filter_version,
+            "ethics_versions": list(self.ethics_versions),
+            "context": self._violation_context({}, {}, context_map),
+        }
+        payload["human_standard_hash"] = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, default=_safe_value).encode("utf-8")
+        ).hexdigest()
+        return humanity_violation_log(payload, log_path=self.log_path)
+
+    def emit_manifest(
+        self,
+        codex_entry: Mapping[str, Any],
+        *,
+        manifest_path: Path | str | None = None,
+        extra: Mapping[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        path = Path(manifest_path) if manifest_path else self.manifest_path
+        manifest = {
+            "generated_at": _now(),
+            "codex_entry": {
+                "timestamp": codex_entry.get("timestamp"),
+                "hash": codex_entry.get("hash"),
+                "type": codex_entry.get("type"),
+            },
+            "human_standard_hash": codex_entry.get("human_standard_hash"),
+            "filter_version": self.filter_version,
+            "ethics_versions": list(self.ethics_versions),
+            "filter_history": list(self.filter_history),
+        }
+        if extra:
+            manifest["context"] = _safe_value(extra)
+        manifest["signature"] = hashlib.sha256(
+            json.dumps(manifest, sort_keys=True, default=_safe_value).encode("utf-8")
+        ).hexdigest()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(manifest, indent=2))
+        return manifest
+
+    def record_filter_upgrade(self, version: str, notes: str | None = None) -> None:
+        entry = {"version": version, "activated": _now()}
+        if notes:
+            entry["notes"] = notes
+        self.filter_history.append(entry)
+        self.filter_version = version
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _resolve_empathy(
+        self,
+        payload: Mapping[str, Any],
+        identity: Mapping[str, Any],
+        context: Mapping[str, Any],
+    ) -> tuple[Optional[float], bool, bool]:
+        for source in (payload, context, identity):
+            for key in ("empathy_score", "empathyScore", "empathy"):
+                value = source.get(key) if isinstance(source, Mapping) else None
+                if value is None:
+                    continue
+                try:
+                    score = float(value)
+                except (TypeError, ValueError):
+                    continue
+                return score, False, score < self.empathy_threshold
+        return None, True, False
+
+    def _collect_texts(
+        self, payload: Mapping[str, Any], context: Mapping[str, Any]
+    ) -> list[str]:
+        texts: list[str] = []
+        for source in (payload, context):
+            for key in TEXT_KEYS:
+                value = source.get(key)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+        return texts
+
+    def _violation_context(
+        self,
+        payload: Mapping[str, Any],
+        identity: Mapping[str, Any],
+        context: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        snapshot: Dict[str, Any] = {}
+        identity_tag = self._resolve_identity(identity)
+        if identity_tag:
+            snapshot["identity"] = identity_tag
+        tags = payload.get("tags") or payload.get("mission_tags") or payload.get("missionTags")
+        if isinstance(tags, Sequence) and not isinstance(tags, (str, bytes, bytearray)):
+            snapshot["tags"] = sorted({str(tag) for tag in tags if tag})
+        elif isinstance(tags, str) and tags.strip():
+            snapshot["tags"] = [tags.strip()]
+        snapshot["dialogue"] = bool(context.get("dialogue"))
+        snapshot["operation_context"] = {
+            "enforce_respect": bool(context.get("enforce_respect")),
+            "enforce_emotional": bool(context.get("enforce_emotional_resonance")),
+            "enforce_human_first": bool(context.get("enforce_human_first")),
+        }
+        return snapshot
+
+    def _resolve_identity(self, identity: Mapping[str, Any]) -> Optional[str]:
+        for key in ("ens", "wallet", "user_id", "userId", "id", "address", "participant"):
+            value = identity.get(key) if isinstance(identity, Mapping) else None
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    def _resolve_trust_tier(self, actor: Mapping[str, Any], context: Mapping[str, Any]) -> str:
+        for source in (actor, context):
+            for key in ("trust_tier", "trustTier", "role", "tier", "permission"):
+                value = source.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip().lower()
+        return ""
+
+    def _sanitize_actor(self, actor: Mapping[str, Any]) -> Dict[str, Any]:
+        sanitized: Dict[str, Any] = {}
+        for key in ("ens", "wallet", "user_id", "id", "role", "trust_tier", "trustTier", "tier"):
+            value = actor.get(key)
+            if isinstance(value, str) and value.strip():
+                sanitized[key] = value.strip()
+        return sanitized
+
+
+DEFAULT_HUMAN_STANDARD_GUARD = HumanStandardGuard()
+
+__all__ = [
+    "HumanStandardGuard",
+    "DEFAULT_HUMAN_STANDARD_GUARD",
+    "humanity_violation_log",
+    "flag_empathy_violation",
+]

--- a/engine/memory_audit_guard.py
+++ b/engine/memory_audit_guard.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
 
 from .alignment_guard import evaluate_alignment
+from .human_standard_guard import DEFAULT_HUMAN_STANDARD_GUARD, HumanStandardGuard
 from .remembrance_guard import RemembranceGuard
 from .resistance_override_guard import ResistanceOverrideDecision, ResistanceOverrideGuard
 
@@ -145,6 +146,8 @@ class MemoryAuditResult:
     codex_violation_flags: List[str]
     review_enqueued: bool
     record: Dict[str, Any]
+    human_standard_hash: str
+    human_standard: Dict[str, Any]
 
     @property
     def remembrance_alerts(self) -> List[Dict[str, Any]]:
@@ -168,6 +171,7 @@ class MemoryAuditGuard:
         codex_seed: str = "vaultfire-codex",
         drift_alert_threshold: float = 0.35,
         belief_shift_threshold: float = 0.12,
+        human_guard: Optional[HumanStandardGuard] = None,
     ) -> None:
         self.codex_seed = codex_seed
         self.drift_alert_threshold = drift_alert_threshold
@@ -183,6 +187,7 @@ class MemoryAuditGuard:
                 event_log_path=log_dir / "resistance_override_events.jsonl",
             )
         self.override_guard = override_guard
+        self.human_guard = human_guard or DEFAULT_HUMAN_STANDARD_GUARD
 
         existing_log = load_json(self.audit_log_path, [])
         if not isinstance(existing_log, list):
@@ -514,6 +519,44 @@ class MemoryAuditGuard:
             record["origin"] = origin_result
         record["alignment"] = alignment
 
+        human_context = {
+            "codex_flags": list(codex_flags),
+            "remembrance_alerts": remembrance_alerts,
+            "origin": origin_result,
+            "rollback_applied": rollback_applied,
+            "override_requested": override_flag,
+            "dialogue": False,
+            "mission": action_type in {"mission_change", "retroactive_change", "scale_authorization"},
+        }
+        human_payload = dict(payload_map)
+        human_payload.setdefault("action_type", action_type)
+        human_payload.setdefault("target_id", target_id)
+        human_payload["new_state_preview"] = deepcopy(new_state)
+        human_payload["previous_state"] = deepcopy(prior_state)
+        human_standard_result = self.human_guard.evaluate(
+            f"audit.{action_type}",
+            human_payload,
+            identity=identity_map,
+            context=human_context,
+            initial_decision=allowed,
+        )
+        record["human_standard"] = human_standard_result["audit_record"]
+        record["human_standard_hash"] = human_standard_result["human_standard_hash"]
+        record["human_standard_escalation"] = human_standard_result["escalation_level"]
+        record["ethics_versions"] = human_standard_result["ethics_versions"]
+        record["passive_empathy_synced"] = human_standard_result["passive_empathy_synced"]
+        if not human_standard_result["allowed"]:
+            allowed = False
+            decision = human_standard_result["decision"]
+            codex_flags.append("human_standard_violation")
+            record["allowed"] = False
+            record["decision"] = decision
+            record["human_standard_reasons"] = human_standard_result["reasons"]
+            if human_standard_result["rollback_required"] and not rollback_applied:
+                record["rollback_required"] = True
+
+        review_required = review_required or not human_standard_result["allowed"]
+
         if review_required:
             review_payload = {
                 "target_id": target_id,
@@ -524,6 +567,12 @@ class MemoryAuditGuard:
                 "override_requested": override_flag,
                 "flags": list(dict.fromkeys(codex_flags)),
             }
+            if not human_standard_result["allowed"]:
+                flags = review_payload.setdefault("flags", [])
+                if "human_standard_violation" not in flags:
+                    flags.append("human_standard_violation")
+                review_payload["human_standard_hash"] = human_standard_result["human_standard_hash"]
+                review_payload["human_standard_reasons"] = human_standard_result["reasons"]
             record["review"] = review_payload
             self.review_queue.append(review_payload)
 
@@ -543,6 +592,8 @@ class MemoryAuditGuard:
             codex_violation_flags=list(dict.fromkeys(codex_flags)),
             review_enqueued=review_required,
             record=record,
+            human_standard_hash=human_standard_result["human_standard_hash"],
+            human_standard=human_standard_result,
         )
 
     # ------------------------------------------------------------------

--- a/engine/mirror_room.py
+++ b/engine/mirror_room.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from datetime import datetime
 from typing import Dict, List
 
+from .human_standard_guard import DEFAULT_HUMAN_STANDARD_GUARD
+
 from .vaultlink import record_mirror_entry  # type: ignore
 from .purpose_engine import moral_memory_mirror  # type: ignore
 from vaultfire_signal_parser import parse_signal  # type: ignore
@@ -65,11 +67,25 @@ def post_message(room_id: str, user_id: str, text: str) -> Dict:
     if not data:
         raise ValueError("room not found")
     loops = parse_signal(text).get("loop_activators", 0)
+    guard_result = DEFAULT_HUMAN_STANDARD_GUARD.evaluate(
+        "mirror_room.post_message",
+        {"text": text, "loops": loops, "room_id": room_id, "topic": data.get("topic")},
+        identity={"user_id": user_id},
+        context={"dialogue": True, "enforce_respect": True, "enforce_emotional_resonance": True},
+    )
+    if not guard_result["allowed"]:
+        raise PermissionError("; ".join(guard_result["reasons"]) or "human standard guard rejection")
     entry = {
         "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
         "user": user_id,
         "text": text,
         "loops": loops,
+        "human_standard_hash": guard_result["human_standard_hash"],
+        "human_standard": {
+            "decision": guard_result["decision"],
+            "escalation_level": guard_result["escalation_level"],
+            "passive_empathy_synced": guard_result["passive_empathy_synced"],
+        },
     }
     data.setdefault("messages", []).append(entry)
     data["messages"] = data["messages"][-500:]

--- a/engine/mission_registry.py
+++ b/engine/mission_registry.py
@@ -128,7 +128,13 @@ def record_mission(
         "reasons": guard_result["reasons"],
         "override": guard_result["override"],
         "drift": guard_result["drift"],
+        "human_standard": {
+            "decision": guard_result["human_standard"]["decision"],
+            "escalation_level": guard_result["human_standard"]["escalation_level"],
+            "reasons": guard_result["human_standard"]["reasons"],
+        },
     }
+    entry["human_standard_hash"] = guard_result["human_standard_hash"]
     data[user_id] = entry
     write_json(DATA_PATH, data)
     return entry

--- a/engine/resistance_override_guard.py
+++ b/engine/resistance_override_guard.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Seque
 
 from utils.json_io import load_json
 
+from .human_standard_guard import DEFAULT_HUMAN_STANDARD_GUARD, HumanStandardGuard
+
 BASE_DIR = Path(__file__).resolve().parents[1]
 DEFAULT_LOG_DIR = BASE_DIR / "logs"
 DEFAULT_AUDIT_PATH = DEFAULT_LOG_DIR / "resistance_override_log.jsonl"
@@ -86,6 +88,7 @@ class ResistanceOverrideGuard:
         contributor_registry_path: str | Path | None = None,
         scorecard_path: str | Path | None = None,
         alignment_log_path: str | Path | None = None,
+        human_guard: HumanStandardGuard | None = None,
     ) -> None:
         self.base_dir = Path(base_dir) if base_dir is not None else BASE_DIR
         self.audit_log_path = Path(audit_log_path) if audit_log_path else DEFAULT_AUDIT_PATH
@@ -100,6 +103,7 @@ class ResistanceOverrideGuard:
         self.alignment_log_path = (
             Path(alignment_log_path) if alignment_log_path else DEFAULT_ALIGNMENT_LOG_PATH
         )
+        self.human_guard = human_guard or DEFAULT_HUMAN_STANDARD_GUARD
 
     # ------------------------------------------------------------------
     # Public API
@@ -181,6 +185,48 @@ class ResistanceOverrideGuard:
         if lineage.get("record"):
             record["lineage_record"] = lineage["record"]
 
+        human_payload = dict(override_map)
+        human_payload.setdefault("mission_type", mission_type)
+        if mission_policy is not None:
+            human_payload.setdefault("mission_policy", mission_policy)
+        human_payload["override_requested"] = override_requested
+        human_payload["pre_guard_allowed"] = allowed
+        human_context = {
+            "alignment_clear": alignment_clear,
+            "alignment_reason": alignment_reason,
+            "reasons": list(reasons),
+            "allowed_pre_guard": allowed,
+            "mission": mission_type in {"growth", "memory", "audit"},
+        }
+        human_identity: Dict[str, Any] = {}
+        if isinstance(lineage.get("record"), Mapping):
+            human_identity.update(dict(lineage.get("record")))
+        human_identity.setdefault("caller_id", caller_id)
+        if lineage.get("trust_tier"):
+            human_identity.setdefault("trust_tier", lineage.get("trust_tier"))
+        human_standard_result = self.human_guard.evaluate(
+            operation,
+            human_payload,
+            identity=human_identity,
+            context=human_context,
+            initial_decision=allowed,
+        )
+        record["human_standard"] = human_standard_result["audit_record"]
+        record["human_standard_hash"] = human_standard_result["human_standard_hash"]
+        record["human_standard_escalation"] = human_standard_result["escalation_level"]
+        record["human_standard_reasons"] = human_standard_result["reasons"]
+        record["ethics_versions"] = human_standard_result["ethics_versions"]
+        record["passive_empathy_synced"] = human_standard_result["passive_empathy_synced"]
+        if not human_standard_result["allowed"]:
+            allowed = False
+            for item in human_standard_result["reasons"] or ["human_standard_violation"]:
+                if item not in reasons:
+                    reasons.append(item)
+            record["status"] = "rejected"
+        record["allowed"] = allowed
+        reason_text = reasons[0] if reasons else ("allowed" if allowed else "human_standard_violation")
+        record["reasons"] = reasons if reasons else (["allowed"] if allowed else ["human_standard_violation"])
+
         audit_entry = self._append_log_entry(self.audit_log_path, record)
         event_entry: Dict[str, Any] | None = None
         if not allowed:
@@ -193,6 +239,7 @@ class ResistanceOverrideGuard:
                 "reasons": list(reasons),
                 "provenance_hash": provenance_hash,
                 "audit_hash": audit_entry.get("hash"),
+                "human_standard_hash": human_standard_result["human_standard_hash"],
             }
             event_entry = self._append_log_entry(self.event_log_path, event_payload)
 

--- a/ghostkey_asm_sync.py
+++ b/ghostkey_asm_sync.py
@@ -4,6 +4,8 @@ import hashlib
 from datetime import datetime, timezone
 from pathlib import Path
 
+from engine.human_standard_guard import DEFAULT_HUMAN_STANDARD_GUARD
+
 WALLET = "bpow20.cb.id"
 IDENTITY = "Ghostkey-316"
 TRIGGER = "loyalty"
@@ -13,6 +15,8 @@ STATUS = "Active Sync Verified"
 LOG_PATH = Path("immutable_log.jsonl")
 RETRO_YIELD_PATH = Path("retro_yield.json")
 CONTRIB_REG_PATH = Path("contributor_registry.json")
+
+HUMAN_GUARD = DEFAULT_HUMAN_STANDARD_GUARD
 
 def _load_log():
     if not LOG_PATH.exists():
@@ -148,6 +152,13 @@ def outputProof():
 
 def codexMemory(event, event_type: str = "ASM_Sync"):
     """Embed event into immutable log with chained hashing."""
+    guard_result = HUMAN_GUARD.evaluate(
+        "codex.push",
+        {"event": event, "event_type": event_type},
+        context={"mission": False, "dialogue": False},
+    )
+    if not guard_result["allowed"]:
+        raise PermissionError("; ".join(guard_result["reasons"]) or "human standard guard rejection")
     log = _load_log()
     prev_hash = log[-1]["hash"] if log else "0" * 64
     entry = {
@@ -157,8 +168,16 @@ def codexMemory(event, event_type: str = "ASM_Sync"):
         "prev_hash": prev_hash,
     }
     entry["hash"] = hashlib.sha256(json.dumps(entry, sort_keys=True).encode()).hexdigest()
+    entry["human_standard_hash"] = guard_result["human_standard_hash"]
+    entry["human_standard"] = {
+        "decision": guard_result["decision"],
+        "escalation_level": guard_result["escalation_level"],
+        "ethics_versions": guard_result["ethics_versions"],
+        "passive_empathy_synced": guard_result["passive_empathy_synced"],
+    }
     with open(LOG_PATH, "a") as f:
         f.write(json.dumps(entry) + "\n")
+    HUMAN_GUARD.emit_manifest(entry, extra={"event_type": event_type})
     return entry
 
 

--- a/onboarding_api.py
+++ b/onboarding_api.py
@@ -6,6 +6,7 @@ from flask import Flask, request, jsonify
 from simulate_partner_activation import simulate_activation, ALIGNMENT_PHRASE
 from engine.ens_sync_status import read_sync_status
 from engine.case_studies import submit_case_study, list_case_studies
+from engine.human_standard_guard import DEFAULT_HUMAN_STANDARD_GUARD
 from partner_modules import (
     get_audit_logs,
     record_audit_log,
@@ -27,6 +28,8 @@ EARNERS_PATH = BASE_DIR / "earners.json"
 SCORECARD_PATH = BASE_DIR / "user_scorecard.json"
 OG_LIST_PATH = BASE_DIR / "og_loyalists.json"
 CONFIG_PATH = BASE_DIR / "vault_config.json"
+
+HUMAN_GUARD = DEFAULT_HUMAN_STANDARD_GUARD
 
 
 def _load_json(path: Path, default):
@@ -61,10 +64,33 @@ def onboard_partner():
     og_flag = data.get("og_loyalist", False)
     if not partner_id or not wallet:
         return jsonify({"error": "partner_id and wallet required"}), 400
+    guard_result = HUMAN_GUARD.evaluate(
+        "onboard.partner",
+        {"partner_id": partner_id, "wallet": wallet, "og_loyalist": og_flag},
+        identity={"partner_id": partner_id, "wallet": wallet},
+        context={"mission": False, "enforce_human_first": True},
+    )
+    if not guard_result["allowed"]:
+        return (
+            jsonify(
+                {
+                    "error": "human_standard_violation",
+                    "reasons": guard_result["reasons"],
+                }
+            ),
+            403,
+        )
     partners = _load_json(PARTNERS_PATH, [])
     if any(p.get("partner_id") == partner_id for p in partners):
         return jsonify({"message": "partner already exists"}), 200
-    partners.append({"partner_id": partner_id, "wallet": wallet, "og_loyalist": og_flag})
+    partners.append(
+        {
+            "partner_id": partner_id,
+            "wallet": wallet,
+            "og_loyalist": og_flag,
+            "human_standard_hash": guard_result["human_standard_hash"],
+        }
+    )
     _write_json(PARTNERS_PATH, partners)
     if og_flag:
         og_list = _load_json(OG_LIST_PATH, [])
@@ -81,6 +107,22 @@ def onboard_contributor():
     wallet = data.get("wallet", "")
     if not user_id:
         return jsonify({"error": "user_id required"}), 400
+    guard_result = HUMAN_GUARD.evaluate(
+        "onboard.contributor",
+        {"user_id": user_id, "wallet": wallet},
+        identity={"user_id": user_id, "wallet": wallet},
+        context={"mission": False, "enforce_human_first": True},
+    )
+    if not guard_result["allowed"]:
+        return (
+            jsonify(
+                {
+                    "error": "human_standard_violation",
+                    "reasons": guard_result["reasons"],
+                }
+            ),
+            403,
+        )
     users = _load_json(CONTRIBUTORS_PATH, [])
     if user_id in users:
         return jsonify({"message": "contributor already exists"}), 200
@@ -88,7 +130,11 @@ def onboard_contributor():
     _write_json(CONTRIBUTORS_PATH, users)
     scorecard = _load_json(SCORECARD_PATH, {})
     if user_id not in scorecard:
-        scorecard[user_id] = {"wallet": wallet, "score": 0}
+        scorecard[user_id] = {
+            "wallet": wallet,
+            "score": 0,
+            "human_standard_hash": guard_result["human_standard_hash"],
+        }
         _write_json(SCORECARD_PATH, scorecard)
     return jsonify({"message": "contributor onboarded"}), 201
 
@@ -99,6 +145,22 @@ def onboard_earner():
     wallet = data.get("wallet")
     if not wallet:
         return jsonify({"error": "wallet required"}), 400
+    guard_result = HUMAN_GUARD.evaluate(
+        "onboard.earner",
+        {"wallet": wallet},
+        identity={"wallet": wallet},
+        context={"mission": False, "enforce_human_first": True},
+    )
+    if not guard_result["allowed"]:
+        return (
+            jsonify(
+                {
+                    "error": "human_standard_violation",
+                    "reasons": guard_result["reasons"],
+                }
+            ),
+            403,
+        )
     earners = _load_json(EARNERS_PATH, [])
     if wallet in earners:
         return jsonify({"message": "earner already exists"}), 200

--- a/tests/human_standard_guard_test.py
+++ b/tests/human_standard_guard_test.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from engine.human_standard_guard import HumanStandardGuard, flag_empathy_violation
+
+
+def _guard(tmp_path: Path) -> HumanStandardGuard:
+    return HumanStandardGuard(
+        empathy_threshold=0.68,
+        log_path=tmp_path / "violations.jsonl",
+        override_log_path=tmp_path / "override.jsonl",
+        manifest_path=tmp_path / "manifest.json",
+    )
+
+
+def test_tone_mismatch_blocks_and_logs(tmp_path: Path) -> None:
+    guard = _guard(tmp_path)
+    result = guard.evaluate(
+        "dialogue.simulation",
+        {
+            "text": "Execute optimization routines on subjects without compassion.",
+            "empathy_score": 0.2,
+        },
+        identity={"user": "tester"},
+        context={"dialogue": True, "enforce_respect": True},
+    )
+    assert not result["allowed"]
+    assert result["decision"] == "block"
+    assert result["rollback_required"] is True
+    assert any("dehumanizing" in reason for reason in result["reasons"])
+    log_path = tmp_path / "violations.jsonl"
+    log_lines = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+    assert log_lines, "violation log should contain an entry"
+    last_entry = log_lines[-1]
+    assert last_entry["human_standard_hash"] == result["human_standard_hash"]
+    assert len(last_entry["signature"]) == 64
+
+
+def test_emotional_absence_triggers_review_with_passive_sync(tmp_path: Path) -> None:
+    guard = _guard(tmp_path)
+    result = guard.evaluate(
+        "dialogue.mirror",
+        {
+            "text": "Automate compliance pipeline metrics to serve people efficiently.",
+        },
+        identity={"user": "tester"},
+        context={
+            "dialogue": True,
+            "enforce_emotional_resonance": True,
+            "passive_empathy": True,
+        },
+    )
+    assert not result["allowed"]
+    assert result["decision"] == "review"
+    assert any("emotional resonance" in reason for reason in result["reasons"])
+    assert result["passive_empathy_synced"] is True
+
+
+def test_respect_override_pathway(tmp_path: Path) -> None:
+    guard = _guard(tmp_path)
+    approved = guard.respect_override(
+        {"ens": "architect.eth", "trust_tier": "architect"},
+        operation="mission.override",
+        justification="Restore safety",
+    )
+    assert approved["status"] == "granted"
+    assert "human_standard_hash" in approved
+
+    rejected = guard.respect_override(
+        {"ens": "member.eth", "trust_tier": "guardian"},
+        operation="mission.override",
+        justification="Test",
+    )
+    assert rejected["status"] == "rejected"
+    violation_log = tmp_path / "violations.jsonl"
+    with violation_log.open() as handle:
+        lines = [json.loads(line) for line in handle if line.strip()]
+    assert any("respect override denied" in reason for entry in lines for reason in entry.get("reasons", []))
+
+
+def test_flag_helper_records_reason(tmp_path: Path) -> None:
+    guard = _guard(tmp_path)
+    entry = flag_empathy_violation("manual_review", {"operation": "sandbox"}, guard=guard)
+    assert entry["reasons"] == ["manual_review"]
+    assert "signature" in entry and len(entry["signature"]) == 64


### PR DESCRIPTION
## Summary
- add the HumanStandardGuard module to enforce empathetic behavior, respect overrides, and emit tamper-evident manifests
- wire the guard into alignment, memory, override, dialogue, onboarding, codex, and mission flows while persisting human_standard_hash metadata
- document Law 10 in the codex and cover the new guard with dedicated human-standard tests

## Testing
- pytest tests/human_standard_guard_test.py

------
https://chatgpt.com/codex/tasks/task_e_68c9eebd35a48322922425249b85e9cb