### PR TITLE
feat: enforce wallet-first identity

### DIFF
--- a/auth/expressExample.js
+++ b/auth/expressExample.js
@@ -58,19 +58,43 @@ try {
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.get('/health', (req, res) => {
-  res.json({ status: 'ok', beliefEngine: 'synchronized', trustPhase: 'sync' });
+  res.json({
+    status: 'ok',
+    beliefEngine: 'synchronized',
+    trustPhase: 'sync',
+    identity: {
+      useWalletAsIdentity: trustConfig.useWalletAsIdentity,
+      rejectExternalID: trustConfig.rejectExternalID,
+      pseudonymousMode: trustConfig.pseudonymousMode,
+    },
+    telemetryMode: trustConfig.telemetryMode,
+  });
 });
 
 app.post('/auth/login', (req, res) => {
-  const { userId, role = ROLES.PARTNER, partnerId = 'demo-partner', scopes = [] } = req.body;
-  if (!userId) {
-    return res.status(400).json({ error: { code: 'auth.invalid_payload', message: 'userId is required' } });
+  const { wallet, ens, role = ROLES.PARTNER, partnerId = 'demo-partner', scopes = [] } = req.body || {};
+  if (!wallet) {
+    return res.status(400).json({ error: { code: 'auth.invalid_payload', message: 'wallet is required' } });
+  }
+  if (!validateWallet(wallet)) {
+    return res.status(400).json({ error: { code: 'auth.invalid_wallet', message: 'wallet must be a valid address' } });
+  }
+  if (trustConfig.identity?.rejectExternalID && req.body?.userId && req.body.userId !== wallet) {
+    return res.status(400).json({
+      error: {
+        code: 'auth.identity_rejected',
+        message: 'External identifiers are not accepted. Use wallet or ENS only.',
+      },
+    });
   }
 
+  const normalizedWallet = wallet.toLowerCase();
+  const ensAlias = ens ? ens.toLowerCase() : null;
+
   try {
-    const accessToken = tokenService.createAccessToken({ userId, role, partnerId, scopes });
-    const refreshToken = tokenService.createRefreshToken({ userId, role, partnerId, scopes });
-    telemetryLedger.record('auth.login', { userId, partnerId, role }, {
+    const accessToken = tokenService.createAccessToken({ wallet: normalizedWallet, ens: ensAlias, role, partnerId, scopes });
+    const refreshToken = tokenService.createRefreshToken({ wallet: normalizedWallet, ens: ensAlias, role, partnerId, scopes });
+    telemetryLedger.record('auth.login', { wallet: normalizedWallet, partnerId, role, ens: ensAlias }, {
       tags: ['auth'],
       visibility: { partner: false, ethics: true, audit: true },
     });
@@ -115,10 +139,17 @@ app.post(
         error: { code: 'activation.invalid_payload', message: 'walletId and activationChannel are required' },
       });
     }
+    if (!validateWallet(walletId)) {
+      return res.status(400).json({
+        error: { code: 'activation.invalid_wallet', message: 'walletId must be a valid address' },
+      });
+    }
+
+    const normalizedWallet = walletId.toLowerCase();
 
     const response = {
       status: 'activated',
-      walletId,
+      walletId: normalizedWallet,
       tierLevel: 'flame',
       activatedAt: new Date().toISOString(),
       modules: [
@@ -127,13 +158,13 @@ app.post(
       ],
     };
 
-    telemetryLedger.record('vaultfire.activation', { walletId, activationChannel, partnerId: req.user.partnerId }, {
+    telemetryLedger.record('vaultfire.activation', { walletId: normalizedWallet, activationChannel, partnerId: req.user.partnerId }, {
       tags: ['activation'],
       visibility: { partner: true, ethics: true, audit: true },
     });
 
     partnerHooks
-      .onActivation({ walletId, activationChannel, partnerId: req.user.partnerId })
+      .onActivation({ walletId: normalizedWallet, activationChannel, partnerId: req.user.partnerId })
       .catch((error) => console.warn('Activation hook delivery error', error));
 
     return res.status(201).json(response);
@@ -174,29 +205,44 @@ function validateBeliefScore(value) {
   return null;
 }
 
+function validateWallet(value) {
+  if (typeof value !== 'string' || !/^0x[a-fA-F0-9]{4,}$/.test(value)) {
+    return false;
+  }
+  return true;
+}
+
 function evaluateBreach(score) {
   return score < BELIEF_BREACH_THRESHOLD;
 }
 
 app.get(
-  '/link-identity',
+  '/link-wallet',
   ...createAuthMiddleware({ requiredRoles: [ROLES.PARTNER, ROLES.ADMIN], tokenService }),
   ethicsGuard,
   async (req, res) => {
-    const { wallet, partnerUserId } = req.query;
-    if (!wallet || !partnerUserId) {
+    const { wallet, ens } = req.query || {};
+    if (!wallet) {
       return res.status(400).json({
         error: {
-          code: 'identity.invalid_query',
-          message: 'wallet and partnerUserId query parameters are required',
+          code: 'wallet.invalid_query',
+          message: 'wallet query parameter is required',
+        },
+      });
+    }
+    if (!validateWallet(wallet)) {
+      return res.status(400).json({
+        error: {
+          code: 'wallet.invalid_query',
+          message: 'wallet must be a valid address',
         },
       });
     }
 
     await identityStoreReady;
-    const anchor = await identityStore.getAnchor({ wallet, partnerUserId });
+    const anchor = await identityStore.getWalletAnchor({ wallet, ensAlias: ens });
     if (!anchor) {
-      return res.status(404).json({ error: { code: 'identity.not_found', message: 'Anchor not found' } });
+      return res.status(404).json({ error: { code: 'wallet.not_found', message: 'Wallet anchor not found' } });
     }
 
     return res.json({ anchor });
@@ -204,36 +250,47 @@ app.get(
 );
 
 app.post(
-  '/link-identity',
+  '/link-wallet',
   ...createAuthMiddleware({ requiredRoles: [ROLES.PARTNER, ROLES.ADMIN], tokenService }),
   ethicsGuard,
   async (req, res) => {
-    const { wallet, partnerUserId, beliefScore, metadata = {} } = req.body || {};
-    if (!wallet || !partnerUserId) {
+    const { wallet, ens, beliefScore, metadata = {} } = req.body || {};
+    if (!wallet) {
       return res.status(400).json({
-        error: { code: 'identity.invalid_payload', message: 'wallet and partnerUserId are required' },
+        error: { code: 'wallet.invalid_payload', message: 'wallet is required' },
+      });
+    }
+    if (!validateWallet(wallet)) {
+      return res.status(400).json({ error: { code: 'wallet.invalid_payload', message: 'wallet must be a valid address' } });
+    }
+    if (trustConfig.identity?.rejectExternalID && metadata?.externalId) {
+      return res.status(400).json({
+        error: {
+          code: 'wallet.identity_rejected',
+          message: 'External identifiers are not accepted. Remove externalId metadata.',
+        },
       });
     }
     const validationError = validateBeliefScore(beliefScore);
     if (validationError) {
-      return res.status(400).json({ error: { code: 'identity.invalid_belief_score', message: validationError } });
+      return res.status(400).json({ error: { code: 'wallet.invalid_belief_score', message: validationError } });
     }
 
     await identityStoreReady;
-    const anchor = await identityStore.linkAnchor({ wallet, partnerUserId, beliefScore, metadata });
+    const anchor = await identityStore.linkWallet({ wallet, ensAlias: ens, beliefScore, metadata });
 
     const snapshot = signalCompass.recordPayload({
-      walletId: wallet,
-      partnerUserId,
+      walletId: anchor.wallet,
+      ensAlias: anchor.ensAlias,
       beliefScore,
       intents: metadata?.intents || [],
       ethicsFlags: metadata?.ethicsFlags || [],
-      metadata: { source: 'link-identity' },
+      metadata: { ...metadata, source: 'link-wallet' },
     });
 
     if (evaluateBreach(beliefScore)) {
       partnerHooks
-        .onBeliefBreach({ walletId: wallet, partnerUserId, beliefScore, partnerId: req.user.partnerId })
+        .onBeliefBreach({ walletId: anchor.wallet, ensAlias: anchor.ensAlias, beliefScore, partnerId: req.user.partnerId })
         .catch((error) => console.warn('Belief breach hook error', error));
     }
 
@@ -280,10 +337,14 @@ app.post(
   async (req, res) => {
     try {
       const parsed = mirrorAgent.parseWebhook(req.body);
+      if (!validateWallet(parsed.walletId)) {
+        throw new Error('walletId must be a valid address');
+      }
       const summary = mirrorAgent.interpretBeliefSignal(parsed);
+      const ensAlias = req.body.ens || req.body.ensAlias || null;
       signalCompass.recordPayload({
         walletId: parsed.walletId,
-        partnerUserId: req.body.partnerUserId || req.user.partnerId,
+        ensAlias: ensAlias ? ensAlias.toLowerCase() : null,
         beliefScore: parsed.beliefScore,
         intents: summary.intents,
         ethicsFlags: summary.ethicsFlags,
@@ -297,21 +358,19 @@ app.post(
         intents: summary.intents,
       });
 
-      if (req.body.partnerUserId) {
-        await identityStoreReady;
-        await identityStore.linkAnchor({
-          wallet: parsed.walletId,
-          partnerUserId: req.body.partnerUserId,
-          beliefScore: parsed.beliefScore,
-          metadata: { source: 'mirror-route' },
-        });
-      }
+      await identityStoreReady;
+      await identityStore.linkWallet({
+        wallet: parsed.walletId,
+        ensAlias,
+        beliefScore: parsed.beliefScore,
+        metadata: { source: 'mirror-route' },
+      });
 
       if (evaluateBreach(parsed.beliefScore)) {
         partnerHooks
           .onBeliefBreach({
             walletId: parsed.walletId,
-            partnerUserId: req.body.partnerUserId || req.user.userId,
+            ensAlias: ensAlias ? ensAlias.toLowerCase() : req.user.ens || null,
             beliefScore: parsed.beliefScore,
             partnerId: req.user.partnerId,
           })

--- a/auth/refreshStore.js
+++ b/auth/refreshStore.js
@@ -6,10 +6,10 @@ class RefreshStore {
     this.ttlMinutes = ttlMinutes;
   }
 
-  create(userId, meta = {}) {
+  create(wallet, meta = {}) {
     const token = crypto.randomBytes(48).toString('hex');
     const expiresAt = Date.now() + this.ttlMinutes * 60 * 1000;
-    this.tokens.set(token, { userId, meta, expiresAt });
+    this.tokens.set(token, { wallet, meta, expiresAt });
     return { token, expiresAt };
   }
 
@@ -31,9 +31,9 @@ class RefreshStore {
     this.tokens.delete(token);
   }
 
-  revokeByUser(userId) {
+  revokeByWallet(wallet) {
     for (const [token, entry] of this.tokens.entries()) {
-      if (entry.userId === userId) {
+      if (entry.wallet === wallet) {
         this.tokens.delete(token);
       }
     }

--- a/auth/tokenService.js
+++ b/auth/tokenService.js
@@ -18,9 +18,16 @@ class TokenService {
 
   createAccessToken(payload) {
     assertRole(payload.role);
+    const wallet = (payload.wallet || payload.userId || '').toLowerCase();
+    if (!wallet) {
+      throw new Error('wallet identity is required');
+    }
+    const ensAlias = payload.ens || payload.ensAlias || null;
     return jwt.sign(
       {
-        sub: payload.userId,
+        sub: wallet,
+        wallet,
+        ens: ensAlias,
         role: payload.role,
         scopes: payload.scopes || [],
         partnerId: payload.partnerId,
@@ -32,10 +39,15 @@ class TokenService {
   }
 
   createRefreshToken(payload) {
-    const entry = this.refreshStore.create(payload.userId, {
+    const wallet = (payload.wallet || payload.userId || '').toLowerCase();
+    if (!wallet) {
+      throw new Error('wallet identity is required');
+    }
+    const entry = this.refreshStore.create(wallet, {
       role: payload.role,
       partnerId: payload.partnerId,
       beliefVector: payload.beliefVector || null,
+      ens: payload.ens || payload.ensAlias || null,
       scopes: payload.scopes || [],
     });
     return entry;
@@ -51,12 +63,13 @@ class TokenService {
       return null;
     }
 
-    const { meta, userId } = entry;
+    const { meta, wallet } = entry;
     const newToken = this.createAccessToken({
-      userId,
+      wallet,
       role: meta.role,
       partnerId: meta.partnerId,
       beliefVector: meta.beliefVector,
+      ens: meta.ens,
       scopes: meta.scopes || [],
     });
     return {

--- a/cli/actions.js
+++ b/cli/actions.js
@@ -7,6 +7,7 @@ const AIMirrorAgent = require('../services/aiMirrorAgent');
 const { loadTrustSyncConfig } = require('../config/trustSyncConfig');
 
 const CONFIG_FILE = 'vaultfire.partner.config.json';
+const DEFAULT_WALLET = '0x0000000000000000000000000000000000000001';
 
 function resolveConfigPath(customPath) {
   return path.resolve(process.cwd(), customPath || CONFIG_FILE);
@@ -18,6 +19,8 @@ function initConfig({
   partnerId = 'demo-partner',
   baseUrl = 'http://localhost:4002',
   role = ROLES.PARTNER,
+  walletAddress = DEFAULT_WALLET,
+  ensAlias = null,
 } = {}) {
   const resolvedPath = resolveConfigPath(configPath);
   if (!overwrite && fs.existsSync(resolvedPath)) {
@@ -28,8 +31,16 @@ function initConfig({
     partnerId,
     baseUrl,
     role,
+    walletAddress: walletAddress.toLowerCase(),
+    ensAlias: ensAlias ? ensAlias.toLowerCase() : null,
     scopes: ['activation:trigger', 'rewards:read', 'belief:sync'],
     beliefFeedPath: 'vaultfire-beliefs.json',
+    identityPolicy: {
+      useWalletAsIdentity: true,
+      rejectExternalID: true,
+      pseudonymousMode: 'always',
+      telemetryMode: 'wallet-anonymous',
+    },
     createdAt: new Date().toISOString(),
   };
 
@@ -43,7 +54,17 @@ function loadConfig(configPath) {
     throw new Error(`Config file not found at ${resolvedPath}. Run \`vaultfire init\` first.`);
   }
   const raw = fs.readFileSync(resolvedPath, 'utf8');
-  return JSON.parse(raw);
+  const config = JSON.parse(raw);
+  config.identityPolicy = config.identityPolicy || {
+    useWalletAsIdentity: true,
+    rejectExternalID: true,
+    pseudonymousMode: 'always',
+    telemetryMode: 'wallet-anonymous',
+  };
+  config.identityPolicy.telemetryMode = config.identityPolicy.telemetryMode || 'wallet-anonymous';
+  config.walletAddress = (config.walletAddress || DEFAULT_WALLET).toLowerCase();
+  config.ensAlias = config.ensAlias ? config.ensAlias.toLowerCase() : null;
+  return config;
 }
 
 async function testConnection({ configPath } = {}) {
@@ -59,11 +80,16 @@ async function testConnection({ configPath } = {}) {
   };
 }
 
-function ensureBeliefPayload(config, overridePath) {
+function ensureBeliefPayload(config, overridePath, identityOverrides = {}) {
   const beliefPath = path.resolve(process.cwd(), overridePath || config.beliefFeedPath);
+  const sessionWallet = (identityOverrides.wallet || config.walletAddress || DEFAULT_WALLET).toLowerCase();
+  const rawEns =
+    identityOverrides.ens !== undefined ? identityOverrides.ens : config.ensAlias || null;
+  const sessionEns = rawEns ? rawEns.toLowerCase() : null;
   if (!fs.existsSync(beliefPath)) {
     const scaffold = {
-      walletId: '0xpartnerwallet',
+      walletId: sessionWallet,
+      ensAlias: sessionEns,
       beliefScore: 0.82,
       mirroredAt: new Date().toISOString(),
       signals: [
@@ -78,12 +104,25 @@ function ensureBeliefPayload(config, overridePath) {
     fs.writeFileSync(beliefPath, JSON.stringify(scaffold, null, 2));
   }
 
-  return JSON.parse(fs.readFileSync(beliefPath, 'utf8'));
+  const payload = JSON.parse(fs.readFileSync(beliefPath, 'utf8'));
+  payload.walletId = (identityOverrides.wallet || payload.walletId || config.walletAddress || DEFAULT_WALLET).toLowerCase();
+  if (identityOverrides.ens !== undefined) {
+    payload.ensAlias = identityOverrides.ens ? identityOverrides.ens.toLowerCase() : null;
+  } else if (!payload.ensAlias && sessionEns) {
+    payload.ensAlias = sessionEns;
+  }
+  return payload;
 }
 
-async function pushBeliefs({ configPath, token } = {}) {
+async function pushBeliefs({ configPath, token, wallet, ens } = {}) {
   const config = loadConfig(configPath);
-  const payload = ensureBeliefPayload(config);
+  const sessionWallet = (wallet || config.walletAddress || '').toLowerCase();
+  if (!sessionWallet) {
+    throw new Error('Wallet identity is required to push beliefs.');
+  }
+  const sessionEns =
+    ens !== undefined ? (ens ? ens.toLowerCase() : null) : config.ensAlias;
+  const payload = ensureBeliefPayload(config, undefined, { wallet: sessionWallet, ens: sessionEns });
   const url = new URL('/vaultfire/mirror', config.baseUrl).toString();
 
   const response = await fetch(url, {
@@ -105,7 +144,10 @@ async function summarizeMirror({ configPath, inputPath, outputChannel = 'cli' } 
   const trustConfig = loadTrustSyncConfig();
   const telemetry = new MultiTierTelemetryLedger(trustConfig.telemetry);
   const agent = new AIMirrorAgent({ telemetry, outputChannel });
-  const payload = ensureBeliefPayload(config, inputPath);
+  const payload = ensureBeliefPayload(config, inputPath, {
+    wallet: config.walletAddress,
+    ens: config.ensAlias,
+  });
   const parsed = agent.parseWebhook(payload);
   const summary = agent.interpretBeliefSignal(parsed);
   await Promise.resolve(agent.emitSummary(summary));

--- a/cli/vaultfire-cli.js
+++ b/cli/vaultfire-cli.js
@@ -20,6 +20,8 @@ program
   .option('--partner <partnerId>', 'Partner identifier to embed in the config')
   .option('--base-url <url>', 'Vaultfire core API URL', 'http://localhost:4002')
   .option('--role <role>', 'Default role for generated tokens', ROLES.PARTNER)
+  .option('--wallet <wallet>', 'Default wallet address used for identity')
+  .option('--ens <ens>', 'Optional ENS alias for the wallet identity')
   .action((options) => {
     try {
       const { config, path } = initConfig({
@@ -28,6 +30,8 @@ program
         partnerId: options.partner,
         baseUrl: options.baseUrl,
         role: options.role,
+        walletAddress: options.wallet,
+        ensAlias: options.ens,
       });
       console.log(chalk.green(`Partner configuration created at ${path}`));
       console.log(JSON.stringify(config, null, 2));
@@ -59,19 +63,33 @@ program
   .command('push')
   .option('-c, --config <path>', 'Path to the partner config file')
   .option('-t, --token <token>', 'Existing JWT to use for authentication')
+  .option('--wallet <wallet>', 'Override wallet address for this session')
+  .option('--ens <ens>', 'Override ENS alias for this session')
   .action(async (options) => {
     try {
       const config = loadConfig(options.config);
+      const sessionWallet = (options.wallet || config.walletAddress || '').toLowerCase();
+      if (!sessionWallet) {
+        throw new Error('Wallet identity is required. Set --wallet or configure walletAddress.');
+      }
+      const sessionEns =
+        options.ens !== undefined ? (options.ens ? options.ens.toLowerCase() : null) : config.ensAlias;
       const token =
         options.token ||
         tokenService.createAccessToken({
-          userId: `${config.partnerId}-cli`,
+          wallet: sessionWallet,
+          ens: sessionEns,
           role: config.role,
           partnerId: config.partnerId,
           scopes: config.scopes,
         });
 
-      const response = await pushBeliefs({ configPath: options.config, token });
+      const response = await pushBeliefs({
+        configPath: options.config,
+        token,
+        wallet: sessionWallet,
+        ens: sessionEns,
+      });
       const color = response.ok ? chalk.green : chalk.yellow;
       console.log(color(`Push response status: ${response.status}`));
       console.log(JSON.stringify(response.body, null, 2));

--- a/config/trustSyncConfig.js
+++ b/config/trustSyncConfig.js
@@ -2,11 +2,21 @@ const fs = require('fs');
 const path = require('path');
 
 const DEFAULT_CONFIG = {
-  identityStore: {
-    provider: 'memory',
+  useWalletAsIdentity: true,
+  rejectExternalID: true,
+  pseudonymousMode: 'always',
+  telemetryMode: 'wallet-anonymous',
+  identity: {
+    useWalletAsIdentity: true,
+    rejectExternalID: true,
+    pseudonymousMode: 'always',
   },
   telemetry: {
     baseDir: path.join(__dirname, '..', 'logs', 'telemetry'),
+    mode: 'wallet-anonymous',
+  },
+  identityStore: {
+    provider: 'memory',
   },
   signalCompass: {
     retentionLimit: 200,
@@ -57,6 +67,15 @@ function loadTrustSyncConfig() {
   if (process.env.VAULTFIRE_ENCRYPTION_KEY) {
     merged.identityStore.encryptionKey = process.env.VAULTFIRE_ENCRYPTION_KEY;
   }
+  merged.identity = merged.identity || {};
+  merged.identity.useWalletAsIdentity =
+    merged.identity.useWalletAsIdentity ?? merged.useWalletAsIdentity ?? true;
+  merged.identity.rejectExternalID = merged.identity.rejectExternalID ?? merged.rejectExternalID ?? true;
+  merged.identity.pseudonymousMode = merged.identity.pseudonymousMode ?? merged.pseudonymousMode ?? 'always';
+  merged.useWalletAsIdentity = merged.identity.useWalletAsIdentity;
+  merged.rejectExternalID = merged.identity.rejectExternalID;
+  merged.pseudonymousMode = merged.identity.pseudonymousMode;
+  merged.telemetryMode = merged.telemetry?.mode || merged.telemetryMode || 'wallet-anonymous';
   return merged;
 }
 

--- a/services/identityStore.js
+++ b/services/identityStore.js
@@ -15,6 +15,10 @@ function normalizeKey(key) {
   return crypto.createHash('sha256').update(material).digest();
 }
 
+function normalizeWallet(wallet) {
+  return wallet ? wallet.toLowerCase() : wallet;
+}
+
 class MemoryProvider {
   constructor() {
     this.anchors = new Map();
@@ -68,7 +72,7 @@ class PostgresProvider {
       CREATE TABLE IF NOT EXISTS ${this.tableName} (
         anchor_id TEXT PRIMARY KEY,
         wallet_hash TEXT NOT NULL,
-        partner_user_id_hash TEXT NOT NULL,
+        ens_alias_hash TEXT,
         payload JSONB NOT NULL,
         updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       );
@@ -78,19 +82,19 @@ class PostgresProvider {
   async upsert(anchorId, record) {
     const query = {
       text: `
-        INSERT INTO ${this.tableName} (anchor_id, wallet_hash, partner_user_id_hash, payload, updated_at)
+        INSERT INTO ${this.tableName} (anchor_id, wallet_hash, ens_alias_hash, payload, updated_at)
         VALUES ($1, $2, $3, $4, NOW())
         ON CONFLICT (anchor_id)
         DO UPDATE SET payload = EXCLUDED.payload, updated_at = NOW()
-        RETURNING anchor_id, wallet_hash, partner_user_id_hash, payload, updated_at;
+        RETURNING anchor_id, wallet_hash, ens_alias_hash, payload, updated_at;
       `,
-      values: [anchorId, record.walletHash, record.partnerUserIdHash, record.payload],
+      values: [anchorId, record.walletHash, record.ensAliasHash, record.payload],
     };
     const result = await this.pool.query(query);
     return {
       anchorId: result.rows[0].anchor_id,
       walletHash: result.rows[0].wallet_hash,
-      partnerUserIdHash: result.rows[0].partner_user_id_hash,
+      ensAliasHash: result.rows[0].ens_alias_hash,
       payload: result.rows[0].payload,
       updatedAt: result.rows[0].updated_at,
     };
@@ -98,7 +102,7 @@ class PostgresProvider {
 
   async getByAnchor(anchorId) {
     const result = await this.pool.query(
-      `SELECT anchor_id, wallet_hash, partner_user_id_hash, payload, updated_at FROM ${this.tableName} WHERE anchor_id = $1`,
+      `SELECT anchor_id, wallet_hash, ens_alias_hash, payload, updated_at FROM ${this.tableName} WHERE anchor_id = $1`,
       [anchorId]
     );
     if (!result.rowCount) {
@@ -108,7 +112,7 @@ class PostgresProvider {
     return {
       anchorId: row.anchor_id,
       walletHash: row.wallet_hash,
-      partnerUserIdHash: row.partner_user_id_hash,
+      ensAliasHash: row.ens_alias_hash,
       payload: row.payload,
       updatedAt: row.updated_at,
     };
@@ -116,13 +120,13 @@ class PostgresProvider {
 
   async findByWallet(walletHash) {
     const result = await this.pool.query(
-      `SELECT anchor_id, wallet_hash, partner_user_id_hash, payload, updated_at FROM ${this.tableName} WHERE wallet_hash = $1`,
+      `SELECT anchor_id, wallet_hash, ens_alias_hash, payload, updated_at FROM ${this.tableName} WHERE wallet_hash = $1`,
       [walletHash]
     );
     return result.rows.map((row) => ({
       anchorId: row.anchor_id,
       walletHash: row.wallet_hash,
-      partnerUserIdHash: row.partner_user_id_hash,
+      ensAliasHash: row.ens_alias_hash,
       payload: row.payload,
       updatedAt: row.updated_at,
     }));
@@ -153,7 +157,7 @@ class MongoProvider {
     const update = {
       $set: {
         walletHash: record.walletHash,
-        partnerUserIdHash: record.partnerUserIdHash,
+        ensAliasHash: record.ensAliasHash || null,
         payload: record.payload,
         updatedAt: new Date(),
       },
@@ -162,7 +166,7 @@ class MongoProvider {
     return {
       anchorId,
       walletHash: record.walletHash,
-      partnerUserIdHash: record.partnerUserIdHash,
+      ensAliasHash: record.ensAliasHash || null,
       payload: record.payload,
       updatedAt: new Date().toISOString(),
     };
@@ -227,20 +231,33 @@ class EncryptedIdentityStore {
     return JSON.parse(decrypted.toString('utf8'));
   }
 
-  #anchorId(wallet, partnerUserId) {
-    return sha256(`${wallet}:${partnerUserId}`);
+  #anchorId(wallet, ensAlias) {
+    const normalizedWallet = normalizeWallet(wallet);
+    const normalizedEns = ensAlias ? ensAlias.toLowerCase() : 'anonymous';
+    return sha256(`${normalizedWallet}:${normalizedEns}`);
   }
 
-  async linkAnchor({ wallet, partnerUserId, beliefScore, metadata = {} }) {
-    const anchorId = this.#anchorId(wallet, partnerUserId);
-    const payload = this.#encrypt({ wallet, partnerUserId, beliefScore, metadata, updatedAt: new Date().toISOString() });
-    const record = await this.provider.upsert(anchorId, {
-      walletHash: sha256(wallet),
-      partnerUserIdHash: sha256(partnerUserId),
+  async linkWallet({ wallet, ensAlias = null, beliefScore, metadata = {} }) {
+    const normalizedWallet = normalizeWallet(wallet);
+    if (!normalizedWallet) {
+      throw new Error('wallet is required');
+    }
+    const normalizedEns = ensAlias ? ensAlias.toLowerCase() : null;
+    const anchorId = this.#anchorId(normalizedWallet, normalizedEns);
+    const payload = this.#encrypt({
+      wallet: normalizedWallet,
+      ensAlias: normalizedEns,
+      beliefScore,
+      metadata,
+      updatedAt: new Date().toISOString(),
+    });
+    await this.provider.upsert(anchorId, {
+      walletHash: sha256(normalizedWallet),
+      ensAliasHash: normalizedEns ? sha256(normalizedEns) : null,
       payload,
     });
 
-    const entry = { anchorId, wallet, partnerUserId, beliefScore, metadata };
+    const entry = { anchorId, wallet: normalizedWallet, ensAlias: normalizedEns, beliefScore, metadata };
     this.telemetry?.record('identity.anchor.linked', entry, {
       tags: ['identity', 'belief'],
       visibility: { partner: true, ethics: true, audit: true },
@@ -248,8 +265,12 @@ class EncryptedIdentityStore {
     return entry;
   }
 
-  async getAnchor({ wallet, partnerUserId }) {
-    const anchorId = this.#anchorId(wallet, partnerUserId);
+  async getWalletAnchor({ wallet, ensAlias = null }) {
+    const normalizedWallet = normalizeWallet(wallet);
+    if (!normalizedWallet) {
+      return null;
+    }
+    const anchorId = this.#anchorId(normalizedWallet, ensAlias ? ensAlias.toLowerCase() : null);
     const record = await this.provider.getByAnchor(anchorId);
     if (!record) {
       return null;
@@ -259,7 +280,11 @@ class EncryptedIdentityStore {
   }
 
   async listByWallet(wallet) {
-    const walletHash = sha256(wallet);
+    const normalizedWallet = normalizeWallet(wallet);
+    if (!normalizedWallet) {
+      return [];
+    }
+    const walletHash = sha256(normalizedWallet);
     const records = await this.provider.findByWallet(walletHash);
     return records.map((record) => ({ ...this.#decrypt(record.payload), anchorId: record.anchorId || record.anchor_id }));
   }

--- a/services/signalCompass.js
+++ b/services/signalCompass.js
@@ -11,11 +11,11 @@ class SignalCompass extends EventEmitter {
     this.incoming = [];
   }
 
-  recordPayload({ walletId, partnerUserId, beliefScore, intents = [], ethicsFlags = [], metadata = {} }) {
+  recordPayload({ walletId, ensAlias = null, beliefScore, intents = [], ethicsFlags = [], metadata = {} }) {
     const timestamp = new Date().toISOString();
     const entry = {
       walletId,
-      partnerUserId,
+      ensAlias,
       beliefScore,
       intents,
       ethicsFlags,
@@ -39,7 +39,7 @@ class SignalCompass extends EventEmitter {
 
     if (ethicsFlags.length) {
       ethicsFlags.forEach((flag) => {
-        this.ethicsTriggers.push({ flag, timestamp, walletId, partnerUserId });
+        this.ethicsTriggers.push({ flag, timestamp, walletId, ensAlias });
       });
       if (this.ethicsTriggers.length > this.retentionLimit) {
         this.ethicsTriggers.splice(0, this.ethicsTriggers.length - this.retentionLimit);

--- a/tests/cliGuardrails.test.js
+++ b/tests/cliGuardrails.test.js
@@ -1,0 +1,82 @@
+const fs = require('fs');
+const path = require('path');
+
+jest.mock('node-fetch', () => jest.fn());
+const fetch = require('node-fetch');
+
+const { pushBeliefs } = require('../cli/actions');
+
+describe('CLI wallet guardrails', () => {
+  const tempDir = path.join(__dirname, 'tmp-cli');
+
+  beforeEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.mkdirSync(tempDir, { recursive: true });
+    fetch.mockReset();
+  });
+
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeConfig({ walletAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', ensAlias = 'cli.eth' } = {}) {
+    const configPath = path.join(tempDir, 'config.json');
+    const beliefPath = path.join(tempDir, 'beliefs.json');
+    const config = {
+      partnerId: 'cli-partner',
+      baseUrl: 'http://localhost:4002',
+      role: 'partner',
+      walletAddress,
+      ensAlias,
+      scopes: ['belief:sync'],
+      beliefFeedPath: beliefPath,
+      identityPolicy: {
+        useWalletAsIdentity: true,
+        rejectExternalID: true,
+        pseudonymousMode: 'always',
+        telemetryMode: 'wallet-anonymous',
+      },
+      createdAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    return configPath;
+  }
+
+  function mockFetch(ok = true) {
+    fetch.mockResolvedValue({
+      ok,
+      status: ok ? 200 : 400,
+      json: async () => ({ ok }),
+    });
+  }
+
+  it('forces wallet identity and ENS alias into belief payloads', async () => {
+    const configPath = writeConfig({ walletAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', ensAlias: 'CLI.ETH' });
+    mockFetch();
+
+    await pushBeliefs({ configPath, token: 'token' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [, options] = fetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.walletId).toBe('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(body.ensAlias).toBe('cli.eth');
+  });
+
+  it('allows wallet overrides per session', async () => {
+    const configPath = writeConfig({ walletAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', ensAlias: null });
+    mockFetch();
+
+    await pushBeliefs({
+      configPath,
+      wallet: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      ens: 'Override.ETH',
+      token: 'token',
+    });
+
+    const [, options] = fetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.walletId).toBe('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+    expect(body.ensAlias).toBe('override.eth');
+  });
+});

--- a/tests/identityStore.test.js
+++ b/tests/identityStore.test.js
@@ -4,19 +4,29 @@ describe('Encrypted identity store', () => {
   it('encrypts anchors and retrieves them by wallet', async () => {
     const store = new EncryptedIdentityStore({ provider: 'memory', encryptionKey: 'test-key' });
     await store.init();
-    const anchor = await store.linkAnchor({
-      wallet: '0xidentity',
-      partnerUserId: 'user-1',
+    const wallet = '0x4444444444444444444444444444444444444444';
+    const anchor = await store.linkWallet({
+      wallet,
       beliefScore: 0.87,
       metadata: { intents: ['align'] },
     });
     expect(anchor.anchorId).toBeDefined();
+    expect(anchor.wallet).toBe(wallet);
+    expect(anchor.ensAlias).toBeNull();
 
-    const fetched = await store.getAnchor({ wallet: '0xidentity', partnerUserId: 'user-1' });
+    const fetched = await store.getWalletAnchor({ wallet });
     expect(fetched.beliefScore).toBeCloseTo(0.87);
 
-    const walletAnchors = await store.listByWallet('0xidentity');
-    expect(walletAnchors).toHaveLength(1);
-    expect(walletAnchors[0].metadata.intents).toContain('align');
+    const aliasAnchor = await store.linkWallet({
+      wallet,
+      ensAlias: 'ghostkey316.eth',
+      beliefScore: 0.91,
+      metadata: { intents: ['alias'] },
+    });
+    expect(aliasAnchor.ensAlias).toBe('ghostkey316.eth');
+
+    const walletAnchors = await store.listByWallet(wallet);
+    expect(walletAnchors).toHaveLength(2);
+    expect(walletAnchors.map((entry) => entry.metadata.intents[0])).toEqual(expect.arrayContaining(['align', 'alias']));
   });
 });

--- a/tests/signalCompass.test.js
+++ b/tests/signalCompass.test.js
@@ -14,16 +14,17 @@ describe('Signal Compass', () => {
     const ledger = new MultiTierTelemetryLedger({ baseDir });
     const compass = new SignalCompass({ telemetry: ledger, retentionLimit: 10 });
     const snapshot = compass.recordPayload({
-      walletId: '0xabc',
-      partnerUserId: 'partner',
+      walletId: '0xabc1',
+      ensAlias: 'partner.eth',
       beliefScore: 0.9,
       intents: ['align', 'reward'],
       ethicsFlags: ['consent:verified'],
     });
 
-    expect(snapshot.incoming[0].walletId).toBe('0xabc');
+    expect(snapshot.incoming[0].walletId).toBe('0xabc1');
+    expect(snapshot.incoming[0].ensAlias).toBe('partner.eth');
     expect(snapshot.timeSeries).toHaveLength(1);
     expect(snapshot.intentFrequency[0]).toEqual({ intent: 'align', count: 1 });
-    expect(snapshot.ethicsTriggers[0].flag).toBe('consent:verified');
+    expect(snapshot.ethicsTriggers[0]).toMatchObject({ flag: 'consent:verified', ensAlias: 'partner.eth' });
   });
 });

--- a/tests/trustSync.test.js
+++ b/tests/trustSync.test.js
@@ -10,9 +10,19 @@ process.env.VAULTFIRE_RC_PATH = path.join(__dirname, 'vaultfirerc.test.json');
 const { app, tokenService, identityStoreReady, partnerHooks, telemetryLedger, createServer } = require('../auth/expressExample');
 const { ROLES } = require('../auth/roles');
 
+const WALLET_PARTNER = '0xcccccccccccccccccccccccccccccccccccccccc';
+const WALLET_SAMPLE = '0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd';
+const WALLET_SECONDARY = '0x1111111111111111111111111111111111111111';
+const WALLET_BREACH = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
+const WALLET_STREAM = '0xfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed';
+const WALLET_REFRESH = '0xcafecafecafecafecafecafecafecafecafecafe';
+const WALLET_MIRROR = '0xdeaddeaddeaddeaddeaddeaddeaddeaddeadbeef';
+const WALLET_CENTRAL = '0x2222222222222222222222222222222222222222';
+const WALLET_CONTRIBUTOR = '0x3333333333333333333333333333333333333333';
+
 function createToken(overrides = {}) {
   return tokenService.createAccessToken({
-    userId: 'trust-sync-tester',
+    wallet: WALLET_PARTNER,
     role: ROLES.PARTNER,
     partnerId: 'trust-partner',
     scopes: ['belief:sync'],
@@ -29,37 +39,38 @@ describe('Trust Sync protocol', () => {
     partnerHooks.removeAllListeners();
   });
 
-  describe('Belief identity linker', () => {
+  describe('Wallet linker', () => {
     it('rejects belief scores outside the 0-1 range', async () => {
       const token = createToken();
       const high = await request(app)
-        .post('/link-identity')
+        .post('/link-wallet')
         .set('Authorization', `Bearer ${token}`)
-        .send({ wallet: '0xabc', partnerUserId: 'user-high', beliefScore: 1.2 });
+        .send({ wallet: WALLET_SAMPLE, beliefScore: 1.2 });
       expect(high.status).toBe(400);
-      expect(high.body.error.code).toBe('identity.invalid_belief_score');
+      expect(high.body.error.code).toBe('wallet.invalid_belief_score');
 
       const low = await request(app)
-        .post('/link-identity')
+        .post('/link-wallet')
         .set('Authorization', `Bearer ${token}`)
-        .send({ wallet: '0xabc', partnerUserId: 'user-low', beliefScore: -0.1 });
+        .send({ wallet: WALLET_SAMPLE, beliefScore: -0.1 });
       expect(low.status).toBe(400);
-      expect(low.body.error.code).toBe('identity.invalid_belief_score');
+      expect(low.body.error.code).toBe('wallet.invalid_belief_score');
     });
 
     it('stores anchors at range boundaries and returns them decrypted', async () => {
       const token = createToken();
       const create = await request(app)
-        .post('/link-identity')
+        .post('/link-wallet')
         .set('Authorization', `Bearer ${token}`)
-        .send({ wallet: '0xwallet', partnerUserId: 'user-0', beliefScore: 1 });
+        .send({ wallet: WALLET_SAMPLE, beliefScore: 1 });
       expect(create.status).toBe(200);
       expect(create.body.anchor.beliefScore).toBe(1);
+      expect(create.body.anchor.ensAlias).toBeNull();
 
       const fetchRes = await request(app)
-        .get('/link-identity')
+        .get('/link-wallet')
         .set('Authorization', `Bearer ${token}`)
-        .query({ wallet: '0xwallet', partnerUserId: 'user-0' });
+        .query({ wallet: WALLET_SAMPLE });
       expect(fetchRes.status).toBe(200);
       expect(fetchRes.body.anchor.beliefScore).toBe(1);
     });
@@ -67,11 +78,32 @@ describe('Trust Sync protocol', () => {
     it('returns 404 when anchor is missing', async () => {
       const token = createToken();
       const res = await request(app)
-        .get('/link-identity')
+        .get('/link-wallet')
         .set('Authorization', `Bearer ${token}`)
-        .query({ wallet: '0xmissing', partnerUserId: 'unknown-user' });
+        .query({ wallet: WALLET_SECONDARY });
       expect(res.status).toBe(404);
     });
+
+    it('rejects payloads containing external identifiers', async () => {
+      const token = createToken();
+      const res = await request(app)
+        .post('/link-wallet')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ wallet: WALLET_SAMPLE, beliefScore: 0.5, metadata: { externalId: '1234' } });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('wallet.identity_rejected');
+    });
+  });
+
+  it('exposes wallet-first identity policy via health check', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.identity).toMatchObject({
+      useWalletAsIdentity: true,
+      rejectExternalID: true,
+      pseudonymousMode: 'always',
+    });
+    expect(res.body.telemetryMode).toBe('wallet-anonymous');
   });
 
   describe('Partner relationship hooks', () => {
@@ -82,13 +114,14 @@ describe('Trust Sync protocol', () => {
       partnerHooks.on('delivery:beliefBreach', (entry) => deliveries.push(entry));
 
       const res = await request(app)
-        .post('/link-identity')
+        .post('/link-wallet')
         .set('Authorization', `Bearer ${token}`)
-        .send({ wallet: '0xbreach', partnerUserId: 'user-breach', beliefScore: 0.2 });
+        .send({ wallet: WALLET_BREACH, ens: 'breach.eth', beliefScore: 0.2 });
       expect(res.status).toBe(200);
 
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(deliveries.some((entry) => entry.payload.beliefScore === 0.2)).toBe(true);
+      expect(deliveries.some((entry) => entry.payload.ensAlias === 'breach.eth')).toBe(true);
 
       const ethicsLog = telemetryLedger.readChannel('ethics');
       expect(ethicsLog.some((entry) => entry.eventType === 'identity.anchor.linked')).toBe(true);
@@ -120,7 +153,7 @@ describe('Trust Sync protocol', () => {
       const updatePromise = new Promise((resolve, reject) => {
         const timeout = setTimeout(() => reject(new Error('No signal update received')), 2000);
         client.on('signal-compass:update', (snapshot) => {
-          if (snapshot.incoming.some((entry) => entry.walletId === '0xstream')) {
+          if (snapshot.incoming.some((entry) => entry.walletId === WALLET_STREAM)) {
             clearTimeout(timeout);
             resolve(snapshot);
           }
@@ -128,9 +161,9 @@ describe('Trust Sync protocol', () => {
       });
 
       await request(app)
-        .post('/link-identity')
+        .post('/link-wallet')
         .set('Authorization', `Bearer ${token}`)
-        .send({ wallet: '0xstream', partnerUserId: 'user-stream', beliefScore: 0.9 });
+        .send({ wallet: WALLET_STREAM, beliefScore: 0.9 });
 
       const snapshot = await updatePromise;
       expect(snapshot.intentFrequency).toBeDefined();
@@ -154,7 +187,7 @@ describe('Trust Sync protocol', () => {
     it('issues and refreshes access tokens', async () => {
       const login = await request(app)
         .post('/auth/login')
-        .send({ userId: 'refresh-user', partnerId: 'trust-partner', role: ROLES.PARTNER });
+        .send({ wallet: WALLET_REFRESH, partnerId: 'trust-partner', role: ROLES.PARTNER, ens: 'refresh.eth' });
       expect(login.status).toBe(200);
       const refresh = await request(app)
         .post('/auth/refresh')
@@ -167,12 +200,20 @@ describe('Trust Sync protocol', () => {
       const res = await request(app).post('/auth/login').send({});
       expect(res.status).toBe(400);
     });
+
+    it('rejects attempts to login with external IDs', async () => {
+      const res = await request(app)
+        .post('/auth/login')
+        .send({ userId: 'centralized-user', wallet: WALLET_CENTRAL, partnerId: 'trust-partner' });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('auth.identity_rejected');
+    });
   });
 
   describe('Mirror agent integration', () => {
     it('interprets belief payloads through the mirror route', async () => {
       const token = tokenService.createAccessToken({
-        userId: 'contributor',
+        wallet: WALLET_CONTRIBUTOR,
         role: ROLES.CONTRIBUTOR,
         partnerId: 'trust-partner',
       });
@@ -180,7 +221,7 @@ describe('Trust Sync protocol', () => {
       const res = await request(app)
         .post('/vaultfire/mirror')
         .set('Authorization', `Bearer ${token}`)
-        .send({ walletId: '0xmirror', beliefScore: 0.76, partnerUserId: 'mirror-user', narrative: 'Aligned mission.' });
+        .send({ walletId: WALLET_MIRROR, beliefScore: 0.76, ens: 'mirror.eth', narrative: 'Aligned mission.' });
       expect(res.status).toBe(202);
       expect(res.body.summary.recommendedAction).toBeDefined();
     });


### PR DESCRIPTION
## Summary
- enforce wallet-only authentication, telemetry, and `/link-wallet` binding across the express example API
- refactor the encrypted identity store and signal compass to anchor beliefs to wallet/ENS pairs and drop centralized IDs
- update CLI identity handling with wallet defaults, ENS overrides, and new guardrail coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dade1bfd8c8322bae314ffb257c077