### PR TITLE
Add HMAC handshake flow and governance telemetry feed

### DIFF
--- a/partnerSync.js
+++ b/partnerSync.js
@@ -1,7 +1,7 @@
+const crypto = require('crypto');
 const express = require('express');
 const http = require('http');
 const rateLimit = require('express-rate-limit');
-const fetch = require('node-fetch');
 const { Server } = require('socket.io');
 const path = require('path');
 const { BeliefMirrorEngine } = require('./mirror/engine');
@@ -15,6 +15,8 @@ const {
   extractMetrics,
   sanitizeScoringConfig,
 } = require('./utils/scoringValidator');
+const SecurityPostureManager = require('./services/securityPosture');
+const WebhookDeliveryQueue = require('./services/deliveryQueue');
 
 function sanitizeVotePayload(vote) {
   assertWalletOnlyData(vote, { context: 'vote' });
@@ -30,11 +32,52 @@ function sanitizeVotePayload(vote) {
   };
 }
 
+const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
+const GOVERNANCE_THRESHOLDS = {
+  multiplierCritical: 1,
+  summaryWarning: 1.05,
+};
+
+function ensureTelemetry(telemetry) {
+  if (telemetry && typeof telemetry.record === 'function') {
+    return telemetry;
+  }
+  return { record: () => {} };
+}
+
+function normalizeWebhookTarget(target, index) {
+  if (!target) {
+    return null;
+  }
+  if (typeof target === 'string') {
+    return {
+      targetUrl: target,
+      partnerId: `webhook-${index + 1}`,
+      signingSecret: null,
+      metadata: {},
+    };
+  }
+  if (typeof target === 'object') {
+    return {
+      targetUrl: target.targetUrl || target.url || target.endpoint || null,
+      partnerId: target.partnerId || target.id || `webhook-${index + 1}`,
+      signingSecret: target.signingSecret || target.secret || target.webhookSecret || null,
+      metadata: target.metadata || {},
+    };
+  }
+  return null;
+}
+
 function createPartnerSyncServer({
   webhookTargets = [],
   telemetryPath,
   votesPath,
   storageOptions = {},
+  telemetry,
+  securityPostureManager,
+  deliveryQueue,
+  sessionTtlMs = DEFAULT_SESSION_TTL_MS,
+  governance = {},
 } = {}) {
   const app = express();
   const httpServer = http.createServer(app);
@@ -42,6 +85,9 @@ function createPartnerSyncServer({
     cors: { origin: '*', methods: ['GET', 'POST'] },
   });
 
+  const resolvedTelemetry = ensureTelemetry(telemetry);
+  const securityPosture =
+    securityPostureManager || new SecurityPostureManager({ telemetry: resolvedTelemetry });
   const engine = new BeliefMirrorEngine({ telemetryPath });
   const resolvedVotesPath = votesPath || path.join(__dirname, 'votes.json');
   const partnerStorage = createPartnerStorage({
@@ -55,6 +101,102 @@ function createPartnerSyncServer({
     localforage: storageOptions.localforage,
   });
   const voteRepository = new VoteRepository({ filePath: resolvedVotesPath });
+  const webhookQueue = deliveryQueue || new WebhookDeliveryQueue();
+  const webhookSubscriptions = webhookTargets
+    .map((target, index) => normalizeWebhookTarget(target, index))
+    .filter((entry) => entry && entry.targetUrl);
+  const handshakeSessions = new Map();
+  const sessionTtl = Math.max(60 * 1000, sessionTtlMs || DEFAULT_SESSION_TTL_MS);
+  const governanceThresholds = {
+    multiplierCritical:
+      governance.multiplierCritical ?? GOVERNANCE_THRESHOLDS.multiplierCritical,
+    summaryWarning: governance.summaryWarning ?? GOVERNANCE_THRESHOLDS.summaryWarning,
+  };
+
+  const securityLogOptions = {
+    tags: ['security'],
+    visibility: { partner: false, ethics: true, audit: true },
+  };
+
+  function recordTelemetry(event, payload, options) {
+    if (!resolvedTelemetry || typeof resolvedTelemetry.record !== 'function') {
+      return;
+    }
+    resolvedTelemetry.record(event, payload, options);
+  }
+
+  function cleanupExpiredSessions(now = Date.now()) {
+    for (const [token, session] of handshakeSessions.entries()) {
+      const expiry = Date.parse(session.expiresAt);
+      if (Number.isFinite(expiry) && expiry <= now) {
+        handshakeSessions.delete(token);
+      }
+    }
+  }
+
+  function createHandshakeSession({ wallet, partnerId, secret, nonce, timestamp }) {
+    cleanupExpiredSessions();
+    const sessionId = crypto.randomUUID ? crypto.randomUUID() : crypto.randomBytes(16).toString('hex');
+    const now = Date.now();
+    const secretExpiry = secret?.expiresAt ? Date.parse(secret.expiresAt) : null;
+    const ttlDeadline = now + sessionTtl;
+    let expiresAt = ttlDeadline;
+    if (Number.isFinite(secretExpiry) && secretExpiry > now) {
+      expiresAt = Math.min(secretExpiry, ttlDeadline);
+    }
+    const session = {
+      token: sessionId,
+      wallet,
+      partnerId: partnerId || null,
+      issuedAt: new Date(now).toISOString(),
+      expiresAt: new Date(expiresAt).toISOString(),
+      secretId: secret?.id || null,
+      nonce: nonce || null,
+      timestamp: timestamp || null,
+    };
+    handshakeSessions.set(sessionId, session);
+    return session;
+  }
+
+  function requireHandshakeSession({ wallet, token }) {
+    if (!token) {
+      const error = new Error('Handshake session required');
+      error.statusCode = 401;
+      throw error;
+    }
+    cleanupExpiredSessions();
+    const session = handshakeSessions.get(token);
+    if (!session) {
+      const error = new Error('Handshake session invalid or expired');
+      error.statusCode = 401;
+      throw error;
+    }
+    if (session.wallet !== wallet.toLowerCase()) {
+      const error = new Error('Handshake session wallet mismatch');
+      error.statusCode = 401;
+      throw error;
+    }
+    return session;
+  }
+
+  async function notifyWebhooks(event, payload) {
+    if (!webhookSubscriptions.length) {
+      return [];
+    }
+    const deliveries = await Promise.all(
+      webhookSubscriptions.map((subscription) =>
+        webhookQueue.enqueue({
+          event,
+          payload,
+          partnerId: subscription.partnerId,
+          targetUrl: subscription.targetUrl,
+          signingSecret: subscription.signingSecret,
+          metadata: subscription.metadata,
+        })
+      )
+    );
+    return deliveries;
+  }
 
   const limiter = rateLimit({
     windowMs: 60 * 1000,
@@ -66,25 +208,78 @@ function createPartnerSyncServer({
   app.use(limiter);
   app.use(express.json({ limit: '1mb' }));
 
-  async function notifyWebhooks(payload) {
-    if (!webhookTargets.length) {
-      return;
+  app.get('/vaultfire/handshake', (req, res) => {
+    try {
+      securityPosture.refresh();
+      const snapshot = securityPosture.getHandshakeSnapshot();
+      res.json({
+        ...snapshot,
+        sessionTtlSeconds: Math.floor(sessionTtl / 1000),
+      });
+    } catch (error) {
+      res.status(500).json({ error: { message: error.message } });
+    }
+  });
+
+  app.post('/vaultfire/handshake', (req, res) => {
+    const { wallet, partnerId = null, nonce, timestamp, digest, secretId } = req.body || {};
+    const normalizedWallet = typeof wallet === 'string' ? wallet.toLowerCase() : null;
+
+    if (!normalizedWallet) {
+      return res.status(400).json({ error: { message: 'wallet is required' } });
     }
 
-    await Promise.all(
-      webhookTargets.map(async (target) => {
-        try {
-          await fetch(target, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-          });
-        } catch (error) {
-          console.warn(`Webhook notification to ${target} failed: ${error.message}`);
-        }
-      })
-    );
-  }
+    try {
+      securityPosture.refresh();
+      const handshakeRequired = securityPosture.requiresHandshake();
+      const handshakePayload =
+        handshakeRequired || digest || secretId
+          ? { nonce, timestamp, digest, secretId }
+          : null;
+      const verification = securityPosture.assertHandshakeSecret(handshakePayload, {
+        wallet: normalizedWallet,
+      });
+      const session = createHandshakeSession({
+        wallet: normalizedWallet,
+        partnerId,
+        secret: verification.secret,
+        nonce,
+        timestamp,
+      });
+      recordTelemetry(
+        'security.handshake.accepted',
+        {
+          wallet: normalizedWallet,
+          partnerId,
+          sessionId: session.token,
+          secretId: session.secretId,
+        },
+        securityLogOptions
+      );
+      res.json({
+        ok: true,
+        status: 'acknowledged',
+        session,
+        posture: securityPosture.getHandshakeSnapshot().posture,
+        rotation: {
+          secretId: session.secretId,
+          expiresAt: session.expiresAt,
+        },
+      });
+    } catch (error) {
+      recordTelemetry(
+        'security.handshake.rejected',
+        {
+          wallet: normalizedWallet,
+          partnerId,
+          reason: error.message,
+        },
+        securityLogOptions
+      );
+      const statusCode = error.statusCode || 400;
+      res.status(statusCode).json({ error: { message: error.message } });
+    }
+  });
 
   function buildSummary(partners) {
     if (!partners.length) {
@@ -118,7 +313,24 @@ function createPartnerSyncServer({
 
   app.post('/vaultfire/sync-belief', async (req, res) => {
     try {
-      const { wallet, signature, message, ens, payload = {} } = req.body || {};
+      const { wallet, signature, message, ens, payload = {}, sessionToken, nonce } = req.body || {};
+      if (typeof wallet !== 'string') {
+        throw new Error('Wallet address is required');
+      }
+      const normalizedWallet = wallet.toLowerCase();
+      const handshakeRequired = securityPosture.requiresHandshake();
+      let activeSession = null;
+      if (handshakeRequired || sessionToken) {
+        activeSession = requireHandshakeSession({ wallet: normalizedWallet, token: sessionToken });
+        if (activeSession.nonce && nonce && nonce !== activeSession.nonce) {
+          const error = new Error('Handshake nonce mismatch');
+          error.statusCode = 401;
+          throw error;
+        }
+      }
+      if (activeSession) {
+        activeSession.lastUsedAt = new Date().toISOString();
+      }
       assertWalletOnlyData(payload, { context: 'payload' });
       const verified = verifyWalletSignature({ wallet, signature, message, ens });
       const metrics = extractMetrics(payload);
@@ -159,10 +371,46 @@ function createPartnerSyncServer({
       };
 
       io.emit('belief-sync', { type: 'partnerSync', entry: partnerRecord });
-      await notifyWebhooks({
-        event: 'partnerSync',
-        payload: partnerRecord,
-      });
+      await notifyWebhooks('partnerSync', partnerRecord);
+
+      const partners = await partnerStorage.listPartners();
+      const summary = buildSummary(partners);
+      const governanceAlerts = [];
+
+      if (entry.multiplier < governanceThresholds.multiplierCritical) {
+        governanceAlerts.push({
+          type: 'multiplier.floor',
+          wallet: entry.wallet,
+          multiplier: entry.multiplier,
+          tier: entry.tier,
+          severity: 'critical',
+        });
+      }
+
+      if (summary.beliefScore < governanceThresholds.summaryWarning) {
+        governanceAlerts.push({
+          type: 'summary.drift',
+          beliefScore: summary.beliefScore,
+          totalPartners: summary.totalPartners,
+          severity: 'warning',
+        });
+      }
+
+      if (governanceAlerts.length) {
+        governanceAlerts.forEach((alert) => {
+          recordTelemetry(
+            'governance.alert',
+            alert,
+            {
+              tags: ['governance'],
+              visibility: { partner: false, ethics: true, audit: true },
+            }
+          );
+        });
+        await Promise.all(governanceAlerts.map((alert) => notifyWebhooks('governance.alert', alert)));
+        io.emit('governance-alert', governanceAlerts);
+        responsePayload.governance = { alerts: governanceAlerts };
+      }
 
       res.json(responsePayload);
     } catch (error) {
@@ -195,6 +443,37 @@ function createPartnerSyncServer({
     }
   });
 
+  app.get('/public/status-feed.json', async (req, res) => {
+    try {
+      const partners = await partnerStorage.listPartners();
+      const summary = buildSummary(partners);
+      const recentEntries = engine.readRecentEntries(20).map((entry) => ({
+        wallet: entry.wallet,
+        ens: entry.ens,
+        multiplier: entry.multiplier,
+        tier: entry.tier,
+        timestamp: entry.timestamp,
+      }));
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json({
+        generatedAt: new Date().toISOString(),
+        summary,
+        partners: partners.map((partner) => ({
+          wallet: partner.wallet,
+          ens: partner.ens,
+          multiplier: partner.multiplier,
+          tier: partner.tier,
+          lastSync: partner.lastSync,
+          status: partner.status,
+        })),
+        recentEntries,
+      });
+    } catch (error) {
+      res.status(500).json({ error: { message: error.message } });
+    }
+  });
+
   const start = ({ port = 4050 } = {}) =>
     new Promise((resolve) => {
       httpServer.listen(port, () => {
@@ -206,7 +485,15 @@ function createPartnerSyncServer({
   const stop = () =>
     new Promise((resolve) => {
       io.removeAllListeners();
-      httpServer.close(() => resolve());
+      httpServer.close(async () => {
+        try {
+          await webhookQueue.flush();
+        } catch (error) {
+          console.warn('Failed to flush webhook queue', error.message);
+        }
+        handshakeSessions.clear();
+        resolve();
+      });
     });
 
   return {

--- a/services/securityPosture.js
+++ b/services/securityPosture.js
@@ -1,0 +1,205 @@
+const crypto = require('crypto');
+const {
+  loadSecurityConfig,
+  resolveActiveSecret,
+  isDomainAllowed,
+} = require('../config/securityConfig');
+
+function toLower(value) {
+  return typeof value === 'string' ? value.toLowerCase() : value;
+}
+
+function toBuffer(value) {
+  if (typeof value !== 'string' || !value) {
+    return null;
+  }
+  try {
+    return Buffer.from(value, 'hex');
+  } catch (error) {
+    return null;
+  }
+}
+
+class SecurityPostureManager {
+  constructor({ telemetry } = {}) {
+    this.telemetry = telemetry || null;
+    this.refresh();
+  }
+
+  refresh() {
+    this.config = loadSecurityConfig();
+    this.rotation = resolveActiveSecret(this.config);
+  }
+
+  getActiveSecret() {
+    return this.rotation?.current || null;
+  }
+
+  getRotation() {
+    return this.rotation;
+  }
+
+  allowsLegacyHandshake() {
+    return Boolean(this.config?.verification?.allowLegacyHandshake);
+  }
+
+  requiresHandshake() {
+    return Boolean(this.getActiveSecret()?.value);
+  }
+
+  getHandshakeSnapshot() {
+    const current = this.getActiveSecret();
+    return {
+      status: current ? 'rotating' : 'legacy',
+      secret: current?.value || null,
+      secretId: current?.id || null,
+      expiresAt: current?.expiresAt || null,
+      posture: {
+        algorithm: 'HMAC-SHA256',
+        rotationGraceDays: this.config?.verification?.rotationGraceDays || 0,
+        allowLegacyHandshake: this.allowsLegacyHandshake(),
+      },
+    };
+  }
+
+  #record(event, payload, options) {
+    if (!this.telemetry || typeof this.telemetry.record !== 'function') {
+      return;
+    }
+    const defaultOptions = {
+      tags: ['security'],
+      visibility: { partner: false, ethics: true, audit: true },
+    };
+    this.telemetry.record(event, payload, options || defaultOptions);
+  }
+
+  #candidateSecrets() {
+    const candidates = [];
+    const current = this.getActiveSecret();
+    if (current) {
+      candidates.push(current);
+    }
+
+    const graceDays = Number(this.config?.verification?.rotationGraceDays || 0);
+    if (!graceDays || !Array.isArray(this.rotation?.previous)) {
+      return candidates;
+    }
+
+    const graceWindowMs = graceDays * 24 * 60 * 60 * 1000;
+    if (!graceWindowMs) {
+      return candidates;
+    }
+
+    const now = Date.now();
+    for (const secret of this.rotation.previous) {
+      const expiresAt = Date.parse(secret.expiresAt);
+      if (Number.isFinite(expiresAt) && now - expiresAt <= graceWindowMs) {
+        candidates.push(secret);
+      }
+    }
+    return candidates;
+  }
+
+  #handshakePayload({ wallet, nonce, timestamp }) {
+    return `${wallet || ''}::${nonce || ''}::${timestamp || ''}`;
+  }
+
+  #timingSafeEqual(expected, actual) {
+    const expectedBuffer = toBuffer(expected);
+    const actualBuffer = toBuffer(actual);
+    if (!expectedBuffer || !actualBuffer || expectedBuffer.length !== actualBuffer.length) {
+      return false;
+    }
+    try {
+      return crypto.timingSafeEqual(expectedBuffer, actualBuffer);
+    } catch (error) {
+      return false;
+    }
+  }
+
+  #fail(reason, context = {}) {
+    this.#record('security.signature.failed', { reason, phase: 'handshake', ...context });
+    const error = new Error('Handshake secret invalid or expired');
+    error.statusCode = 401;
+    throw error;
+  }
+
+  assertHandshakeSecret(handshake, { wallet } = {}) {
+    const normalizedWallet = toLower(wallet || '');
+    const candidates = this.#candidateSecrets();
+
+    if (!handshake || typeof handshake !== 'object') {
+      if (candidates.length) {
+        if (this.allowsLegacyHandshake()) {
+          this.#record('security.signature.legacy', { wallet: normalizedWallet, reason: 'handshake_payload_missing' });
+          return { secret: null, legacy: true };
+        }
+        return this.#fail('secret_missing', { wallet: normalizedWallet });
+      }
+      this.#record('security.signature.legacy', { wallet: normalizedWallet, reason: 'no_active_secret' });
+      return { secret: null, legacy: true };
+    }
+
+    if (!candidates.length) {
+      this.#record('security.signature.legacy', { wallet: normalizedWallet, reason: 'no_active_secret' });
+      return { secret: null, legacy: true };
+    }
+
+    const { nonce, timestamp, digest, secretId } = handshake;
+    if (!nonce || !timestamp || !digest) {
+      return this.#fail('secret_mismatch', { wallet: normalizedWallet, reason: 'payload_incomplete' });
+    }
+
+    const payload = this.#handshakePayload({ wallet: normalizedWallet, nonce, timestamp });
+
+    for (const secret of candidates) {
+      if (secretId && secret.id !== secretId) {
+        continue;
+      }
+      const expected = crypto.createHmac('sha256', secret.value).update(payload).digest('hex');
+      if (this.#timingSafeEqual(expected, digest)) {
+        const ts = Number(timestamp);
+        if (Number.isFinite(ts)) {
+          const drift = Math.abs(Date.now() - ts);
+          if (drift > 5 * 60 * 1000) {
+            this.#record('security.signature.warning', {
+              wallet: normalizedWallet,
+              reason: 'timestamp_drift',
+              driftMs: drift,
+              secretId: secret.id,
+            });
+          }
+        }
+        return { secret, legacy: false };
+      }
+    }
+
+    if (this.allowsLegacyHandshake()) {
+      this.#record('security.signature.legacy', {
+        wallet: normalizedWallet,
+        reason: 'digest_mismatch_legacy_fallback',
+        providedSecretId: secretId || null,
+      });
+      return { secret: null, legacy: true };
+    }
+
+    return this.#fail('secret_mismatch', { wallet: normalizedWallet, providedSecretId: secretId || null });
+  }
+
+  assertDomain(domain) {
+    if (!domain) {
+      return;
+    }
+    const normalized = toLower(domain);
+    if (normalized === 'localhost' || normalized === '127.0.0.1') {
+      return;
+    }
+    if (isDomainAllowed(this.config, normalized)) {
+      return;
+    }
+    this.#record('security.domain.rejected', { host: normalized });
+    throw new Error('Domain not allowed');
+  }
+}
+
+module.exports = SecurityPostureManager;

--- a/tests/integrity.test.js
+++ b/tests/integrity.test.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const request = require('supertest');
 const { ethers } = require('ethers');
 const { createPartnerSyncServer } = require('../partnerSync');
@@ -145,12 +146,35 @@ defineIntegrityTest('Dashboard data reflects correct backend truth', async () =>
   const agent = request(server.app);
 
   const wallet = ethers.Wallet.createRandom();
-  const handshake = await agent.get('/vaultfire/handshake');
-  const secret = handshake.body?.secret || null;
-  const nonce = Date.now();
+  const handshakeSnapshot = await agent.get('/vaultfire/handshake');
+  const secret = handshakeSnapshot.body?.secret || null;
+  const secretId = handshakeSnapshot.body?.secretId || null;
+  const nonce = `nonce-${Date.now()}`;
+  const timestamp = Date.now().toString();
+  const digest =
+    secret
+      ? crypto
+          .createHmac('sha256', secret)
+          .update(`${wallet.address.toLowerCase()}::${nonce}::${timestamp}`)
+          .digest('hex')
+      : null;
+
+  const handshakeResponse = await agent.post('/vaultfire/handshake').send({
+    wallet: wallet.address,
+    nonce,
+    timestamp,
+    digest,
+    secretId,
+  });
+
+  if (handshakeResponse.status !== 200) {
+    throw new Error(`Handshake request failed with status ${handshakeResponse.status}`);
+  }
+
+  const sessionToken = handshakeResponse.body?.session?.token || null;
   const messageParts = [`Vaultfire belief sync handshake :: wallet=${wallet.address.toLowerCase()}`];
-  if (secret) {
-    messageParts.push(`secret=${secret}`);
+  if (sessionToken) {
+    messageParts.push(`session=${sessionToken}`);
   }
   messageParts.push(`nonce=${nonce}`);
   const message = messageParts.join(' :: ');
@@ -165,7 +189,7 @@ defineIntegrityTest('Dashboard data reflects correct backend truth', async () =>
 
   const syncResponse = await agent
     .post('/vaultfire/sync-belief')
-    .send({ wallet: wallet.address, message, signature, payload });
+    .send({ wallet: wallet.address, message, signature, payload, sessionToken, nonce });
 
   if (syncResponse.status !== 200) {
     throw new Error(`Sync request failed with status ${syncResponse.status}`);

--- a/tests/securityPosture.test.js
+++ b/tests/securityPosture.test.js
@@ -7,6 +7,7 @@ jest.mock('../config/securityConfig', () => {
   };
 });
 
+const crypto = require('crypto');
 const { loadSecurityConfig, resolveActiveSecret } = require('../config/securityConfig');
 const SecurityPostureManager = require('../services/securityPosture');
 
@@ -35,11 +36,19 @@ describe('SecurityPostureManager handshake enforcement', () => {
     jest.clearAllMocks();
   });
 
-  test('accepts messages containing the active secret', () => {
+  test('accepts payloads signed with the active secret', () => {
     const { manager, telemetry } = createManager();
+    const wallet = '0xabc';
+    const nonce = 'nonce-123';
+    const timestamp = Date.now().toString();
+    const digest = crypto
+      .createHmac('sha256', activeSecret.value)
+      .update(`${wallet.toLowerCase()}::${nonce}::${timestamp}`)
+      .digest('hex');
+
     expect(() =>
-      manager.assertHandshakeSecret('Vaultfire :: secret=vaultfire-secret-token :: handshake', {
-        wallet: '0xabc',
+      manager.assertHandshakeSecret({ nonce, timestamp, digest, secretId: activeSecret.id }, {
+        wallet,
       })
     ).not.toThrow();
     expect(telemetry.record).not.toHaveBeenCalledWith('security.signature.failed', expect.anything(), expect.anything());
@@ -50,7 +59,7 @@ describe('SecurityPostureManager handshake enforcement', () => {
 
     let capturedError;
     try {
-      manager.assertHandshakeSecret('Vaultfire handshake payload without token', { wallet: '0xabc' });
+      manager.assertHandshakeSecret({ nonce: 'nonce', timestamp: Date.now().toString() }, { wallet: '0xabc' });
     } catch (error) {
       capturedError = error;
     }
@@ -61,7 +70,7 @@ describe('SecurityPostureManager handshake enforcement', () => {
 
     const failureCall = telemetry.record.mock.calls.find(([event]) => event === 'security.signature.failed');
     expect(failureCall).toBeTruthy();
-    expect(failureCall[1]).toMatchObject({ reason: 'secret_mismatch', phase: 'handshake' });
+    expect(failureCall[1]).toMatchObject({ reason: 'payload_incomplete', phase: 'handshake', wallet: '0xabc' });
   });
 
   test('allows legacy handshake path when explicitly enabled', () => {
@@ -70,9 +79,10 @@ describe('SecurityPostureManager handshake enforcement', () => {
     };
     const { manager, telemetry } = createManager(overrides);
 
-    expect(() => manager.assertHandshakeSecret('Legacy Vaultfire handshake message', { wallet: '0xabc' })).not.toThrow();
+    expect(() => manager.assertHandshakeSecret(null, { wallet: '0xabc' })).not.toThrow();
     const legacyCall = telemetry.record.mock.calls.find(([event]) => event === 'security.signature.legacy');
     expect(legacyCall).toBeTruthy();
+    expect(legacyCall[1]).toMatchObject({ wallet: '0xabc' });
   });
 });
 


### PR DESCRIPTION
## Summary
- introduce a reusable security posture manager that validates rotating handshake secrets and domain policies
- refactor the partner sync server to enforce HMAC-based handshake sessions, queue webhook deliveries, emit governance alerts, and expose a public status feed
- update integrity and security posture tests to cover the new handshake flow and session requirements

## Testing
- npm test -- --runTestsByPath tests/securityPosture.test.js tests/integrity.test.js
- npm test *(fails: partnerStorageAdapters tests expect Postgres/Supabase adapters that are not implemented in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db44744a688322bea1e308992daf0a