### PR TITLE
Fix fetch mocks for Jest tests

### DIFF
--- a/tests/aiMirrorAgent.test.js
+++ b/tests/aiMirrorAgent.test.js
@@ -5,7 +5,7 @@ jest.mock('node-fetch');
 
 describe('AI Mirror Agent', () => {
   beforeEach(() => {
-    fetch.mockReset();
+    fetch.resetMocks();
   });
 
   it('parses and summarizes webhook payloads', () => {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -15,7 +15,7 @@ describe('vaultfire CLI actions', () => {
     cwd = process.cwd();
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vaultfire-cli-'));
     process.chdir(tempDir);
-    fetch.mockReset();
+    fetch.resetMocks();
   });
 
   afterEach(() => {

--- a/tests/cliGuardrails.test.js
+++ b/tests/cliGuardrails.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-jest.mock('node-fetch', () => jest.fn());
+jest.mock('node-fetch', () => require('jest-fetch-mock'));
 const fetch = require('node-fetch');
 
 const { pushBeliefs } = require('../cli/actions');
@@ -12,7 +12,7 @@ describe('CLI wallet guardrails', () => {
   beforeEach(() => {
     fs.rmSync(tempDir, { recursive: true, force: true });
     fs.mkdirSync(tempDir, { recursive: true });
-    fetch.mockReset();
+    fetch.resetMocks();
   });
 
   afterAll(() => {

--- a/tests/partnerHooks.test.js
+++ b/tests/partnerHooks.test.js
@@ -5,7 +5,7 @@ jest.mock('node-fetch');
 
 describe('Partner hook registry', () => {
   beforeEach(() => {
-    fetch.mockReset();
+    fetch.resetMocks();
   });
 
   it('delivers hook payloads and records telemetry', async () => {


### PR DESCRIPTION
## Summary
- replace direct fetch.mockReset usage with fetch.resetMocks across Node-based tests
- ensure CLI guardrail tests load `jest-fetch-mock` so resetMocks is available when mocking `node-fetch`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daf99279f883228f5af63f9e5527d9