### PR TITLE
Finalize scoring safeguards and mobile dashboard

### DIFF
--- a/cli/beliefVote.js
+++ b/cli/beliefVote.js
@@ -5,6 +5,9 @@ const { keccak256, toUtf8Bytes } = require('ethers');
 const { BeliefMirrorEngine } = require('../mirror/engine');
 const { determineTier } = require('../mirror/belief-weight');
 const { verifyWalletSignature, normalizeWallet } = require('../utils/walletAuth');
+const { VoteRepository } = require('../services/voteRepository');
+const { assertWalletOnlyData } = require('../utils/identityGuards');
+const { validateMetrics } = require('../utils/scoringValidator');
 
 function readJson(filePath, fallback = []) {
   if (!fs.existsSync(filePath)) {
@@ -17,10 +20,6 @@ function readJson(filePath, fallback = []) {
   } catch (error) {
     throw new Error(`Unable to parse ${path.basename(filePath)}: ${error.message}`);
   }
-}
-
-function writeJson(filePath, payload) {
-  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2));
 }
 
 function loadProposals(proposalsPath = path.join(__dirname, '..', 'proposals.json')) {
@@ -56,22 +55,25 @@ async function castBeliefVote(
 
   const verified = verifyWalletSignature({ wallet, signature, message, ens });
   const normalizedWallet = normalizeWallet(verified.wallet);
-  const votes = readJson(votesPath, []);
+  const voteRepository = new VoteRepository({ filePath: votesPath });
+  const votes = await voteRepository.loadVotes();
   const previousVotes = votes.filter((voteRecord) => voteRecord.wallet === normalizedWallet).length;
 
   const mirrorEngine = new BeliefMirrorEngine({ telemetryPath });
+  const metrics = validateMetrics({
+    loyalty: Math.min(68 + previousVotes * 6, 100),
+    ethics: Math.min(88 + previousVotes * 2, 100),
+    frequency: Math.min(60 + previousVotes * 5, 100),
+    alignment: 80,
+    holdDuration: Math.min(55 + previousVotes * 3, 95),
+  });
+
   const action = {
     wallet: normalizedWallet,
     ens: verified.ens,
     type: 'vote',
     origin: 'belief-vote-cli',
-    metrics: {
-      loyalty: Math.min(68 + previousVotes * 6, 100),
-      ethics: Math.min(88 + previousVotes * 2, 100),
-      frequency: Math.min(60 + previousVotes * 5, 100),
-      alignment: 80,
-      holdDuration: Math.min(55 + previousVotes * 3, 95),
-    },
+    metrics,
   };
 
   const entry = await mirrorEngine.processAction(action);
@@ -88,8 +90,8 @@ async function castBeliefVote(
     messageDigest,
   };
 
-  votes.push(voteRecord);
-  writeJson(votesPath, votes);
+  assertWalletOnlyData(voteRecord, { context: 'vote' });
+  await voteRepository.appendVote(voteRecord);
 
   return {
     proposal,

--- a/compliance/exportLogs.js
+++ b/compliance/exportLogs.js
@@ -1,0 +1,94 @@
+const fs = require('fs');
+const path = require('path');
+const { BeliefMirrorEngine } = require('../mirror/engine');
+
+function ensureDirectory(targetPath) {
+  const dir = path.dirname(targetPath);
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function toCsv(entries) {
+  const header = [
+    'timestamp',
+    'wallet',
+    'ens',
+    'type',
+    'multiplier',
+    'tier',
+    'overrides',
+    'metrics.loyalty',
+    'metrics.ethics',
+    'metrics.frequency',
+    'metrics.alignment',
+    'metrics.holdDuration',
+  ];
+
+  const rows = entries.map((entry) => {
+    const metrics = entry.metrics || {};
+    return [
+      entry.timestamp || '',
+      entry.wallet || '',
+      entry.ens || '',
+      entry.type || '',
+      entry.multiplier ?? '',
+      entry.tier || '',
+      Array.isArray(entry.overrides) && entry.overrides.length ? entry.overrides.join('|') : '',
+      metrics.loyalty ?? '',
+      metrics.ethics ?? '',
+      metrics.frequency ?? '',
+      metrics.alignment ?? '',
+      metrics.holdDuration ?? '',
+    ]
+      .map((value) => {
+        if (value === null || value === undefined) {
+          return '';
+        }
+        const stringValue = String(value);
+        return stringValue.includes(',') ? `"${stringValue.replace(/"/g, '""')}"` : stringValue;
+      })
+      .join(',');
+  });
+
+  return [header.join(','), ...rows].join('\n');
+}
+
+function exportLogs(options = {}) {
+  const {
+    telemetryPath,
+    format = 'json',
+    writeTo,
+    ...filters
+  } = options;
+
+  const engine = new BeliefMirrorEngine({ telemetryPath });
+  const entries = engine.exportLogs(filters);
+
+  if (format === 'json' && !writeTo) {
+    return entries;
+  }
+
+  let content;
+  if (format === 'csv') {
+    content = toCsv(entries);
+  } else if (format === 'json') {
+    content = JSON.stringify(entries, null, 2);
+  } else {
+    throw new Error(`Unsupported export format: ${format}`);
+  }
+
+  let filePath = null;
+  if (writeTo) {
+    filePath = path.isAbsolute(writeTo) ? writeTo : path.join(process.cwd(), writeTo);
+    ensureDirectory(filePath);
+    fs.writeFileSync(filePath, content);
+  }
+
+  return {
+    format,
+    entries,
+    content,
+    filePath,
+  };
+}
+
+module.exports = { exportLogs };

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 import BeliefOverview from './components/BeliefOverview.jsx';
 import SyncTable from './components/SyncTable.jsx';
@@ -16,7 +16,39 @@ function WalletLogin() {
     ethics: 91,
     interactionFrequency: 68,
     partnerAlignment: 77,
+    holdDuration: 45,
   });
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [weights, setWeights] = useState({
+    loyalty: '',
+    ethics: '',
+    frequency: '',
+    alignment: '',
+    holdDuration: '',
+  });
+  const [baselineMultiplier, setBaselineMultiplier] = useState('');
+
+  const scoringConfig = useMemo(() => {
+    const normalizedWeights = Object.entries(weights).reduce((acc, [key, value]) => {
+      if (value === '') {
+        return acc;
+      }
+      const numeric = Number(value);
+      if (!Number.isNaN(numeric)) {
+        acc[key === 'frequency' ? 'frequency' : key] = numeric;
+      }
+      return acc;
+    }, {});
+    const config = {};
+    if (Object.keys(normalizedWeights).length) {
+      config.weights = normalizedWeights;
+    }
+    const baselineValue = Number(baselineMultiplier);
+    if (baselineMultiplier && !Number.isNaN(baselineValue)) {
+      config.baselineMultiplier = baselineValue;
+    }
+    return Object.keys(config).length ? config : undefined;
+  }, [weights, baselineMultiplier]);
 
   useEffect(() => {
     if (wallet) {
@@ -44,7 +76,10 @@ function WalletLogin() {
   const handleConnect = async (event) => {
     event.preventDefault();
     try {
-      await connect({ wallet, ens, signature, message, payload });
+      const submissionPayload = scoringConfig
+        ? { ...payload, scoringConfig }
+        : payload;
+      await connect({ wallet, ens, signature, message, payload: submissionPayload });
     } catch (err) {
       console.error('Belief sync failed', err.message);
     }
@@ -130,7 +165,102 @@ function WalletLogin() {
             }
           />
         </label>
+        <label>
+          Hold Duration (days)
+          <input
+            type="number"
+            value={payload.holdDuration}
+            min="0"
+            max="365"
+            onChange={(event) =>
+              setPayload((prev) => ({ ...prev, holdDuration: Number(event.target.value) }))
+            }
+          />
+        </label>
       </div>
+      <button
+        type="button"
+        className="ghost-button advanced-toggle"
+        onClick={() => setShowAdvanced((prev) => !prev)}
+      >
+        {showAdvanced ? 'Hide Scoring Overrides' : 'Advanced: Scoring Overrides'}
+      </button>
+      {showAdvanced ? (
+        <div className="advanced-grid">
+          <p className="subtitle">
+            Override the default belief weights (0-1 values are normalized automatically).
+          </p>
+          <div className="weights-grid">
+            <label>
+              Loyalty Weight
+              <input
+                type="number"
+                inputMode="decimal"
+                value={weights.loyalty}
+                min="0"
+                step="0.01"
+                onChange={(event) => setWeights((prev) => ({ ...prev, loyalty: event.target.value }))}
+              />
+            </label>
+            <label>
+              Ethics Weight
+              <input
+                type="number"
+                inputMode="decimal"
+                value={weights.ethics}
+                min="0"
+                step="0.01"
+                onChange={(event) => setWeights((prev) => ({ ...prev, ethics: event.target.value }))}
+              />
+            </label>
+            <label>
+              Frequency Weight
+              <input
+                type="number"
+                inputMode="decimal"
+                value={weights.frequency}
+                min="0"
+                step="0.01"
+                onChange={(event) => setWeights((prev) => ({ ...prev, frequency: event.target.value }))}
+              />
+            </label>
+            <label>
+              Alignment Weight
+              <input
+                type="number"
+                inputMode="decimal"
+                value={weights.alignment}
+                min="0"
+                step="0.01"
+                onChange={(event) => setWeights((prev) => ({ ...prev, alignment: event.target.value }))}
+              />
+            </label>
+            <label>
+              Hold Duration Weight
+              <input
+                type="number"
+                inputMode="decimal"
+                value={weights.holdDuration}
+                min="0"
+                step="0.01"
+                onChange={(event) => setWeights((prev) => ({ ...prev, holdDuration: event.target.value }))}
+              />
+            </label>
+          </div>
+          <label>
+            Baseline Multiplier
+            <input
+              type="number"
+              inputMode="decimal"
+              value={baselineMultiplier}
+              min="0.5"
+              step="0.01"
+              onChange={(event) => setBaselineMultiplier(event.target.value)}
+              placeholder="Default partner baseline is 1.15"
+            />
+          </label>
+        </div>
+      ) : null}
       <div className="actions">
         <button
           type="button"

--- a/dashboard/src/components/EnsResolverModal.jsx
+++ b/dashboard/src/components/EnsResolverModal.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { resolveEns } from '../services/ens.js';
+
+export default function EnsResolverModal({ identity, onClose }) {
+  const [loading, setLoading] = useState(false);
+  const [resolution, setResolution] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!identity || !identity.wallet) {
+      setResolution(null);
+      setError(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    async function hydrate() {
+      setLoading(true);
+      setError(null);
+      try {
+        const target = identity.ens || identity.wallet;
+        const result = await resolveEns(target);
+        if (!cancelled) {
+          setResolution(result);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err.message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    hydrate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [identity]);
+
+  if (!identity) {
+    return null;
+  }
+
+  const displayName = resolution?.name || identity.ens || 'Unregistered ENS';
+  const displayAddress = resolution?.address || identity.wallet;
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal-card">
+        <header className="modal-header">
+          <h3>ENS Identity</h3>
+          <button type="button" className="ghost-button modal-close" onClick={onClose}>
+            Close
+          </button>
+        </header>
+        <div className="modal-body">
+          <p className="modal-field">
+            <span className="label">Wallet</span>
+            <span className="value">{displayAddress}</span>
+          </p>
+          <p className="modal-field">
+            <span className="label">Resolved ENS</span>
+            <span className="value">{displayName}</span>
+          </p>
+          {resolution?.avatar ? (
+            <div className="modal-avatar">
+              <img src={resolution.avatar} alt="ENS avatar" />
+            </div>
+          ) : null}
+          {loading ? <p className="hint">Resolving ENS…</p> : null}
+          {error ? <p className="error-text">{error}</p> : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/MirrorLog.jsx
+++ b/dashboard/src/components/MirrorLog.jsx
@@ -1,35 +1,100 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import EnsResolverModal from './EnsResolverModal.jsx';
 
 export default function MirrorLog({ logs }) {
-  const latest = logs.slice(-8).reverse();
+  const [query, setQuery] = useState('');
+  const [activeIdentity, setActiveIdentity] = useState(null);
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return false;
+    }
+    return window.matchMedia('(max-width: 768px)').matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return () => {};
+    }
+    const media = window.matchMedia('(max-width: 768px)');
+    const listener = (event) => setIsMobile(event.matches);
+    if (media.addEventListener) {
+      media.addEventListener('change', listener);
+    } else {
+      media.addListener(listener);
+    }
+    return () => {
+      if (media.removeEventListener) {
+        media.removeEventListener('change', listener);
+      } else {
+        media.removeListener(listener);
+      }
+    };
+  }, []);
+
+  const filteredLogs = useMemo(() => {
+    const recent = [...logs].slice(-50).reverse();
+    if (!query) {
+      return recent;
+    }
+    const normalized = query.toLowerCase();
+    return recent.filter((entry) => {
+      const haystack = `${entry.wallet || ''} ${entry.ens || ''} ${entry.type || ''}`.toLowerCase();
+      return haystack.includes(normalized);
+    });
+  }, [logs, query]);
+
+  const visibleEntries = useMemo(
+    () => filteredLogs.slice(0, isMobile ? 12 : 20),
+    [filteredLogs, isMobile]
+  );
 
   return (
-    <section className="panel mirror-log">
+    <section className={`panel mirror-log ${isMobile ? 'mirror-log--mobile' : ''}`}>
       <header>
-        <h2>Mirror Reflection Log</h2>
-        <p className="subtitle">Hourly AI resonance of belief signals</p>
+        <div>
+          <h2>Mirror Reflection Log</h2>
+          <p className="subtitle">Hourly AI resonance of belief signals</p>
+        </div>
+        <div className="mirror-log__controls">
+          <input
+            className="mirror-log__search"
+            type="search"
+            value={query}
+            placeholder="Search wallet / ENS / type"
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </div>
       </header>
-      <ul className="log-list">
-        {latest.length ? (
-          latest.map((entry) => (
-            <li key={`${entry.wallet}-${entry.timestamp}`}>
-              <div className="log-primary">
-                <span className="log-wallet">{entry.ens || entry.wallet}</span>
-                <span className={`tier-tag tier-${(entry.tier || 'observer').toLowerCase()}`}>
-                  {entry.tier}
-                </span>
-              </div>
-              <div className="log-secondary">
-                <span>{entry.type}</span>
-                <span>×{entry.multiplier.toFixed(4)}</span>
-                <span>{new Date(entry.timestamp).toLocaleTimeString()}</span>
-              </div>
-            </li>
-          ))
-        ) : (
-          <li>No mirror reflections captured yet.</li>
-        )}
-      </ul>
+      <div className="mirror-log__viewport">
+        <ul className="log-list">
+          {visibleEntries.length ? (
+            visibleEntries.map((entry) => (
+              <li key={`${entry.wallet}-${entry.timestamp}`} className="log-item">
+                <div className="log-primary">
+                  <button
+                    type="button"
+                    className="log-wallet"
+                    onClick={() => setActiveIdentity({ wallet: entry.wallet, ens: entry.ens })}
+                  >
+                    {entry.ens || entry.wallet}
+                  </button>
+                  <span className={`tier-tag tier-${(entry.tier || 'observer').toLowerCase()}`}>
+                    {entry.tier}
+                  </span>
+                </div>
+                <div className="log-secondary">
+                  <span className="log-type">{entry.type}</span>
+                  <span className="log-multiplier">×{entry.multiplier.toFixed(4)}</span>
+                  <span className="log-timestamp">{new Date(entry.timestamp).toLocaleString()}</span>
+                </div>
+              </li>
+            ))
+          ) : (
+            <li>No mirror reflections captured yet.</li>
+          )}
+        </ul>
+      </div>
+      <EnsResolverModal identity={activeIdentity} onClose={() => setActiveIdentity(null)} />
     </section>
   );
 }

--- a/dashboard/src/services/ens.js
+++ b/dashboard/src/services/ens.js
@@ -1,0 +1,36 @@
+const cache = new Map();
+
+export async function resolveEns(target) {
+  if (!target) {
+    return { address: null, name: null, avatar: null };
+  }
+  const key = target.toLowerCase();
+  if (cache.has(key)) {
+    return cache.get(key);
+  }
+
+  const fallback = { address: key, name: null, avatar: null };
+  if (typeof fetch !== 'function') {
+    cache.set(key, fallback);
+    return fallback;
+  }
+
+  try {
+    const response = await fetch(`https://api.ensideas.com/ens/resolve/${encodeURIComponent(key)}`);
+    if (!response.ok) {
+      cache.set(key, fallback);
+      return fallback;
+    }
+    const data = await response.json();
+    const result = {
+      address: (data.address || key || '').toLowerCase(),
+      name: data.name || null,
+      avatar: data.avatar || null,
+    };
+    cache.set(key, result);
+    return result;
+  } catch (error) {
+    cache.set(key, fallback);
+    return fallback;
+  }
+}

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -204,6 +204,23 @@ button:hover {
   gap: 1rem;
 }
 
+.advanced-toggle {
+  margin-top: 0.75rem;
+  align-self: flex-start;
+}
+
+.advanced-grid {
+  margin-top: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.weights-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
 .error-text {
   color: #fda4af;
   font-size: 0.9rem;
@@ -245,6 +262,13 @@ th {
   gap: 0.75rem;
 }
 
+.log-item {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 0.85rem;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
 .log-primary {
   display: flex;
   justify-content: space-between;
@@ -263,6 +287,58 @@ th {
 
 .log-wallet {
   font-size: 0.95rem;
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.log-wallet:hover,
+.log-wallet:focus-visible {
+  color: #5eead4;
+  text-decoration: underline;
+}
+
+.mirror-log__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.mirror-log__search {
+  border-radius: 999px;
+  border: 1px solid rgba(94, 234, 212, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  padding: 0.55rem 1rem;
+  color: inherit;
+  min-width: 220px;
+}
+
+.mirror-log__viewport {
+  margin-top: 1rem;
+  max-height: 380px;
+  overflow-y: auto;
+}
+
+.mirror-log--mobile .mirror-log__viewport {
+  max-height: 460px;
+}
+
+.mirror-log--mobile .log-secondary {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+}
+
+.log-type {
+  text-transform: capitalize;
+}
+
+.log-timestamp {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.6);
 }
 
 .vote-columns {
@@ -293,4 +369,115 @@ textarea::-webkit-scrollbar-thumb,
 .log-list::-webkit-scrollbar-thumb {
   background: rgba(148, 163, 184, 0.3);
   border-radius: 999px;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 7, 18, 0.76);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.modal-card {
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  width: min(400px, 100%);
+  border: 1px solid rgba(94, 234, 212, 0.25);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.55);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.modal-body {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.modal-field {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.modal-field .label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.modal-field .value {
+  font-size: 0.95rem;
+  word-break: break-all;
+}
+
+.modal-avatar {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.modal-avatar img {
+  width: 80px;
+  height: 80px;
+  border-radius: 999px;
+  object-fit: cover;
+  border: 2px solid rgba(94, 234, 212, 0.45);
+}
+
+.modal-close {
+  padding: 0.35rem 0.75rem;
+}
+
+@media (max-width: 960px) {
+  #root {
+    padding: 1.5rem;
+  }
+  .panel {
+    padding: 1.25rem;
+  }
+  .dashboard-meta {
+    flex-wrap: wrap;
+  }
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  #root {
+    padding: 1rem;
+  }
+  .panel header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+  .mirror-log__controls {
+    width: 100%;
+  }
+  .mirror-log__search {
+    width: 100%;
+  }
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .advanced-grid {
+    padding: 0.75rem;
+    background: rgba(15, 23, 42, 0.6);
+    border-radius: 1rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+  }
 }

--- a/frontend/components/Dashboard.jsx
+++ b/frontend/components/Dashboard.jsx
@@ -1,0 +1,606 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+const POLL_INTERVAL_MS = 30_000;
+const ENS_CACHE = new Map();
+const MOBILE_BREAKPOINT = 768;
+
+const styles = {
+  container: {
+    padding: '1rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1rem',
+    maxWidth: '1200px',
+    margin: '0 auto',
+  },
+  headerCard: {
+    background: 'rgba(15, 23, 42, 0.8)',
+    borderRadius: '18px',
+    color: '#f8fafc',
+    padding: '1.25rem',
+    boxShadow: '0 12px 30px rgba(15, 23, 42, 0.35)',
+  },
+  summaryRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '1rem',
+  },
+  summaryTile: {
+    flex: '1 1 120px',
+    background: 'rgba(30, 41, 59, 0.7)',
+    borderRadius: '14px',
+    padding: '0.75rem 1rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.25rem',
+  },
+  pill: {
+    padding: '0.35rem 0.75rem',
+    borderRadius: '999px',
+    fontSize: '0.85rem',
+    background: 'rgba(56, 189, 248, 0.2)',
+    color: '#38bdf8',
+    width: 'fit-content',
+  },
+  grid: (isMobile) => ({
+    display: 'grid',
+    gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr',
+    gap: '1rem',
+  }),
+  card: {
+    background: 'rgba(15, 23, 42, 0.85)',
+    color: '#f1f5f9',
+    borderRadius: '18px',
+    padding: '1rem',
+    minHeight: '220px',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  sectionTitle: {
+    fontSize: '1.1rem',
+    fontWeight: 600,
+    marginBottom: '0.5rem',
+  },
+  list: {
+    flex: '1 1 auto',
+    overflowY: 'auto',
+    WebkitOverflowScrolling: 'touch',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+  },
+  listItem: {
+    background: 'rgba(30, 41, 59, 0.65)',
+    borderRadius: '14px',
+    padding: '0.75rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.35rem',
+  },
+  toolbar: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.5rem',
+    marginBottom: '0.5rem',
+  },
+  input: {
+    flex: '1 1 220px',
+    borderRadius: '12px',
+    border: '1px solid rgba(148, 163, 184, 0.4)',
+    background: 'rgba(15, 23, 42, 0.65)',
+    color: '#f8fafc',
+    padding: '0.5rem 0.75rem',
+  },
+  button: {
+    borderRadius: '12px',
+    border: 'none',
+    padding: '0.5rem 1rem',
+    background: 'linear-gradient(135deg, #38bdf8, #818cf8)',
+    color: '#0f172a',
+    fontWeight: 600,
+    cursor: 'pointer',
+  },
+  mutedButton: {
+    borderRadius: '12px',
+    border: '1px solid rgba(148, 163, 184, 0.4)',
+    padding: '0.45rem 1rem',
+    background: 'transparent',
+    color: '#e2e8f0',
+    fontWeight: 500,
+    cursor: 'pointer',
+  },
+  badgeRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.35rem',
+    alignItems: 'center',
+  },
+  validation: (hasIssues) => ({
+    borderRadius: '16px',
+    padding: '0.75rem 1rem',
+    background: hasIssues ? 'rgba(248, 113, 113, 0.15)' : 'rgba(34, 197, 94, 0.15)',
+    color: hasIssues ? '#fca5a5' : '#bbf7d0',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.35rem',
+  }),
+  fallbackCard: {
+    borderRadius: '16px',
+    padding: '0.75rem 1rem',
+    background: 'rgba(248, 113, 113, 0.18)',
+    color: '#fecaca',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.45rem',
+  },
+  modalBackdrop: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    background: 'rgba(15, 23, 42, 0.65)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '1.5rem',
+    zIndex: 1000,
+  },
+  modalCard: {
+    background: 'rgba(15, 23, 42, 0.95)',
+    borderRadius: '18px',
+    padding: '1.25rem',
+    maxWidth: '420px',
+    width: '100%',
+    color: '#f8fafc',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.65rem',
+  },
+};
+
+async function fetchStatus(signal) {
+  const response = await fetch('/vaultfire/sync-status', { signal });
+  if (!response.ok) {
+    throw new Error(`Sync status request failed with code ${response.status}`);
+  }
+  return response.json();
+}
+
+async function resolveEns(target) {
+  if (!target) {
+    return { address: null, name: null, avatar: null };
+  }
+
+  const key = target.toLowerCase();
+  if (ENS_CACHE.has(key)) {
+    return ENS_CACHE.get(key);
+  }
+
+  if (typeof fetch !== 'function') {
+    const fallback = { address: key, name: null, avatar: null };
+    ENS_CACHE.set(key, fallback);
+    return fallback;
+  }
+
+  try {
+    const response = await fetch(`https://api.ensideas.com/ens/resolve/${encodeURIComponent(key)}`);
+    if (!response.ok) {
+      const fallback = { address: key, name: null, avatar: null };
+      ENS_CACHE.set(key, fallback);
+      return fallback;
+    }
+    const data = await response.json();
+    const result = {
+      address: (data.address || key || '').toLowerCase(),
+      name: data.name || null,
+      avatar: data.avatar || null,
+    };
+    ENS_CACHE.set(key, result);
+    return result;
+  } catch (error) {
+    const fallback = { address: key, name: null, avatar: null };
+    ENS_CACHE.set(key, fallback);
+    return fallback;
+  }
+}
+
+function hasDisallowedIdentityKeys(record) {
+  if (!record || typeof record !== 'object') {
+    return false;
+  }
+  const bannedKeys = ['email', 'name', 'kyc', 'identity', 'userId'];
+  return Object.keys(record).some((key) => bannedKeys.includes(key.toLowerCase()));
+}
+
+function ensureMetricsShape(metrics) {
+  if (!metrics || typeof metrics !== 'object') {
+    return false;
+  }
+  const required = ['loyalty', 'ethics', 'frequency', 'alignment', 'holdDuration'];
+  return required.every((field) => metrics[field] !== undefined && metrics[field] !== null);
+}
+
+function evaluateBeliefRules(status) {
+  if (!status) {
+    return [];
+  }
+
+  const issues = [];
+  const partners = Array.isArray(status.partners) ? status.partners : [];
+  partners.forEach((partner) => {
+    if (!partner.wallet) {
+      issues.push({
+        scope: 'partner',
+        message: 'Partner record missing wallet identity.',
+      });
+    }
+    if (hasDisallowedIdentityKeys(partner)) {
+      issues.push({
+        scope: 'partner',
+        message: 'Partner payload contains disallowed identity metadata.',
+      });
+    }
+    const metrics = partner?.payload?.metrics;
+    if (!ensureMetricsShape(metrics)) {
+      issues.push({
+        scope: 'partner',
+        message: `Metrics missing for ${partner.wallet || partner.ens || 'partner record'}.`,
+      });
+    }
+  });
+
+  const logs = Array.isArray(status.mirrorLog) ? status.mirrorLog : [];
+  logs.forEach((entry) => {
+    if (!ensureMetricsShape(entry.metrics)) {
+      issues.push({
+        scope: 'telemetry',
+        message: `Telemetry entry ${entry.timestamp} missing full metric set.`,
+      });
+    }
+    if (hasDisallowedIdentityKeys(entry)) {
+      issues.push({
+        scope: 'telemetry',
+        message: 'Telemetry entry contains disallowed identity fields.',
+      });
+    }
+  });
+
+  const votes = Array.isArray(status.votes) ? status.votes : [];
+  votes.forEach((vote) => {
+    if (!vote.wallet) {
+      issues.push({ scope: 'votes', message: 'Vote record missing wallet reference.' });
+    }
+    if (hasDisallowedIdentityKeys(vote)) {
+      issues.push({ scope: 'votes', message: 'Vote record contains disallowed identity fields.' });
+    }
+  });
+
+  return issues;
+}
+
+function formatTimestamp(timestamp) {
+  if (!timestamp) {
+    return '—';
+  }
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return timestamp;
+  }
+  return date.toLocaleString();
+}
+
+function EnsModal({ request, onClose }) {
+  if (!request) {
+    return null;
+  }
+  return (
+    <div style={styles.modalBackdrop} onClick={onClose} role="presentation">
+      <div style={styles.modalCard} onClick={(event) => event.stopPropagation()} role="dialog">
+        <h3 style={{ fontSize: '1.1rem', fontWeight: 600 }}>ENS Resolution</h3>
+        {request.loading ? (
+          <p>Resolving ENS metadata…</p>
+        ) : request.error ? (
+          <p style={{ color: '#fecaca' }}>{request.error}</p>
+        ) : (
+          <>
+            <p style={{ fontFamily: 'monospace' }}>{request.address}</p>
+            {request.name ? <p>Primary ENS: {request.name}</p> : <p>No ENS record detected.</p>}
+            {request.avatar ? (
+              <img
+                src={request.avatar}
+                alt="ENS avatar"
+                style={{ width: '96px', height: '96px', borderRadius: '16px' }}
+              />
+            ) : null}
+          </>
+        )}
+        <button type="button" style={styles.button} onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function Dashboard() {
+  const [status, setStatus] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [filter, setFilter] = useState('');
+  const [ensLookup, setEnsLookup] = useState(null);
+  const [validationIssues, setValidationIssues] = useState([]);
+  const [isMobile, setIsMobile] = useState(
+    () => (typeof window !== 'undefined' ? window.innerWidth <= MOBILE_BREAKPOINT : true)
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return () => {};
+    }
+    const handler = () => {
+      setIsMobile(window.innerWidth <= MOBILE_BREAKPOINT);
+    };
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
+
+  useEffect(() => {
+    let timer;
+    const controller = new AbortController();
+
+    const loadStatus = async () => {
+      try {
+        setLoading(true);
+        const payload = await fetchStatus(controller.signal);
+        setStatus(payload);
+        setValidationIssues(evaluateBeliefRules(payload));
+        setError('');
+      } catch (err) {
+        if (err.name !== 'AbortError') {
+          setError(err.message || 'Failed to load belief sync status.');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadStatus();
+    timer = setInterval(loadStatus, POLL_INTERVAL_MS);
+
+    return () => {
+      controller.abort();
+      clearInterval(timer);
+    };
+  }, []);
+
+  const partners = useMemo(() => {
+    const list = Array.isArray(status?.partners) ? status.partners : [];
+    if (!filter) {
+      return list;
+    }
+    const lower = filter.toLowerCase();
+    return list.filter((partner) => {
+      return (
+        partner.wallet?.toLowerCase().includes(lower) ||
+        (partner.ens && partner.ens.toLowerCase().includes(lower))
+      );
+    });
+  }, [status, filter]);
+
+  const logs = useMemo(() => {
+    const list = Array.isArray(status?.mirrorLog) ? status.mirrorLog : [];
+    if (!filter) {
+      return list;
+    }
+    const lower = filter.toLowerCase();
+    return list.filter((entry) => {
+      return (
+        entry.wallet?.toLowerCase().includes(lower) ||
+        (entry.ens && entry.ens.toLowerCase().includes(lower))
+      );
+    });
+  }, [status, filter]);
+
+  const summary = status?.summary;
+  const validationOk = !validationIssues.length;
+
+  const openEnsModal = async (target) => {
+    setEnsLookup({ loading: true });
+    try {
+      const record = await resolveEns(target);
+      setEnsLookup({ loading: false, ...record });
+    } catch (err) {
+      setEnsLookup({ loading: false, error: err.message });
+    }
+  };
+
+  const closeEnsModal = () => setEnsLookup(null);
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.headerCard}>
+        <div style={styles.summaryRow}>
+          <div style={styles.summaryTile}>
+            <span>Belief Score</span>
+            <strong style={{ fontSize: '1.35rem' }}>
+              {summary?.beliefScore ? summary.beliefScore.toFixed(3) : '—'}
+            </strong>
+          </div>
+          <div style={styles.summaryTile}>
+            <span>Active Partners</span>
+            <strong style={{ fontSize: '1.35rem' }}>{summary?.totalPartners ?? '—'}</strong>
+          </div>
+          <div style={styles.summaryTile}>
+            <span>Healthy Partners</span>
+            <strong style={{ fontSize: '1.35rem' }}>{summary?.healthyPartners ?? '—'}</strong>
+          </div>
+          <div style={styles.summaryTile}>
+            <span>Tier</span>
+            <strong style={{ fontSize: '1.35rem' }}>{summary?.tier ?? '—'}</strong>
+          </div>
+        </div>
+        <div style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <div style={styles.validation(!validationOk)}>
+            <div style={styles.badgeRow}>
+              <span style={styles.pill}>{validationOk ? 'Belief aligned' : 'Validation alerts'}</span>
+              {loading ? <span>Checking…</span> : null}
+            </div>
+            {validationOk ? (
+              <p style={{ margin: 0 }}>✅ Belief-Aligned: No digital ID detected. Wallet-native only.</p>
+            ) : (
+              <ul style={{ paddingLeft: '1.25rem', margin: 0, display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+                {validationIssues.map((issue, index) => (
+                  <li key={`${issue.scope}-${index}`}>{issue.message}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+          {error ? (
+            <div style={styles.fallbackCard}>
+              <strong>Mobile sync warning</strong>
+              <p style={{ margin: 0 }}>{error}</p>
+              <p style={{ margin: 0 }}>
+                Retry the request or run <code>node tools/mobile_pr_helper.js --prepare-pr</code> from a trusted
+                device to draft the PR manually.
+              </p>
+              <div style={styles.badgeRow}>
+                <button type="button" style={styles.button} onClick={() => window.location.reload()}>
+                  Retry
+                </button>
+                <button
+                  type="button"
+                  style={styles.mutedButton}
+                  onClick={() => openEnsModal(filter || 'vaultfire.eth')}
+                >
+                  Test ENS Fallback
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div style={styles.toolbar}>
+        <input
+          style={styles.input}
+          value={filter}
+          placeholder="Search wallet or ENS"
+          onChange={(event) => setFilter(event.target.value)}
+        />
+        <button type="button" style={styles.mutedButton} onClick={() => openEnsModal(filter)}>
+          Resolve ENS
+        </button>
+        <button type="button" style={styles.mutedButton} onClick={() => setValidationIssues(evaluateBeliefRules(status))}>
+          Re-run validation
+        </button>
+      </div>
+
+      <div style={styles.grid(isMobile)}>
+        <div style={styles.card}>
+          <h2 style={styles.sectionTitle}>Partners</h2>
+          <div style={styles.list}>
+            {loading && !partners.length ? (
+              <p>Loading partners…</p>
+            ) : partners.length ? (
+              partners.map((partner) => (
+                <div key={`${partner.wallet}-${partner.lastSync}`} style={styles.listItem}>
+                  <div style={styles.badgeRow}>
+                    <button
+                      type="button"
+                      style={styles.mutedButton}
+                      onClick={() => openEnsModal(partner.wallet)}
+                    >
+                      {partner.wallet}
+                    </button>
+                    {partner.ens ? <span style={styles.pill}>{partner.ens}</span> : null}
+                    <span style={styles.pill}>Tier {partner.tier}</span>
+                  </div>
+                  <span>Multiplier: {partner.multiplier?.toFixed?.(3) ?? partner.multiplier ?? '—'}</span>
+                  <span>Last Sync: {formatTimestamp(partner.lastSync)}</span>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.35rem', fontSize: '0.85rem' }}>
+                    {partner?.payload?.metrics ? (
+                      Object.entries(partner.payload.metrics).map(([key, value]) => (
+                        <span key={key} style={styles.pill}>
+                          {key}: {value}
+                        </span>
+                      ))
+                    ) : (
+                      <span>No metrics supplied</span>
+                    )}
+                  </div>
+                  {partner.configOverrides ? (
+                    <span style={{ color: '#fcd34d' }}>Scoring override detected</span>
+                  ) : null}
+                </div>
+              ))
+            ) : (
+              <p>No partners synced yet.</p>
+            )}
+          </div>
+        </div>
+
+        <div style={styles.card}>
+          <h2 style={styles.sectionTitle}>Telemetry</h2>
+          <div style={styles.list}>
+            {loading && !logs.length ? (
+              <p>Loading telemetry…</p>
+            ) : logs.length ? (
+              logs.map((entry) => (
+                <div key={`${entry.wallet}-${entry.timestamp}`} style={styles.listItem}>
+                  <div style={styles.badgeRow}>
+                    <button
+                      type="button"
+                      style={styles.mutedButton}
+                      onClick={() => openEnsModal(entry.wallet)}
+                    >
+                      {entry.wallet}
+                    </button>
+                    {entry.ens ? <span style={styles.pill}>{entry.ens}</span> : null}
+                    <span style={styles.pill}>{entry.type}</span>
+                  </div>
+                  <span>Multiplier: {entry.multiplier}</span>
+                  <span>Tier: {entry.tier}</span>
+                  <span>Timestamp: {formatTimestamp(entry.timestamp)}</span>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.35rem', fontSize: '0.8rem' }}>
+                    {entry.metrics ? (
+                      Object.entries(entry.metrics).map(([key, value]) => (
+                        <span key={key} style={styles.pill}>
+                          {key}: {value}
+                        </span>
+                      ))
+                    ) : (
+                      <span>No metrics attached</span>
+                    )}
+                  </div>
+                  {entry.overrides?.length ? (
+                    <span style={{ color: '#fbbf24' }}>
+                      Overrides: {entry.overrides.join(', ')}
+                    </span>
+                  ) : null}
+                </div>
+              ))
+            ) : (
+              <p>No telemetry entries available.</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <EnsModal
+        request={
+          ensLookup
+            ? {
+                loading: ensLookup.loading,
+                error: ensLookup.error,
+                address: ensLookup.address,
+                name: ensLookup.name,
+                avatar: ensLookup.avatar,
+              }
+            : null
+        }
+        onClose={closeEnsModal}
+      />
+    </div>
+  );
+}

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+printf '%s\n' '🔒 Vaultfire pre-push verification in progress...'
+
+npm run lint:guardrails
+npx tsc --noEmit
+node tools/belief_rule_validator.js
+node tools/mobile_pr_helper.js --prepare
+
+printf '%s\n' '✅ Pre-push checks complete.'

--- a/mirror/belief-weight.js
+++ b/mirror/belief-weight.js
@@ -5,6 +5,14 @@ const ACTION_BASELINES = {
   partnerSync: 1.15,
 };
 
+const DEFAULT_WEIGHTS = {
+  loyalty: 0.4,
+  ethics: 0.3,
+  frequency: 0.15,
+  alignment: 0.1,
+  holdDuration: 0.05,
+};
+
 const TIER_THRESHOLDS = [
   { name: 'Mythic', min: 1.6 },
   { name: 'Ascendant', min: 1.3 },
@@ -37,22 +45,72 @@ function baseMultiplierFor(actionType) {
   return ACTION_BASELINES[actionType] || 1.02;
 }
 
-function computeBeliefMultiplier(actionType, metrics = {}) {
+function applyWeightOverrides(config) {
+  const overrides = config?.weights || null;
+  if (!overrides) {
+    return { weights: { ...DEFAULT_WEIGHTS }, overrides: [] };
+  }
+
+  const weights = { ...DEFAULT_WEIGHTS };
+  const changed = [];
+  for (const [key, value] of Object.entries(overrides)) {
+    if (weights[key] === undefined) {
+      // Ignore unsupported metric keys
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    const numeric = Number(value);
+    if (Number.isFinite(numeric) && numeric >= 0) {
+      weights[key] = numeric;
+      changed.push(`weights.${key}`);
+    }
+  }
+
+  const total = Object.values(weights).reduce((acc, weight) => acc + weight, 0) || 1;
+  const normalized = Object.fromEntries(
+    Object.entries(weights).map(([key, weight]) => [key, Number((weight / total).toFixed(6))])
+  );
+
+  return { weights: normalized, overrides: changed };
+}
+
+function resolveBaseline(actionType, config) {
+  const base = baseMultiplierFor(actionType);
+  if (!config || config.baselineMultiplier === undefined) {
+    return { baseline: base, overrides: [] };
+  }
+  const override = Number(config.baselineMultiplier);
+  if (!Number.isFinite(override) || override <= 0) {
+    return { baseline: base, overrides: [] };
+  }
+  return { baseline: override, overrides: ['baselineMultiplier'] };
+}
+
+function computeBeliefMultiplier(actionType, metrics = {}, config = {}) {
   const loyalty = normalize(metrics.loyalty);
   const ethics = normalize(metrics.ethics);
   const frequency = normalize(metrics.frequency ?? metrics.interactionFrequency);
   const alignment = normalize(metrics.alignment ?? metrics.partnerAlignment);
   const duration = normalize(metrics.holdDuration ?? metrics.holdDurationDays);
 
-  const base = baseMultiplierFor(actionType);
-  const loyaltySignal = loyalty * 0.4;
-  const ethicsSignal = ethics * 0.3;
-  const frequencySignal = frequency * 0.15;
-  const alignmentSignal = alignment * 0.1;
-  const durationSignal = duration * 0.05;
+  const { weights, overrides: weightOverrides } = applyWeightOverrides(config);
+  const { baseline, overrides: baselineOverrides } = resolveBaseline(actionType, config);
 
-  const multiplier = base + loyaltySignal + ethicsSignal + frequencySignal + alignmentSignal + durationSignal;
-  return Number(multiplier.toFixed(4));
+  const multiplier =
+    baseline +
+    loyalty * weights.loyalty +
+    ethics * weights.ethics +
+    frequency * weights.frequency +
+    alignment * weights.alignment +
+    duration * weights.holdDuration;
+
+  return {
+    multiplier: Number(multiplier.toFixed(4)),
+    weights,
+    baseline,
+    overridesDetected: Boolean(weightOverrides.length || baselineOverrides.length),
+    overrides: [...weightOverrides, ...baselineOverrides],
+  };
 }
 
 function determineTier(multiplier) {
@@ -68,4 +126,5 @@ module.exports = {
   computeBeliefMultiplier,
   determineTier,
   baseMultiplierFor,
+  DEFAULT_WEIGHTS,
 };

--- a/mirror/engine.js
+++ b/mirror/engine.js
@@ -1,12 +1,17 @@
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
+const zlib = require('zlib');
 const { computeBeliefMultiplier, determineTier } = require('./belief-weight');
+const { assertWalletOnlyData } = require('../utils/identityGuards');
 
 class BeliefMirrorEngine {
-  constructor({ telemetryPath } = {}) {
+  constructor({ telemetryPath, rotationDays = 7, archiveDir } = {}) {
     this.telemetryPath =
       telemetryPath || path.join(__dirname, '..', 'telemetry', 'belief-log.json');
     this.ensureTelemetryFile();
+    this.archiveDir = archiveDir || path.join(path.dirname(this.telemetryPath), 'archive');
+    this.rotationWindowMs = rotationDays * 24 * 60 * 60 * 1000;
   }
 
   ensureTelemetryFile() {
@@ -19,6 +24,46 @@ class BeliefMirrorEngine {
     }
   }
 
+  #writeLog(entries) {
+    fs.writeFileSync(this.telemetryPath, JSON.stringify(entries, null, 2));
+  }
+
+  #archiveLog(entries) {
+    if (!entries.length) {
+      return;
+    }
+    const oldest = Date.parse(entries[0].timestamp);
+    const latest = Date.parse(entries[entries.length - 1].timestamp);
+    if (!Number.isFinite(oldest) || !Number.isFinite(latest)) {
+      return;
+    }
+    const serialized = JSON.stringify(entries, null, 2);
+    const hash = crypto.createHash('sha256').update(serialized).digest('hex').slice(0, 16);
+    const start = new Date(oldest).toISOString().split('T')[0];
+    const end = new Date(latest).toISOString().split('T')[0];
+    fs.mkdirSync(this.archiveDir, { recursive: true });
+    const archivePath = path.join(this.archiveDir, `${start}_${end}_${hash}.json.gz`);
+    fs.writeFileSync(archivePath, zlib.gzipSync(serialized));
+  }
+
+  #rotateIfNeeded(entries, currentTimestamp) {
+    if (!entries.length) {
+      return entries;
+    }
+    const firstTimestamp = Date.parse(entries[0].timestamp);
+    const latestTimestamp = Date.parse(currentTimestamp || entries[entries.length - 1].timestamp);
+    if (!Number.isFinite(firstTimestamp) || !Number.isFinite(latestTimestamp)) {
+      return entries;
+    }
+
+    if (latestTimestamp - firstTimestamp >= this.rotationWindowMs) {
+      this.#archiveLog(entries);
+      this.#writeLog([]);
+      return [];
+    }
+    return entries;
+  }
+
   readLog() {
     const raw = fs.readFileSync(this.telemetryPath, 'utf8');
     try {
@@ -28,10 +73,19 @@ class BeliefMirrorEngine {
     }
   }
 
+  readRecentEntries(limit = 50) {
+    const log = this.readLog();
+    if (!limit || limit >= log.length) {
+      return log;
+    }
+    return log.slice(-limit);
+  }
+
   async appendEntry(entry) {
     const log = this.readLog();
-    log.push(entry);
-    fs.writeFileSync(this.telemetryPath, JSON.stringify(log, null, 2));
+    const rotatedLog = this.#rotateIfNeeded(log, entry.timestamp);
+    rotatedLog.push(entry);
+    this.#writeLog(rotatedLog);
     return entry;
   }
 
@@ -39,7 +93,10 @@ class BeliefMirrorEngine {
     const timestamp = new Date().toISOString();
     const type = action.type || 'partnerSync';
     const metrics = action.metrics || {};
-    const multiplier = computeBeliefMultiplier(type, metrics);
+    assertWalletOnlyData({ wallet: action.wallet, ens: action.ens }, { context: 'action.identity' });
+
+    const result = computeBeliefMultiplier(type, metrics, action.scoringConfig);
+    const multiplier = result.multiplier;
     const tier = determineTier(multiplier);
 
     return {
@@ -51,6 +108,12 @@ class BeliefMirrorEngine {
       metrics,
       origin: action.origin || 'mirror-engine',
       timestamp,
+      configOverrides: result.overridesDetected,
+      scoring: {
+        weights: result.weights,
+        baseline: result.baseline,
+        overrides: result.overrides,
+      },
     };
   }
 
@@ -133,6 +196,54 @@ class BeliefMirrorEngine {
       }
     }
     return null;
+  }
+
+  exportLogs(filters = {}) {
+    const {
+      from,
+      to,
+      wallet,
+      ens,
+      type,
+      limit = 200,
+    } = filters;
+    const lowerWallet = wallet ? wallet.toLowerCase() : null;
+    const lowerEns = ens ? ens.toLowerCase() : null;
+    const fromTime = from ? Date.parse(from) : null;
+    const toTime = to ? Date.parse(to) : null;
+
+    const entries = this.readLog().filter((entry) => {
+      const entryTime = Date.parse(entry.timestamp);
+      if (Number.isFinite(fromTime) && (!Number.isFinite(entryTime) || entryTime < fromTime)) {
+        return false;
+      }
+      if (Number.isFinite(toTime) && (!Number.isFinite(entryTime) || entryTime > toTime)) {
+        return false;
+      }
+      if (lowerWallet && entry.wallet?.toLowerCase() !== lowerWallet) {
+        return false;
+      }
+      if (lowerEns && (!entry.ens || entry.ens.toLowerCase() !== lowerEns)) {
+        return false;
+      }
+      if (type && entry.type !== type) {
+        return false;
+      }
+      return true;
+    });
+
+    const sliced = limit ? entries.slice(-limit) : entries;
+    return sliced.map((entry) => ({
+      wallet: entry.wallet,
+      ens: entry.ens,
+      multiplier: entry.multiplier,
+      tier: entry.tier,
+      type: entry.type,
+      timestamp: entry.timestamp,
+      metrics: entry.metrics,
+      configOverrides: Boolean(entry.configOverrides),
+      overrides: entry.scoring?.overrides || [],
+    }));
   }
 }
 

--- a/partnerSync.js
+++ b/partnerSync.js
@@ -4,33 +4,37 @@ const rateLimit = require('express-rate-limit');
 const fetch = require('node-fetch');
 const { Server } = require('socket.io');
 const path = require('path');
-const fs = require('fs');
 const { BeliefMirrorEngine } = require('./mirror/engine');
 const { determineTier } = require('./mirror/belief-weight');
 const { verifyWalletSignature } = require('./utils/walletAuth');
+const { createPartnerStorage } = require('./services/partnerStorage');
+const { VoteRepository } = require('./services/voteRepository');
+const { assertWalletOnlyData } = require('./utils/identityGuards');
+const {
+  ValidationError,
+  extractMetrics,
+  sanitizeScoringConfig,
+} = require('./utils/scoringValidator');
 
-function safeReadJson(filePath, fallback = []) {
-  if (!fs.existsSync(filePath)) {
-    fs.writeFileSync(filePath, JSON.stringify(fallback, null, 2));
-    return Array.isArray(fallback) ? [...fallback] : { ...fallback };
-  }
-
-  const raw = fs.readFileSync(filePath, 'utf8');
-  try {
-    return JSON.parse(raw);
-  } catch (error) {
-    throw new Error(`Unable to parse ${path.basename(filePath)}: ${error.message}`);
-  }
-}
-
-function safeWriteJson(filePath, payload) {
-  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2));
+function sanitizeVotePayload(vote) {
+  assertWalletOnlyData(vote, { context: 'vote' });
+  return {
+    proposalId: vote.proposalId,
+    choice: vote.choice,
+    wallet: vote.wallet,
+    ens: vote.ens || null,
+    weight: vote.weight,
+    tier: vote.tier,
+    timestamp: vote.timestamp,
+    messageDigest: vote.messageDigest,
+  };
 }
 
 function createPartnerSyncServer({
   webhookTargets = [],
   telemetryPath,
   votesPath,
+  storageOptions = {},
 } = {}) {
   const app = express();
   const httpServer = http.createServer(app);
@@ -39,11 +43,18 @@ function createPartnerSyncServer({
   });
 
   const engine = new BeliefMirrorEngine({ telemetryPath });
-  const partnerStore = new Map();
   const resolvedVotesPath = votesPath || path.join(__dirname, 'votes.json');
-  if (!fs.existsSync(resolvedVotesPath)) {
-    fs.writeFileSync(resolvedVotesPath, JSON.stringify([], null, 2));
-  }
+  const partnerStorage = createPartnerStorage({
+    sqlite: {
+      dbPath: path.join(__dirname, 'data', 'partner-sync.db'),
+      ...(storageOptions.sqlite || {}),
+    },
+    adapter: storageOptions.adapter,
+    provider: storageOptions.provider,
+    readOnly: storageOptions.readOnly,
+    localforage: storageOptions.localforage,
+  });
+  const voteRepository = new VoteRepository({ filePath: resolvedVotesPath });
 
   const limiter = rateLimit({
     windowMs: 60 * 1000,
@@ -95,34 +106,31 @@ function createPartnerSyncServer({
     };
   }
 
-  function loadVotes() {
-    return safeReadJson(resolvedVotesPath, []);
+  async function loadVotes() {
+    return voteRepository.loadVotes();
   }
 
-  function appendVote(vote) {
-    const votes = loadVotes();
-    votes.push(vote);
-    safeWriteJson(resolvedVotesPath, votes);
-    return votes;
+  async function appendVote(vote) {
+    const sanitized = sanitizeVotePayload(vote);
+    await voteRepository.appendVote(sanitized);
+    return voteRepository.loadVotes();
   }
 
   app.post('/vaultfire/sync-belief', async (req, res) => {
     try {
       const { wallet, signature, message, ens, payload = {} } = req.body || {};
+      assertWalletOnlyData(payload, { context: 'payload' });
       const verified = verifyWalletSignature({ wallet, signature, message, ens });
+      const metrics = extractMetrics(payload);
+      const scoringConfig = sanitizeScoringConfig(payload.scoringConfig);
 
       const action = {
         wallet: verified.wallet,
         ens: verified.ens,
         type: 'partnerSync',
         origin: 'partner-sync-interface',
-        metrics: {
-          loyalty: payload.loyalty ?? payload.loyaltyScore ?? 75,
-          ethics: payload.ethics ?? payload.ethicsScore ?? 80,
-          frequency: payload.interactionFrequency ?? payload.frequency ?? 60,
-          alignment: payload.partnerAlignment ?? payload.alignment ?? 70,
-          holdDuration: payload.holdDuration ?? payload.holdDurationDays ?? 40,
-        },
+        metrics,
+        scoringConfig,
       };
 
       const entry = await engine.processAction(action);
@@ -133,16 +141,21 @@ function createPartnerSyncServer({
         multiplier: entry.multiplier,
         tier: entry.tier,
         status: 'healthy',
-        payload,
+        payload: {
+          metrics,
+          scoringConfig,
+        },
+        configOverrides: Boolean(entry.configOverrides),
       };
 
-      partnerStore.set(entry.wallet.toLowerCase(), partnerRecord);
+      await partnerStorage.savePartner(partnerRecord);
 
       const responsePayload = {
         ok: true,
         status: 'synced',
         entry,
         tier: entry.tier,
+        overridesDetected: Boolean(entry.configOverrides),
       };
 
       io.emit('belief-sync', { type: 'partnerSync', entry: partnerRecord });
@@ -153,23 +166,33 @@ function createPartnerSyncServer({
 
       res.json(responsePayload);
     } catch (error) {
-      res.status(401).json({ error: { message: error.message } });
+      const statusCode = error.statusCode || (error.message && error.message.includes('Signature') ? 401 : 400);
+      res.status(statusCode).json({
+        error: {
+          message: error.message,
+          details: error instanceof ValidationError ? error.details : undefined,
+        },
+      });
     }
   });
 
-  app.get('/vaultfire/sync-status', (req, res) => {
-    const partners = Array.from(partnerStore.values());
-    const summary = buildSummary(partners);
-    const mirrorLog = engine.readLog().slice(-50);
-    const votes = loadVotes();
+  app.get('/vaultfire/sync-status', async (req, res) => {
+    try {
+      const partners = await partnerStorage.listPartners();
+      const summary = buildSummary(partners);
+      const mirrorLog = engine.readRecentEntries(50);
+      const votes = await loadVotes();
 
-    res.json({
-      system: partners.length ? 'operational' : 'awaiting_sync',
-      summary,
-      partners,
-      mirrorLog,
-      votes,
-    });
+      res.json({
+        system: partners.length ? 'operational' : 'awaiting_sync',
+        summary,
+        partners,
+        mirrorLog,
+        votes,
+      });
+    } catch (error) {
+      res.status(500).json({ error: { message: error.message } });
+    }
   });
 
   const start = ({ port = 4050 } = {}) =>
@@ -194,7 +217,7 @@ function createPartnerSyncServer({
     stop,
     appendVote,
     loadVotes,
-    partnerStore,
+    partnerStorage,
     engine,
   };
 }

--- a/services/partnerStorage.js
+++ b/services/partnerStorage.js
@@ -1,0 +1,232 @@
+const fs = require('fs');
+const path = require('path');
+const { normalizeWallet } = require('../utils/walletAuth');
+
+function safeRequire(moduleName) {
+  try {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    return require(moduleName);
+  } catch (error) {
+    if (error && error.code === 'MODULE_NOT_FOUND') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+class BasePartnerStorage {
+  constructor({ readOnly = false } = {}) {
+    this.readOnly = readOnly;
+  }
+
+  async init() {
+    return undefined;
+  }
+
+  async listPartners() {
+    throw new Error('listPartners not implemented');
+  }
+
+  async getPartner(wallet) {
+    const partners = await this.listPartners();
+    return partners.find((item) => item.wallet.toLowerCase() === wallet.toLowerCase()) || null;
+  }
+
+  async savePartner() {
+    throw new Error('savePartner not implemented');
+  }
+}
+
+class MemoryPartnerStorage extends BasePartnerStorage {
+  constructor({ readOnly = true } = {}) {
+    super({ readOnly });
+    this.partners = new Map();
+    this.warned = false;
+  }
+
+  #warnIfEphemeral() {
+    if (!this.readOnly || this.warned) {
+      return;
+    }
+    this.warned = true;
+    // eslint-disable-next-line no-console
+    console.warn('Vaultfire partner storage running in read-only memory mode. State will not persist.');
+  }
+
+  async listPartners() {
+    return Array.from(this.partners.values());
+  }
+
+  async savePartner(record) {
+    this.#warnIfEphemeral();
+    this.partners.set(record.wallet.toLowerCase(), { ...record });
+    return record;
+  }
+}
+
+class SQLitePartnerStorage extends BasePartnerStorage {
+  constructor(options = {}) {
+    super({ readOnly: false });
+    this.dbPath = options.dbPath || path.join(__dirname, '..', 'data', 'partner-sync.db');
+    this.sqlite3 = safeRequire('sqlite3');
+    if (!this.sqlite3) {
+      throw new Error('sqlite3 dependency is required for SQLitePartnerStorage.');
+    }
+    this.db = null;
+  }
+
+  async init() {
+    if (this.db) return;
+    const dir = path.dirname(this.dbPath);
+    fs.mkdirSync(dir, { recursive: true });
+    await new Promise((resolve, reject) => {
+      const Database = this.sqlite3.Database;
+      this.db = new Database(this.dbPath, (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+    await this.#run('PRAGMA journal_mode = WAL;');
+    await this.#run(`
+      CREATE TABLE IF NOT EXISTS partners (
+        wallet TEXT PRIMARY KEY,
+        ens TEXT,
+        last_sync TEXT,
+        multiplier REAL NOT NULL,
+        tier TEXT NOT NULL,
+        status TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        config_overrides INTEGER DEFAULT 0,
+        inserted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+  }
+
+  async #run(sql, params = []) {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      this.db.run(sql, params, function onRun(err) {
+        if (err) reject(err);
+        else resolve(this);
+      });
+    });
+  }
+
+  async #all(sql, params = []) {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      this.db.all(sql, params, (err, rows) => {
+        if (err) reject(err);
+        else resolve(rows);
+      });
+    });
+  }
+
+  async listPartners() {
+    const rows = await this.#all(
+      'SELECT wallet, ens, last_sync as lastSync, multiplier, tier, status, payload, config_overrides as configOverrides FROM partners ORDER BY datetime(last_sync) DESC'
+    );
+    return rows.map((row) => ({
+      wallet: row.wallet,
+      ens: row.ens,
+      lastSync: row.lastSync,
+      multiplier: Number(row.multiplier),
+      tier: row.tier,
+      status: row.status,
+      payload: JSON.parse(row.payload),
+      configOverrides: Boolean(row.configOverrides),
+    }));
+  }
+
+  async savePartner(record) {
+    const normalizedWallet = normalizeWallet(record.wallet);
+    const payload = JSON.stringify(record.payload || {});
+    await this.#run(
+      `
+        INSERT INTO partners (wallet, ens, last_sync, multiplier, tier, status, payload, config_overrides)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(wallet)
+        DO UPDATE SET
+          ens = excluded.ens,
+          last_sync = excluded.last_sync,
+          multiplier = excluded.multiplier,
+          tier = excluded.tier,
+          status = excluded.status,
+          payload = excluded.payload,
+          config_overrides = excluded.config_overrides
+      `,
+      [
+        normalizedWallet,
+        record.ens || null,
+        record.lastSync,
+        record.multiplier,
+        record.tier,
+        record.status,
+        payload,
+        record.configOverrides ? 1 : 0,
+      ]
+    );
+    return {
+      ...record,
+      wallet: normalizedWallet,
+    };
+  }
+}
+
+class LocalForagePartnerStorage extends BasePartnerStorage {
+  constructor(options = {}) {
+    super({ readOnly: false });
+    const localforage = safeRequire('localforage');
+    if (!localforage) {
+      throw new Error('localforage dependency is required for browser storage.');
+    }
+    this.store = localforage.createInstance({
+      name: options.name || 'vaultfire',
+      storeName: options.storeName || 'partnerSync',
+    });
+  }
+
+  async listPartners() {
+    const partners = (await this.store.getItem('partners')) || {};
+    return Object.values(partners);
+  }
+
+  async savePartner(record) {
+    const partners = (await this.store.getItem('partners')) || {};
+    partners[record.wallet.toLowerCase()] = { ...record };
+    await this.store.setItem('partners', partners);
+    return record;
+  }
+}
+
+function createPartnerStorage(options = {}) {
+  const adapter = options.adapter || options.provider || null;
+  if (adapter === 'memory') {
+    return new MemoryPartnerStorage({ readOnly: !!options.readOnly });
+  }
+
+  if (adapter === 'localforage' || (typeof window !== 'undefined' && window.indexedDB)) {
+    try {
+      return new LocalForagePartnerStorage(options.localforage || {});
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Falling back to memory partner storage:', error.message);
+      return new MemoryPartnerStorage({ readOnly: true });
+    }
+  }
+
+  try {
+    return new SQLitePartnerStorage(options.sqlite || {});
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('SQLite adapter unavailable, falling back to memory partner storage:', error.message);
+    return new MemoryPartnerStorage({ readOnly: true });
+  }
+}
+
+module.exports = {
+  createPartnerStorage,
+  MemoryPartnerStorage,
+  SQLitePartnerStorage,
+  LocalForagePartnerStorage,
+};

--- a/services/voteRepository.js
+++ b/services/voteRepository.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+
+function ensureFile(filePath, fallback = []) {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+  if (!fs.existsSync(filePath)) {
+    fs.writeFileSync(filePath, JSON.stringify(fallback, null, 2));
+  }
+}
+
+function readJson(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+  const raw = fs.readFileSync(filePath, 'utf8');
+  if (!raw.trim()) {
+    return [];
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Unable to parse ${path.basename(filePath)}: ${error.message}`);
+  }
+}
+
+function writeJsonAtomic(filePath, data) {
+  const dir = path.dirname(filePath);
+  const tmpPath = path.join(dir, `${path.basename(filePath)}.tmp-${process.pid}-${Date.now()}`);
+  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2));
+  fs.renameSync(tmpPath, filePath);
+  const fd = fs.openSync(filePath, 'r');
+  fs.fsyncSync(fd);
+  fs.closeSync(fd);
+}
+
+class VoteRepository {
+  constructor({ filePath }) {
+    if (!filePath) {
+      throw new Error('VoteRepository requires a filePath');
+    }
+    this.filePath = filePath;
+    ensureFile(this.filePath, []);
+    this.queue = Promise.resolve();
+  }
+
+  async loadVotes() {
+    return readJson(this.filePath);
+  }
+
+  async #runExclusive(task) {
+    const next = this.queue.then(() => task());
+    this.queue = next
+      .then(
+        () => Promise.resolve(),
+        () => Promise.resolve()
+      )
+      .catch(() => Promise.resolve());
+    return next;
+  }
+
+  async appendVote(vote) {
+    if (!vote || typeof vote !== 'object') {
+      throw new Error('Vote payload must be an object');
+    }
+    return this.#runExclusive(async () => {
+      const votes = readJson(this.filePath);
+      votes.push(vote);
+      writeJsonAtomic(this.filePath, votes);
+      return vote;
+    });
+  }
+}
+
+module.exports = { VoteRepository };

--- a/tests/integrity.test.js
+++ b/tests/integrity.test.js
@@ -78,7 +78,8 @@ defineIntegrityTest('Belief mirror logs correct multipliers', async () => {
     },
   };
 
-  const expectedMultiplier = computeBeliefMultiplier(action.type, action.metrics);
+  const expected = computeBeliefMultiplier(action.type, action.metrics);
+  const expectedMultiplier = expected.multiplier;
   const [entry] = await engine.run([action]);
   const log = JSON.parse(fs.readFileSync(telemetryPath, 'utf8'));
 
@@ -147,6 +148,7 @@ defineIntegrityTest('Dashboard data reflects correct backend truth', async () =>
     ethics: 92,
     interactionFrequency: 75,
     partnerAlignment: 83,
+    holdDuration: 61,
   };
 
   const syncResponse = await agent

--- a/tools/belief_rule_validator.js
+++ b/tools/belief_rule_validator.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+const IGNORED_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', 'logs', 'telemetry', 'data']);
+const SCANNED_EXTENSIONS = new Set(['.js', '.ts', '.tsx', '.jsx']);
+const SKIP_FILES = new Set([
+  path.join('utils', 'identityGuards.js'),
+  path.join('services', 'identityStore.js'),
+  path.join('tests', 'integrity.test.js'),
+  path.join('tools', 'lint_guardrails.js'),
+  path.join('tools', 'belief_rule_validator.js'),
+]);
+const SCAN_PATHS = [
+  'partnerSync.js',
+  'cli',
+  'services',
+  'dashboard',
+  'src',
+  'utils',
+  'mirror',
+  'hooks',
+  'auth',
+  'tools',
+  'vaultfire_core.js',
+];
+
+const BANNED_DEPENDENCY_PATTERNS = [
+  /auth0/i,
+  /firebase/i,
+  /cognito/i,
+  /passport(?!\s*\.md)/i,
+  /worldcoin/i,
+  /didkit/i,
+  /selfid/i,
+  /decentralized-identity/i,
+  /identity\.js/i,
+  /kyc/i,
+];
+
+const BANNED_CONTENT_PATTERNS = [
+  /did:/i,
+  /self[-\s]?sovereign\s+identity/i,
+  /decentralized\s+identity/i,
+  /digital\s+identity\s+framework/i,
+  /digital\s+identity\s+provider/i,
+  /\bssi\b/i,
+  /oauth\b/i,
+  /openid/i,
+  /firebase\s*auth/i,
+  /auth0/i,
+  /cognito/i,
+  /worldcoin/i,
+  /onfido/i,
+  /passbase/i,
+  /trulioo/i,
+  /veriff/i,
+];
+
+function loadPackageJson() {
+  const pkgPath = path.join(ROOT, 'package.json');
+  const raw = fs.readFileSync(pkgPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function scanDependencies() {
+  const pkg = loadPackageJson();
+  const combined = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+  const issues = [];
+  for (const [name] of Object.entries(combined)) {
+    for (const pattern of BANNED_DEPENDENCY_PATTERNS) {
+      if (pattern.test(name)) {
+        issues.push({
+          type: 'dependency',
+          message: `Dependency '${name}' violates belief-aligned identity guardrails.`,
+        });
+        break;
+      }
+    }
+  }
+  return issues;
+}
+
+function shouldSkipFile(relativePath) {
+  if (SKIP_FILES.has(relativePath)) {
+    return true;
+  }
+  return false;
+}
+
+function walk(dir, callback) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (IGNORED_DIRS.has(entry.name)) {
+      continue;
+    }
+    const fullPath = path.join(dir, entry.name);
+    const relativePath = path.relative(ROOT, fullPath);
+    if (entry.isDirectory()) {
+      walk(fullPath, callback);
+    } else {
+      const ext = path.extname(entry.name).toLowerCase();
+      if (!SCANNED_EXTENSIONS.has(ext)) {
+        continue;
+      }
+      if (shouldSkipFile(relativePath)) {
+        continue;
+      }
+      callback(fullPath, relativePath);
+    }
+  }
+}
+
+function scanContent() {
+  const issues = [];
+  for (const target of SCAN_PATHS) {
+    const resolved = path.join(ROOT, target);
+    if (!fs.existsSync(resolved)) {
+      continue;
+    }
+    const stats = fs.statSync(resolved);
+    if (stats.isDirectory()) {
+      walk(resolved, (fullPath, relativePath) => {
+        const content = fs.readFileSync(fullPath, 'utf8');
+        for (const pattern of BANNED_CONTENT_PATTERNS) {
+          if (pattern.test(content)) {
+            issues.push({
+              type: 'content',
+              file: relativePath,
+              message: `Detected disallowed identity pattern '${pattern}' in ${relativePath}.`,
+            });
+            break;
+          }
+        }
+      });
+    } else if (stats.isFile()) {
+      const relativePath = path.relative(ROOT, resolved);
+      if (shouldSkipFile(relativePath)) {
+        continue;
+      }
+      const ext = path.extname(resolved).toLowerCase();
+      if (!SCANNED_EXTENSIONS.has(ext)) {
+        continue;
+      }
+      const content = fs.readFileSync(resolved, 'utf8');
+      for (const pattern of BANNED_CONTENT_PATTERNS) {
+        if (pattern.test(content)) {
+          issues.push({
+            type: 'content',
+            file: relativePath,
+            message: `Detected disallowed identity pattern '${pattern}' in ${relativePath}.`,
+          });
+          break;
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+(function main() {
+  const dependencyIssues = scanDependencies();
+  const contentIssues = scanContent();
+  const issues = [...dependencyIssues, ...contentIssues];
+
+  if (issues.length) {
+    // eslint-disable-next-line no-console
+    console.warn('⚠️  Digital identity or centralized auth references detected:');
+    for (const issue of issues) {
+      // eslint-disable-next-line no-console
+      console.warn(`- ${issue.message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('✅ Belief-Aligned: No digital ID detected. Wallet-native only.');
+})();

--- a/tools/mobile_pr_helper.js
+++ b/tools/mobile_pr_helper.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { execSync, spawnSync } = require('child_process');
+
+function detectMobileGitHubApp(env = process.env) {
+  const userAgent = (env.GITHUB_USER_AGENT || env.GIT_USER_AGENT || '').toLowerCase();
+  if (userAgent.includes('githubmobile') || userAgent.includes('github-ios')) {
+    return true;
+  }
+  const mobileHints = [
+    env.GITHUB_MOBILE,
+    env.GITHUB_APP_DEVICE,
+    env.MOBILE_GITHUB,
+    env.MOBILE_DEVICE,
+    env.TERMUX_VERSION,
+    env.ANDROID_ROOT,
+  ];
+  if (mobileHints.some((value) => typeof value === 'string' && /mobile|ios|android/.test(value.toLowerCase()))) {
+    return true;
+  }
+  if ((env.SSH_CONNECTION || '').includes('mobile')) {
+    return true;
+  }
+  return false;
+}
+
+function getRepoSlug() {
+  try {
+    const url = execSync('git config --get remote.origin.url', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+    if (!url) return null;
+    const sshMatch = url.match(/github.com[:/](.+?)(\.git)?$/i);
+    return sshMatch ? sshMatch[1].replace(/\.git$/, '') : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function getCurrentBranch() {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch (error) {
+    return null;
+  }
+}
+
+function getDefaultBranch() {
+  try {
+    const ref = execSync('git symbolic-ref refs/remotes/origin/HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+    if (!ref) return 'main';
+    const parts = ref.split('/');
+    return parts[parts.length - 1] || 'main';
+  } catch (error) {
+    return 'main';
+  }
+}
+
+function getLastCommit() {
+  try {
+    const subject = execSync('git log -1 --pretty=%s', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+    const body = execSync('git log -1 --pretty=%b', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+    return { subject, body };
+  } catch (error) {
+    return { subject: 'Vaultfire Protocol Update', body: '' };
+  }
+}
+
+function buildPrefilledPrUrl({ repo, base, head, title, body }) {
+  if (!repo || !head) {
+    return null;
+  }
+  const params = new URLSearchParams({
+    quick_pull: '1',
+    title: title || '',
+    body: body || '',
+  });
+  return `https://github.com/${repo}/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}?${params.toString()}`;
+}
+
+function writeState(state) {
+  const filePath = path.join(process.cwd(), '.git', 'vaultfire-mobile-pr.json');
+  fs.writeFileSync(filePath, JSON.stringify(state, null, 2));
+  return filePath;
+}
+
+function readState() {
+  const filePath = path.join(process.cwd(), '.git', 'vaultfire-mobile-pr.json');
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    return null;
+  }
+}
+
+function openUrl(url) {
+  const candidates = ['termux-open-url', 'xdg-open', 'open'];
+  for (const command of candidates) {
+    const result = spawnSync(command, [url], { stdio: 'ignore' });
+    if (result.status === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function prepare() {
+  if (!detectMobileGitHubApp()) {
+    return;
+  }
+  const repo = getRepoSlug();
+  const head = getCurrentBranch();
+  if (!repo || !head) {
+    return;
+  }
+  const base = getDefaultBranch();
+  const commit = getLastCommit();
+  const url = buildPrefilledPrUrl({
+    repo,
+    base,
+    head,
+    title: commit.subject,
+    body: commit.body,
+  });
+  const state = {
+    generatedAt: new Date().toISOString(),
+    repo,
+    base,
+    head,
+    title: commit.subject,
+    body: commit.body,
+    url,
+  };
+  writeState(state);
+  // eslint-disable-next-line no-console
+  console.log('📱 GitHub mobile context detected. Prefilled PR link prepared for fallback.');
+  // eslint-disable-next-line no-console
+  console.log(`➡️  ${url}`);
+}
+
+function redirect() {
+  if (!detectMobileGitHubApp()) {
+    return;
+  }
+  const state = readState();
+  if (!state || !state.url) {
+    // eslint-disable-next-line no-console
+    console.warn('No mobile PR metadata available. Run with --prepare before pushing.');
+    return;
+  }
+  const opened = openUrl(state.url);
+  if (!opened) {
+    // eslint-disable-next-line no-console
+    console.warn('Unable to launch browser automatically. Open this URL manually:');
+    // eslint-disable-next-line no-console
+    console.warn(state.url);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log('Redirected to mobile PR creation flow.');
+  }
+}
+
+(function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--redirect')) {
+    redirect();
+  } else {
+    prepare();
+  }
+})();

--- a/utils/identityGuards.js
+++ b/utils/identityGuards.js
@@ -1,0 +1,57 @@
+const BANNED_IDENTITY_PATTERNS = [
+  'email',
+  'phone',
+  'passport',
+  'kyc',
+  'ssi',
+  'did',
+  'oauth',
+  'cognito',
+  'firebase',
+  'digitalid',
+  'identity',
+  'biometric',
+  'socialsecurity',
+  'nationalid',
+  'fullname',
+  'surname',
+  'legalname',
+];
+
+function assertWalletOnlyData(data, { context = 'payload' } = {}) {
+  if (!data || typeof data !== 'object') {
+    return;
+  }
+
+  const stack = [{ node: data, path: context }];
+  while (stack.length) {
+    const { node, path } = stack.pop();
+    if (!node || typeof node !== 'object') {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    for (const key of Object.keys(node)) {
+      const normalizedKey = key.toLowerCase();
+      if (['wallet', 'ens', 'metrics', 'payload', 'message', 'signature'].includes(normalizedKey)) {
+        const value = node[key];
+        if (value && typeof value === 'object') {
+          stack.push({ node: value, path: `${path}.${key}` });
+        }
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      if (BANNED_IDENTITY_PATTERNS.some((pattern) => normalizedKey.includes(pattern))) {
+        throw new Error(`Field '${path}.${key}' is not permitted. Wallet + ENS only.`);
+      }
+      const value = node[key];
+      if (value && typeof value === 'object') {
+        stack.push({ node: value, path: `${path}.${key}` });
+      }
+    }
+  }
+}
+
+module.exports = {
+  assertWalletOnlyData,
+  BANNED_IDENTITY_PATTERNS,
+};

--- a/utils/scoringValidator.js
+++ b/utils/scoringValidator.js
@@ -1,0 +1,128 @@
+const ALLOWED_WEIGHT_KEYS = ['loyalty', 'ethics', 'frequency', 'alignment', 'holdDuration'];
+
+const METRIC_FIELDS = {
+  loyalty: ['loyalty'],
+  ethics: ['ethics'],
+  frequency: ['frequency', 'interactionFrequency'],
+  alignment: ['alignment', 'partnerAlignment'],
+  holdDuration: ['holdDuration', 'holdDurationDays'],
+};
+
+class ValidationError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'ValidationError';
+    this.statusCode = 422;
+    this.details = details;
+  }
+}
+
+function normalizeMetricValue(value, field) {
+  if (value === undefined || value === null) {
+    throw new ValidationError(`${field} metric is required.`, { field });
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      throw new ValidationError(`${field} metric cannot be empty.`, { field });
+    }
+    const numeric = Number(trimmed);
+    if (!Number.isFinite(numeric)) {
+      throw new ValidationError(`${field} must be numeric.`, { field, value });
+    }
+    if (numeric < 0 || numeric > 100) {
+      throw new ValidationError(`${field} must be between 0 and 100.`, { field, value: numeric });
+    }
+    return numeric;
+  }
+
+  if (typeof value !== 'number') {
+    throw new ValidationError(`${field} must be numeric.`, { field, value });
+  }
+
+  if (!Number.isFinite(value) || value < 0 || value > 100) {
+    throw new ValidationError(`${field} must be between 0 and 100.`, { field, value });
+  }
+
+  return value;
+}
+
+function extractMetrics(payload = {}) {
+  const source = typeof payload.metrics === 'object' && payload.metrics !== null ? payload.metrics : payload;
+  const metrics = {};
+
+  for (const [targetKey, aliases] of Object.entries(METRIC_FIELDS)) {
+    const alias = aliases.find((key) => source[key] !== undefined && source[key] !== null);
+    if (alias === undefined) {
+      throw new ValidationError(`${targetKey} metric is required.`, { field: targetKey });
+    }
+    metrics[targetKey] = normalizeMetricValue(source[alias], targetKey);
+  }
+
+  return metrics;
+}
+
+function sanitizeScoringConfig(rawConfig) {
+  if (!rawConfig || typeof rawConfig !== 'object') {
+    return null;
+  }
+
+  const sanitized = {};
+
+  if (rawConfig.weights !== undefined) {
+    if (!rawConfig.weights || typeof rawConfig.weights !== 'object') {
+      throw new ValidationError('scoringConfig.weights must be an object mapping metrics to weights.', {
+        field: 'scoringConfig.weights',
+      });
+    }
+
+    const weights = {};
+    let hasWeight = false;
+    for (const key of ALLOWED_WEIGHT_KEYS) {
+      if (rawConfig.weights[key] !== undefined) {
+        const numeric = Number(rawConfig.weights[key]);
+        if (!Number.isFinite(numeric) || numeric < 0) {
+          throw new ValidationError(`Weight for ${key} must be a non-negative number.`, {
+            field: `scoringConfig.weights.${key}`,
+          });
+        }
+        weights[key] = numeric;
+        hasWeight = true;
+      }
+    }
+
+    if (!hasWeight) {
+      throw new ValidationError('scoringConfig.weights must reference at least one supported metric.', {
+        field: 'scoringConfig.weights',
+      });
+    }
+
+    sanitized.weights = weights;
+  }
+
+  if (rawConfig.baselineMultiplier !== undefined) {
+    const baseline = Number(rawConfig.baselineMultiplier);
+    if (!Number.isFinite(baseline) || baseline < 0.5 || baseline > 3) {
+      throw new ValidationError('scoringConfig.baselineMultiplier must be between 0.5 and 3.', {
+        field: 'scoringConfig.baselineMultiplier',
+      });
+    }
+    sanitized.baselineMultiplier = baseline;
+  }
+
+  return Object.keys(sanitized).length ? sanitized : null;
+}
+
+function validateMetrics(metrics = {}) {
+  return extractMetrics({ metrics });
+}
+
+module.exports = {
+  ValidationError,
+  extractMetrics,
+  sanitizeScoringConfig,
+  validateMetrics,
+  METRIC_FIELDS,
+  ALLOWED_WEIGHT_KEYS,
+};

--- a/vaultfire_core.js
+++ b/vaultfire_core.js
@@ -8,6 +8,7 @@
 const fs = require('fs');
 const path = require('path');
 const MANIFEST = path.join(__dirname, 'ghostkey_manifesto.md');
+const { exportLogs } = require('./compliance/exportLogs');
 
 function activateCore() {
   if (!fs.existsSync(MANIFEST)) {
@@ -64,4 +65,11 @@ async function syncToASM({ wallet, layer, trigger }) {
   return { wallet, layer, trigger, timestamp, success: true };
 }
 
-module.exports = { activateCore, injectVaultfire, syncToASM };
+module.exports = {
+  activateCore,
+  injectVaultfire,
+  syncToASM,
+  logs: {
+    export: exportLogs,
+  },
+};


### PR DESCRIPTION
## Summary
- centralize metric validation in a shared scoring validator and reuse it across the CLI and partner sync endpoints to eliminate fallback defaults and surface override metadata
- extend the compliance export helper to support CSV/JSON output and optional file emission so rotated telemetry can be shared in audit-friendly formats
- add a responsive React dashboard component with ENS resolution, real-time belief rule feedback, and mobile-centric error handling for PR fallbacks

## Testing
- npm run lint:guardrails
- node tools/belief_rule_validator.js
- npm test
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68db03b35b5883228d45c34f89f0b2dd