### PR TITLE
Embed ethics sync metadata and watermark values

### DIFF
--- a/contributors/VaultfireManifest.log
+++ b/contributors/VaultfireManifest.log
@@ -3,3 +3,4 @@ Ghostkey-316 | v26.2–v27.0 Full Stack Expansion | 2025-07-29
 Ghostkey-316 | Vaultfire Forkpoint v27.0 Finalized | 2025-07-29 | Partner onboarding and global sync active
 Ghostkey-316 | Vaultfire v27.0 | 2025-07-29 | Commit: Partner Forkpoint Activated and Global Handshake Initiated
 Ghostkey-316 | Vaultfire v27.2 | 2025-07-30 | Remote activation validated. Echo relay confirmed. Snapshot ID minted.
+ghostkey316.eth | Vaultfire Ethics Sync Soft Mode | 2025-08-24 | Values embedded: Human First / Private by Default / Decentralized by Design | FounderAnchorVerified=true | ethics_root_signer=ghostkey316.eth | Audit pulse: 7 days notify ghostkey316.eth

--- a/ghostkey_metadata_snapshot.json
+++ b/ghostkey_metadata_snapshot.json
@@ -11,5 +11,19 @@
     "contributor",
     "proof",
     "forkproof"
-  ]
+  ],
+  "ethics_values": [
+    "Human First",
+    "Private by Default",
+    "Decentralized by Design"
+  ],
+  "ethics_sync": {
+    "FounderAnchorVerified": true,
+    "ethics_root_signer": "ghostkey316.eth",
+    "audit": {
+      "enabled": true,
+      "pulse_interval_days": 7,
+      "anchor_drift_notification": "ghostkey316.eth"
+    }
+  }
 }

--- a/vaultfire_config.json
+++ b/vaultfire_config.json
@@ -1,6 +1,19 @@
 {
   "system_name": "Vaultfire Partner",
   "ethics_anchor": true,
+  "ethics_values": [
+    "Human First",
+    "Private by Default",
+    "Decentralized by Design"
+  ],
+  "ethics_sync": {
+    "FounderAnchorVerified": true,
+    "ethics_root_signer": "ghostkey316.eth",
+    "audit": {
+      "pulse_interval_days": 7,
+      "notify_on_anchor_drift": "ghostkey316.eth"
+    }
+  },
   "monetization_mode": "Behavioral Yield + Contributor Split",
   "public_visibility": "controlled",
   "partner_hooks_enabled": true,

--- a/visual_shell.js
+++ b/visual_shell.js
@@ -2,6 +2,11 @@ const fs = require('fs');
 const path = require('path');
 
 const CONFIG_PATH = path.join(__dirname, 'visual_config.json');
+const ETHICS_WATERMARK_VALUES = [
+  'Human First',
+  'Private by Default',
+  'Decentralized by Design'
+];
 
 function loadConfig() {
   try {
@@ -16,7 +21,10 @@ function renderModel(record) {
   const cfg = loadConfig();
   const engine = cfg.engine === 'babylon' ? 'babylon' : 'three';
   const meta = [];
-  if (record.watermark) meta.push('watermark');
+  if (record.watermark) {
+    meta.push('watermark');
+    ETHICS_WATERMARK_VALUES.forEach(value => meta.push(value));
+  }
   if (record.timed_reveal) meta.push('timed_reveal');
   if (record.partner_lock) meta.push('partner_lock');
   const overlay = meta.map(m => `<span class="meta">${m}</span>`).join(' ');


### PR DESCRIPTION
## Summary
- embed ethics values and sync confirmation details in the primary metadata snapshot and Vaultfire configuration
- surface the Human First / Private by Default / Decentralized by Design watermark cues in the renderer overlay
- record the soft-mode ethics sync for ghostkey316.eth in the contributor manifest

## Testing
- pytest tests/test_visual_shell_render.py

------
https://chatgpt.com/codex/tasks/task_e_68d1783cdd348322901e2a578f0385a8