### PR TITLE
Refactor trust sync handshake and telemetry persistence

### DIFF
--- a/auth/expressExample.js
+++ b/auth/expressExample.js
@@ -16,6 +16,8 @@ const PartnerHookRegistry = require('../services/partnerHooks');
 const AIMirrorAgent = require('../services/aiMirrorAgent');
 const { createFingerprint } = require('../services/originFingerprint');
 const { loadTrustSyncConfig } = require('../config/trustSyncConfig');
+const TrustSyncVerifier = require('../services/trustSyncVerifier');
+const RewardStreamPlanner = require('../services/rewardStreamPlanner');
 
 const app = express();
 const port = process.env.PORT || 4002;
@@ -31,6 +33,11 @@ const identityStoreReady = identityStore.init();
 const signalCompass = new SignalCompass({ telemetry: telemetryLedger, ...(trustConfig.signalCompass || {}) });
 const partnerHooks = new PartnerHookRegistry({ telemetry: telemetryLedger });
 const mirrorAgent = new AIMirrorAgent({ telemetry: telemetryLedger, ...(trustConfig.mirror || {}) });
+const trustVerifier = new TrustSyncVerifier({
+  telemetry: telemetryLedger,
+  remote: trustConfig.verification?.remote || null,
+});
+const rewardStreamPlanner = new RewardStreamPlanner({ telemetry: telemetryLedger });
 const BELIEF_BREACH_THRESHOLD = trustConfig.identityStore?.breachThreshold ?? 0.35;
 
 if (Array.isArray(trustConfig.hooks?.defaultSubscriptions)) {
@@ -177,10 +184,16 @@ app.get(
   ...createAuthMiddleware({ requiredRoles: [ROLES.PARTNER, ROLES.ADMIN], tokenService }),
   ethicsGuard,
   (req, res) => {
+    const currentYield = { apr: 6.4, multiplier: 1.15, tierLevel: 'flame' };
+    const streamPreview = rewardStreamPlanner.previewStream(req.params.walletId, {
+      partnerId: req.user.partnerId,
+      currentYield,
+    });
     const response = {
       walletId: req.params.walletId,
-      currentYield: { apr: 6.4, multiplier: 1.15, tierLevel: 'flame' },
+      currentYield,
       signalsReviewed: true,
+      streamPreview,
     };
 
     telemetryLedger.record('vaultfire.rewards.view', { walletId: req.params.walletId, partnerId: req.user.partnerId }, {
@@ -299,7 +312,23 @@ app.post(
     }
 
     const anchorWithOrigin = { ...anchor, originFingerprint: fingerprint.fingerprint };
-    return res.status(200).json({ anchor: anchorWithOrigin, signalCompass: snapshot });
+    const verification = await trustVerifier.verifyAnchor(anchorWithOrigin, {
+      partnerId: req.user.partnerId,
+      wallet,
+      event: 'link-wallet',
+    });
+
+    if (verification.status === 'rejected') {
+      return res.status(409).json({
+        error: {
+          code: 'wallet.verification_rejected',
+          message: 'Remote trust verifier rejected anchor attestation.',
+        },
+        verification,
+      });
+    }
+
+    return res.status(200).json({ anchor: anchorWithOrigin, signalCompass: snapshot, verification });
   }
 );
 

--- a/belief_sync_engine.js
+++ b/belief_sync_engine.js
@@ -10,6 +10,7 @@ const GLOBAL_BUS = new EventEmitter();
 const LOG_PATH = path.join(__dirname, 'fork_log.json');
 const PARTNER_NODE_PATH = path.join(__dirname, 'partner_port', 'external_nodes.json');
 const RELAY_DIR = path.join(__dirname, 'logs', 'partner_relays');
+const RETRY_SCHEDULE_PATH = path.join(RELAY_DIR, 'retry-schedule.json');
 
 function _loadLog() {
   if (!fs.existsSync(LOG_PATH)) return [];
@@ -50,6 +51,41 @@ function _ensureRelayDir() {
   if (!fs.existsSync(RELAY_DIR)) {
     fs.mkdirSync(RELAY_DIR, { recursive: true });
   }
+}
+
+function _loadRetrySchedule() {
+  if (!fs.existsSync(RETRY_SCHEDULE_PATH)) {
+    return [];
+  }
+  try {
+    const raw = fs.readFileSync(RETRY_SCHEDULE_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    return [];
+  }
+}
+
+function _writeRetrySchedule(entries) {
+  _ensureRelayDir();
+  fs.writeFileSync(RETRY_SCHEDULE_PATH, JSON.stringify(entries, null, 2));
+}
+
+function _scheduleRemoteRetry(node, payload, { attempts = 0, delayMs } = {}) {
+  const queue = _loadRetrySchedule();
+  const baseDelay = delayMs || Math.min(60 * 60 * 1000, 60 * 1000 * 2 ** attempts);
+  const scheduled = {
+    id: crypto.randomUUID(),
+    nodeId: node.id || node.partnerId || 'unknown',
+    endpoint: node.endpoint || null,
+    payload,
+    attempts,
+    nextAttemptAt: new Date(Date.now() + baseDelay).toISOString(),
+  };
+  queue.push(scheduled);
+  _writeRetrySchedule(queue);
+  return scheduled;
+  // TODO(remote-relay-roadmap): escalate retries to remote scheduler once governance approves cross-region relay orchestration.
 }
 
 function _encryptRelayPayload(entry, key) {
@@ -159,6 +195,7 @@ class BeliefSyncEngine extends EventEmitter {
         const ok = await _sendToEndpoint(node.endpoint, payload);
         if (!ok) {
           _writeRelayFallback(node, payload);
+          _scheduleRemoteRetry(node, payload, { attempts: 0 });
         }
       })
     );
@@ -188,6 +225,52 @@ class BeliefSyncEngine extends EventEmitter {
       counts[entry.choice] = (counts[entry.choice] || 0) + 1;
     }
     return counts;
+  }
+
+  async processRetryQueue({ now = Date.now(), maxAttempts = 5 } = {}) {
+    const queue = _loadRetrySchedule();
+    if (!queue.length) {
+      return { attempted: 0, delivered: 0, remaining: 0 };
+    }
+    const keep = [];
+    let attempted = 0;
+    let delivered = 0;
+    const nowTs = typeof now === 'number' ? now : new Date(now).getTime();
+
+    for (const job of queue) {
+      const nextAttemptTs = new Date(job.nextAttemptAt).getTime();
+      if (Number.isNaN(nextAttemptTs) || nextAttemptTs > nowTs) {
+        keep.push(job);
+        continue;
+      }
+      attempted += 1;
+      const ok = await _sendToEndpoint(job.endpoint, job.payload);
+      if (ok) {
+        delivered += 1;
+        continue;
+      }
+      const attempts = (job.attempts || 0) + 1;
+      if (attempts >= maxAttempts) {
+        const fallbackRecord = {
+          timestamp: new Date(nowTs).toISOString(),
+          node: job.nodeId,
+          endpoint: job.endpoint,
+          status: 'exhausted',
+          attempts,
+        };
+        _writeRelayFallback({ id: job.nodeId, endpoint: job.endpoint }, fallbackRecord);
+        continue;
+      }
+      const delay = Math.min(2 ** attempts * 60 * 1000, 6 * 60 * 60 * 1000);
+      keep.push({
+        ...job,
+        attempts,
+        nextAttemptAt: new Date(nowTs + delay).toISOString(),
+      });
+    }
+
+    _writeRetrySchedule(keep);
+    return { attempted, delivered, remaining: keep.length };
   }
 }
 

--- a/config/trustSyncConfig.js
+++ b/config/trustSyncConfig.js
@@ -24,6 +24,9 @@ const DEFAULT_CONFIG = {
   mirror: {
     outputChannel: 'cli',
   },
+  verification: {
+    remote: null,
+  },
 };
 
 function mergeConfig(base, override) {

--- a/docs/handshake-hardening.md
+++ b/docs/handshake-hardening.md
@@ -1,0 +1,34 @@
+# Partner handshake hardening
+
+Vaultfire partner sync now exposes a modular handshake surface so security
+reviews can reason about each trust boundary independently.
+
+## Components
+
+- **JWT authority** – `services/handshake/jwtAuthority.js` issues and verifies
+  tokens using the unified secrets manager. Rotate
+  `VAULTFIRE_HANDSHAKE_ACCESS_SECRET` via the secrets manager to refresh socket
+  credentials without redeploying the service.
+- **API key gate** – `services/handshake/apiKeyGate.js` centralises API key
+  validation across HTTP and Socket.IO entry points. Keys are loaded from the
+  secrets manager and compared with timing-safe equality.
+- **Socket relay** – `services/handshake/socketRelay.js` now records telemetry
+  for every connection and enforces authentication before joining the relay bus.
+- **Governance enforcer** – `services/handshake/governanceEnforcer.js` evaluates
+  multiplier floors and belief drift thresholds before broadcasting partner
+  updates. Alerts are mirrored to telemetry, webhooks and the socket relay so
+  partner operations receive consistent guidance.
+
+## Auditing & monitoring
+
+1. Enable telemetry persistence (Postgres or Supabase) so handshake events are
+   mirrored to a durable store for compliance review.
+2. Subscribe to the `handshake.socket.*` events in telemetry to detect unusual
+   connection churn or replay attempts.
+3. Monitor `governance.alert` entries emitted by the enforcer; they include the
+   computed severity and will be forwarded to partner webhooks.
+4. Record API key provisioning in your secrets manager audit trail. The default
+   environment provider can be replaced with Vault or HSM-backed providers once
+   the TODO migrations are scheduled.
+
+<!-- TODO(handshake-observability-roadmap): integrate SIEM shipping for socket relay metrics. -->

--- a/docs/identity-linking.md
+++ b/docs/identity-linking.md
@@ -52,3 +52,29 @@ AES-256-GCM using the key supplied via `VAULTFIRE_ENCRYPTION_KEY`.
 Set `trustSync.identityStore.breachThreshold` to customise the score that
 should trigger `onBeliefBreach`. The default is `0.35`. Breaches are recorded in
 all telemetry channels and propagated to any registered partner hooks.
+
+## Remote verification
+
+Partners can opt into remote verification by configuring
+`trustSync.verification.remote`. When present the Trust Sync API forwards anchor
+payloads to the remote verifier and includes the verdict in the response. A
+rejected verdict returns HTTP `409` so client SDKs can surface actionable
+messages. <!-- TODO(trust-sync-remote-migration): wire verifier retries into job queue -->
+
+```json
+{
+  "trustSync": {
+    "verification": {
+      "remote": {
+        "endpoint": "https://partner.example.com/verify-anchor",
+        "apiKey": "partner-service-token"
+      }
+    }
+  }
+}
+```
+
+The verifier receives `{ anchor, context }` and should respond with
+`{ accepted: true }` or `{ accepted: false, reason: "explain" }`. Any network
+failures are logged as deferred telemetry so operators can re-run the
+verification later.

--- a/docs/telemetry-ledger.md
+++ b/docs/telemetry-ledger.md
@@ -32,3 +32,63 @@ ledger.record('identity.anchor.linked', { walletId: '0xabc', partnerUserId: 'dem
 
 Production deployments should point `trustSync.telemetry.baseDir` to a persistent
 volume so the audit history survives restarts.
+
+## Persistence adapters
+
+`MultiTierTelemetryLedger` now loads a pluggable persistence adapter so the
+flat-file audit log can be mirrored into durable backends. The adapter is
+configured via `trustSync.telemetry.persistence` and supports:
+
+- `type: 'postgres'` – writes each entry to a relational table using `pg`.
+  Provide `connection` options or a custom `clientFactory` when running inside
+  existing pools. Partitioning is deferred until the reward stream ledger lands
+  on-chain. <!-- TODO(vaultfire-rewards-migration): revisit retention policies -->
+- `type: 'supabase'` – uses a service role key to upsert telemetry into a
+  Supabase project. Ideal for partners that already enforce Supabase row-level
+  policies. <!-- TODO(partner-rbac-migration): document signed row policies -->
+- `type: 'json'` (default) – continues writing newline-delimited JSON when no
+  external config is supplied.
+
+If no adapter is configured or initialisation fails the ledger automatically
+falls back to file-based logging, ensuring telemetry never drops.
+
+### Configuration examples
+
+```json
+{
+  "trustSync": {
+    "telemetry": {
+      "baseDir": "./logs/telemetry",
+      "persistence": {
+        "type": "postgres",
+        "connection": {
+          "connectionString": "postgres://vaultfire:secret@localhost:5432/telemetry"
+        },
+        "tableName": "vaultfire_telemetry"
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "trustSync": {
+    "telemetry": {
+      "persistence": {
+        "type": "supabase",
+        "url": "https://org.supabase.co",
+        "serviceRoleKey": "supabase-service-role"
+      }
+    }
+  }
+}
+```
+
+### Partner spike safeguards
+
+For partner launches expected to trigger telemetry spikes, enable database
+adapters and configure auto-scaling policies before cutting over production
+traffic. Governance automation will treat `rewards.stream.preview` events as
+signals for upcoming payout migrations, so coordinators should monitor both the
+database adapter metrics and the JSON audit chain for anomalies.

--- a/partnerSync.js
+++ b/partnerSync.js
@@ -17,10 +17,14 @@ const {
 } = require('./utils/scoringValidator');
 const SecurityPostureManager = require('./services/securityPosture');
 const WebhookDeliveryQueue = require('./services/deliveryQueue');
-const TokenService = require('./auth/tokenService');
 const { ROLES, hasRequiredRole } = require('./auth/roles');
 const { createAuthMiddleware } = require('./auth/authMiddleware');
 const { sendSignedJson } = require('./utils/responseSigner');
+const { SecretsManager } = require('./services/secretsManager');
+const HandshakeJWTAuthority = require('./services/handshake/jwtAuthority');
+const ApiKeyGate = require('./services/handshake/apiKeyGate');
+const GovernanceEnforcer = require('./services/handshake/governanceEnforcer');
+const SocketRelay = require('./services/handshake/socketRelay');
 
 function sanitizeVotePayload(vote) {
   assertWalletOnlyData(vote, { context: 'vote' });
@@ -90,6 +94,11 @@ function createPartnerSyncServer({
   });
 
   const resolvedTelemetry = ensureTelemetry(telemetry);
+  const socketRelay = new SocketRelay({ io, telemetry: resolvedTelemetry });
+  const secretsManager = storageOptions.secretsManager || new SecretsManager({});
+  const jwtAuthority = new HandshakeJWTAuthority({ secretsManager, telemetry: resolvedTelemetry });
+  const discoveryTokenService = jwtAuthority.tokenService;
+  const apiKeyGate = new ApiKeyGate({ secretsManager, telemetry: resolvedTelemetry });
   const securityPosture =
     securityPostureManager || new SecurityPostureManager({ telemetry: resolvedTelemetry });
   const engine = new BeliefMirrorEngine({ telemetryPath });
@@ -114,19 +123,17 @@ function createPartnerSyncServer({
     .filter((entry) => entry && entry.targetUrl);
   const handshakeSessions = new Map();
   const sessionTtl = Math.max(60 * 1000, sessionTtlMs || DEFAULT_SESSION_TTL_MS);
-  const governanceThresholds = {
-    multiplierCritical:
-      governance.multiplierCritical ?? GOVERNANCE_THRESHOLDS.multiplierCritical,
-    summaryWarning: governance.summaryWarning ?? GOVERNANCE_THRESHOLDS.summaryWarning,
-  };
+  const governanceEnforcer = new GovernanceEnforcer({
+    telemetry: resolvedTelemetry,
+    thresholds: {
+      multiplierCritical:
+        governance.multiplierCritical ?? GOVERNANCE_THRESHOLDS.multiplierCritical,
+      summaryWarning: governance.summaryWarning ?? GOVERNANCE_THRESHOLDS.summaryWarning,
+    },
+  });
+  socketRelay.register({ jwtAuthority, apiKeyGate });
 
-  const discoveryTokenService = new TokenService();
   const handshakeRequiredRoles = [ROLES.PARTNER, ROLES.ADMIN];
-  const discoveryApiKeys = (process.env.VAULTFIRE_HANDSHAKE_API_KEYS || process.env.VAULTFIRE_HANDSHAKE_API_KEY || '')
-    .split(',')
-    .map((value) => value.trim())
-    .filter(Boolean);
-  const apiKeyHeaders = ['x-api-key', 'x-vaultfire-api-key', 'x-vf-handshake-key'];
   const [adminAuthRateLimiter, adminAuthGuard] = createAuthMiddleware({
     requiredRoles: [ROLES.ADMIN],
     tokenService: discoveryTokenService,
@@ -151,22 +158,6 @@ function createPartnerSyncServer({
     return error;
   }
 
-  function safeCompare(expected, actual) {
-    if (!expected || !actual) {
-      return false;
-    }
-    const expectedBuffer = Buffer.from(expected);
-    const actualBuffer = Buffer.from(actual);
-    if (expectedBuffer.length !== actualBuffer.length) {
-      return false;
-    }
-    try {
-      return crypto.timingSafeEqual(expectedBuffer, actualBuffer);
-    } catch (error) {
-      return false;
-    }
-  }
-
   function extractBearerToken(req) {
     const header = req.headers.authorization;
     if (!header) {
@@ -185,36 +176,25 @@ function createPartnerSyncServer({
       return null;
     }
 
-    const decoded = discoveryTokenService.verifyAccessToken(token);
-    if (!hasRequiredRole(decoded.role, requiredRoles)) {
+    const result = jwtAuthority.verify(token, { tags: ['http'] });
+    if (!result.valid) {
+      throw authError('Invalid bearer token for handshake discovery.', 'auth.unauthorized', 401);
+    }
+    if (!hasRequiredRole(result.payload.role, requiredRoles)) {
       throw authError('Insufficient role access for this resource.', 'auth.forbidden', 403);
     }
-    return decoded;
-  }
-
-  function extractApiKey(req) {
-    for (const header of apiKeyHeaders) {
-      if (req.headers[header]) {
-        return String(req.headers[header]);
-      }
-    }
-    return null;
+    return result.payload;
   }
 
   function verifyApiKey(req) {
-    if (!discoveryApiKeys.length) {
-      return null;
-    }
-    const provided = extractApiKey(req);
-    if (!provided) {
-      return null;
-    }
-
-    const matched = discoveryApiKeys.some((key) => safeCompare(key, provided));
-    if (!matched) {
+    const result = apiKeyGate.verify(req);
+    if (!result.valid) {
+      if (result.reason === 'no_keys_configured') {
+        return null;
+      }
       throw authError('Invalid API key for handshake discovery.', 'auth.unauthorized', 401);
     }
-    return { type: 'api-key', key: provided };
+    return { type: 'api-key', key: result.key };
   }
 
   function requireDiscoveryAuth(req) {
@@ -509,33 +489,38 @@ function createPartnerSyncServer({
         overridesDetected: Boolean(entry.configOverrides),
       };
 
-      io.emit('belief-sync', { type: 'partnerSync', entry: partnerRecord });
+      socketRelay.emit('belief-sync', { type: 'partnerSync', entry: partnerRecord });
       await notifyWebhooks('partnerSync', partnerRecord);
 
       const partners = await partnerStorage.listPartners();
       const summary = buildSummary(partners);
-      const governanceAlerts = [];
+      const enforcement = governanceEnforcer.assess({
+        multiplier: entry.multiplier,
+        summaryScore: summary.beliefScore,
+      });
 
-      if (entry.multiplier < governanceThresholds.multiplierCritical) {
-        governanceAlerts.push({
-          type: 'multiplier.floor',
-          wallet: entry.wallet,
-          multiplier: entry.multiplier,
-          tier: entry.tier,
-          severity: 'critical',
+      if (enforcement.alerts.length) {
+        const governanceAlerts = enforcement.alerts.map((alert) => {
+          if (alert.type === 'multiplier.floor') {
+            return {
+              type: 'multiplier.floor',
+              wallet: entry.wallet,
+              multiplier: entry.multiplier,
+              tier: entry.tier,
+              severity: 'critical',
+            };
+          }
+          if (alert.type === 'summary.threshold') {
+            return {
+              type: 'summary.drift',
+              beliefScore: summary.beliefScore,
+              totalPartners: summary.totalPartners,
+              severity: 'warning',
+            };
+          }
+          return alert;
         });
-      }
 
-      if (summary.beliefScore < governanceThresholds.summaryWarning) {
-        governanceAlerts.push({
-          type: 'summary.drift',
-          beliefScore: summary.beliefScore,
-          totalPartners: summary.totalPartners,
-          severity: 'warning',
-        });
-      }
-
-      if (governanceAlerts.length) {
         governanceAlerts.forEach((alert) => {
           recordTelemetry(
             'governance.alert',
@@ -547,8 +532,8 @@ function createPartnerSyncServer({
           );
         });
         await Promise.all(governanceAlerts.map((alert) => notifyWebhooks('governance.alert', alert)));
-        io.emit('governance-alert', governanceAlerts);
-        responsePayload.governance = { alerts: governanceAlerts };
+        socketRelay.emit('governance-alert', governanceAlerts);
+        responsePayload.governance = { alerts: governanceAlerts, status: enforcement.status };
       }
 
       res.json(responsePayload);
@@ -623,6 +608,7 @@ function createPartnerSyncServer({
 
   const stop = () =>
     new Promise((resolve) => {
+      socketRelay.close();
       io.removeAllListeners();
       httpServer.close(async () => {
         try {

--- a/services/handshake/apiKeyGate.js
+++ b/services/handshake/apiKeyGate.js
@@ -1,0 +1,64 @@
+class ApiKeyGate {
+  constructor({ secretsManager, telemetry, headerNames } = {}) {
+    this.secretsManager = secretsManager;
+    this.telemetry = telemetry || null;
+    this.headerNames = headerNames || ['x-api-key', 'x-vaultfire-api-key', 'x-vf-handshake-key'];
+    this.cachedKeys = null;
+  }
+
+  loadKeys() {
+    if (this.cachedKeys) {
+      return this.cachedKeys;
+    }
+    const raw = this.secretsManager?.getSecret('VAULTFIRE_HANDSHAKE_API_KEYS');
+    const single = this.secretsManager?.getSecret('VAULTFIRE_HANDSHAKE_API_KEY');
+    const values = [raw, single]
+      .filter(Boolean)
+      .flatMap((entry) => String(entry).split(',').map((value) => value.trim()))
+      .filter(Boolean);
+    this.cachedKeys = new Set(values);
+    return this.cachedKeys;
+  }
+
+  verify(req) {
+    const keys = this.loadKeys();
+    if (!keys || keys.size === 0) {
+      return { valid: false, reason: 'no_keys_configured' };
+    }
+    for (const header of this.headerNames) {
+      const provided = req.headers?.[header];
+      if (!provided) {
+        continue;
+      }
+      const normalized = String(provided).trim();
+      for (const candidate of keys) {
+        if (candidate && this.safeCompare(candidate, normalized)) {
+          return { valid: true, key: candidate };
+        }
+      }
+    }
+    this.telemetry?.record('handshake.apikey.rejected', { headers: this.headerNames }, {
+      tags: ['handshake', 'api-key'],
+      visibility: { partner: false, ethics: true, audit: true },
+    });
+    return { valid: false, reason: 'invalid_key' };
+  }
+
+  safeCompare(expected, actual) {
+    if (!expected || !actual) {
+      return false;
+    }
+    const expectedBuffer = Buffer.from(expected);
+    const actualBuffer = Buffer.from(actual);
+    if (expectedBuffer.length !== actualBuffer.length) {
+      return false;
+    }
+    try {
+      return require('crypto').timingSafeEqual(expectedBuffer, actualBuffer);
+    } catch (error) {
+      return false;
+    }
+  }
+}
+
+module.exports = ApiKeyGate;

--- a/services/handshake/governanceEnforcer.js
+++ b/services/handshake/governanceEnforcer.js
@@ -1,0 +1,36 @@
+class GovernanceEnforcer {
+  constructor({ telemetry, thresholds } = {}) {
+    this.telemetry = telemetry || null;
+    this.thresholds = {
+      multiplierCritical: thresholds?.multiplierCritical ?? 1,
+      summaryWarning: thresholds?.summaryWarning ?? 1.05,
+    };
+  }
+
+  assess({ multiplier, summaryScore }) {
+    const alerts = [];
+    if (multiplier < this.thresholds.multiplierCritical) {
+      alerts.push({ type: 'multiplier.floor', multiplier, summaryScore });
+      this.telemetry?.record('handshake.governance.blocked', { multiplier, summaryScore }, {
+        tags: ['handshake', 'governance'],
+        visibility: { partner: false, ethics: true, audit: true },
+      });
+    }
+    if (summaryScore < this.thresholds.summaryWarning) {
+      alerts.push({ type: 'summary.threshold', multiplier, summaryScore });
+      this.telemetry?.record('handshake.governance.warned', { multiplier, summaryScore }, {
+        tags: ['handshake', 'governance'],
+        visibility: { partner: true, ethics: true, audit: true },
+      });
+    }
+    const status = alerts.some((alert) => alert.type === 'multiplier.floor')
+      ? 'blocked'
+      : alerts.length
+      ? 'warning'
+      : 'ok';
+    return { status, alerts };
+    // TODO(governance-dao-thresholds): wire DAO-configured dynamic thresholds once partner councils expose signed snapshots.
+  }
+}
+
+module.exports = GovernanceEnforcer;

--- a/services/handshake/jwtAuthority.js
+++ b/services/handshake/jwtAuthority.js
@@ -1,0 +1,32 @@
+const TokenService = require('../../auth/tokenService');
+
+class HandshakeJWTAuthority {
+  constructor({ secretsManager, telemetry, tokenService } = {}) {
+    this.telemetry = telemetry || null;
+    this.secretsManager = secretsManager;
+    const secret = secretsManager?.getSecret('VAULTFIRE_HANDSHAKE_ACCESS_SECRET', {
+      fallback: secretsManager?.getSecret('VAULTFIRE_ACCESS_SECRET', { fallback: 'vaultfire-dev-access' }),
+    });
+    this.tokenService = tokenService || new TokenService({ accessSecret: secret });
+  }
+
+  issue(payload) {
+    return this.tokenService.createAccessToken(payload);
+  }
+
+  verify(token, { tags = [] } = {}) {
+    try {
+      const decoded = this.tokenService.verifyAccessToken(token);
+      return { valid: true, payload: decoded };
+    } catch (error) {
+      this.telemetry?.record('handshake.jwt.invalid', { reason: error.message }, {
+        tags: ['handshake', 'jwt', ...tags],
+        visibility: { partner: false, ethics: true, audit: true },
+      });
+      return { valid: false, error };
+    }
+    // TODO(handshake-jwt-rotation): add automated rotation once secrets manager integrates with remote HSM.
+  }
+}
+
+module.exports = HandshakeJWTAuthority;

--- a/services/handshake/socketRelay.js
+++ b/services/handshake/socketRelay.js
@@ -1,0 +1,64 @@
+class SocketRelay {
+  constructor({ io, telemetry } = {}) {
+    this.io = io;
+    this.telemetry = telemetry || null;
+    this.connectionCount = 0;
+  }
+
+  register({ jwtAuthority, apiKeyGate } = {}) {
+    if (!this.io) {
+      throw new Error('SocketRelay requires an io instance');
+    }
+    if (this._registered) {
+      return;
+    }
+    this._registered = true;
+    this.io.use((socket, next) => {
+      const token = socket.handshake?.auth?.token;
+      if (token && jwtAuthority) {
+        const result = jwtAuthority.verify(token, { tags: ['socket'] });
+        if (!result.valid) {
+          return next(new Error('Invalid socket token'));
+        }
+        socket.handshake.user = result.payload;
+        return next();
+      }
+      if (apiKeyGate) {
+        const result = apiKeyGate.verify({ headers: socket.handshake?.headers || {} });
+        if (result.valid) {
+          socket.handshake.user = { apiKey: result.key };
+          return next();
+        }
+      }
+      return next(new Error('Unauthorized socket handshake'));
+    });
+
+    this.io.on('connection', (socket) => {
+      this.connectionCount += 1;
+      this.telemetry?.record('handshake.socket.connected', { connectionCount: this.connectionCount }, {
+        tags: ['handshake', 'socket'],
+        visibility: { partner: true, ethics: true, audit: true },
+      });
+      socket.on('disconnect', () => {
+        this.connectionCount = Math.max(0, this.connectionCount - 1);
+        this.telemetry?.record('handshake.socket.disconnected', { connectionCount: this.connectionCount }, {
+          tags: ['handshake', 'socket'],
+          visibility: { partner: false, ethics: true, audit: true },
+        });
+      });
+    });
+    // TODO(handshake-socket-audit): integrate SIEM export once enterprise sockets require persistent audit trails.
+  }
+
+  emit(event, payload) {
+    this.io?.emit(event, payload);
+  }
+
+  close() {
+    if (this.io) {
+      this.io.removeAllListeners();
+    }
+  }
+}
+
+module.exports = SocketRelay;

--- a/services/rewardStreamPlanner.js
+++ b/services/rewardStreamPlanner.js
@@ -1,0 +1,29 @@
+class RewardStreamPlanner {
+  constructor({ telemetry } = {}) {
+    this.telemetry = telemetry || null;
+  }
+
+  previewStream(walletId, { partnerId, currentYield } = {}) {
+    const preview = {
+      walletId,
+      partnerId: partnerId || null,
+      status: 'pending-integration',
+      plannedContract: null,
+      projectedYield: currentYield || null,
+      roadmap: {
+        phase: 'alpha',
+        next: 'vaultfire-rewards-beta',
+      },
+    };
+
+    this.telemetry?.record('rewards.stream.preview', preview, {
+      tags: ['rewards', 'on-chain'],
+      visibility: { partner: true, ethics: false, audit: true },
+    });
+
+    return preview;
+    // TODO(rewards-onchain-migration): replace preview with live on-chain contract wiring once staking vault deployed.
+  }
+}
+
+module.exports = RewardStreamPlanner;

--- a/services/secretsManager/index.js
+++ b/services/secretsManager/index.js
@@ -1,0 +1,39 @@
+class EnvironmentSecretsProvider {
+  getSecret(key) {
+    return process.env[key];
+  }
+}
+
+class SecretsManager {
+  constructor({ providers } = {}) {
+    this.providers = Array.isArray(providers) && providers.length ? providers : [new EnvironmentSecretsProvider()];
+  }
+
+  getSecret(key, { fallback, required = false } = {}) {
+    for (const provider of this.providers) {
+      if (!provider || typeof provider.getSecret !== 'function') {
+        continue;
+      }
+      const value = provider.getSecret(key);
+      if (value !== undefined && value !== null) {
+        return value;
+      }
+    }
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    if (required) {
+      throw new Error(`Secret ${key} not found`);
+    }
+    return undefined;
+    // TODO(secrets-vault-migration): extend to async providers (HashiCorp Vault, HSM) while preserving interface parity.
+  }
+
+  list(keys = []) {
+    return keys
+      .map((key) => this.getSecret(key))
+      .filter((value) => value !== undefined && value !== null && String(value).length > 0);
+  }
+}
+
+module.exports = { SecretsManager, EnvironmentSecretsProvider };

--- a/services/telemetryLedger.js
+++ b/services/telemetryLedger.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { createTelemetrySinkRegistry } = require('./telemetrySinks');
+const { createTelemetryPersistence } = require('./telemetryPersistence');
 
 function ensureDirectory(dirPath) {
   if (!fs.existsSync(dirPath)) {
@@ -37,6 +38,7 @@ class MultiTierTelemetryLedger {
     ethicsLog = 'ethics.log',
     auditLog = 'audit.log',
     sinks = [],
+    persistence,
   } = {}) {
     this.baseDir = baseDir;
     ensureDirectory(this.baseDir);
@@ -46,6 +48,25 @@ class MultiTierTelemetryLedger {
     ensureDirectory(path.dirname(this.auditLogPath));
     this.lastAuditHash = this.#bootstrapAuditHash();
     this.sinkRegistry = createTelemetrySinkRegistry(sinks);
+    this.persistenceAdapter = null;
+    if (persistence) {
+      try {
+        this.persistenceAdapter = createTelemetryPersistence({
+          ...persistence,
+          telemetry: this,
+        });
+        if (this.persistenceAdapter?.init) {
+          Promise.resolve(this.persistenceAdapter.init()).catch((error) => {
+            // eslint-disable-next-line no-console
+            console.warn('Telemetry persistence initialisation failed, falling back to file logs:', error.message);
+            this.persistenceAdapter = null;
+          });
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Unable to create telemetry persistence adapter:', error.message);
+      }
+    }
   }
 
   #bootstrapAuditHash() {
@@ -100,6 +121,13 @@ class MultiTierTelemetryLedger {
       scope: options.tags || [],
     });
 
+    if (this.persistenceAdapter?.persist) {
+      Promise.resolve(this.persistenceAdapter.persist(entry, { visibility })).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.warn('Telemetry persistence error:', error.message);
+      });
+    }
+
     return entry;
   }
 
@@ -144,9 +172,14 @@ class MultiTierTelemetryLedger {
   }
 
   async flushExternal() {
+    const tasks = [];
     if (this.sinkRegistry) {
-      await this.sinkRegistry.flush();
+      tasks.push(this.sinkRegistry.flush());
     }
+    if (this.persistenceAdapter?.flush) {
+      tasks.push(this.persistenceAdapter.flush());
+    }
+    await Promise.all(tasks);
   }
 }
 

--- a/services/telemetryPersistence.js
+++ b/services/telemetryPersistence.js
@@ -1,0 +1,200 @@
+const fs = require('fs');
+const path = require('path');
+
+class TelemetryPersistenceAdapter {
+  constructor({ telemetry }) {
+    this.telemetry = telemetry;
+  }
+
+  async init() {
+    return undefined;
+  }
+
+  async persist() {
+    throw new Error('persist must be implemented by subclasses');
+  }
+
+  async flush() {
+    return undefined;
+  }
+}
+
+class JsonFileTelemetryAdapter extends TelemetryPersistenceAdapter {
+  constructor({ baseDir, fileName = 'telemetry.jsonl', telemetry }) {
+    super({ telemetry });
+    this.baseDir = baseDir || path.join(__dirname, '..', 'logs', 'telemetry');
+    this.filePath = path.join(this.baseDir, fileName);
+  }
+
+  async init() {
+    if (!fs.existsSync(this.baseDir)) {
+      fs.mkdirSync(this.baseDir, { recursive: true });
+    }
+    if (!fs.existsSync(this.filePath)) {
+      fs.writeFileSync(this.filePath, '', 'utf8');
+    }
+  }
+
+  async persist(entry) {
+    fs.appendFileSync(this.filePath, `${JSON.stringify(entry)}\n`, { encoding: 'utf8' });
+  }
+}
+
+class PostgresTelemetryAdapter extends TelemetryPersistenceAdapter {
+  constructor({ config = {}, tableName = 'vaultfire_telemetry', telemetry, clientFactory } = {}) {
+    super({ telemetry });
+    this.config = config;
+    this.tableName = tableName;
+    this.clientFactory = clientFactory;
+    this.client = null;
+  }
+
+  async init() {
+    if (this.client) {
+      return;
+    }
+    const factory =
+      this.clientFactory ||
+      (() => {
+        // eslint-disable-next-line global-require
+        const { Client } = require('pg');
+        return new Client(this.config);
+      });
+    this.client = await factory();
+    if (typeof this.client.connect === 'function') {
+      await this.client.connect();
+    }
+    await this.#ensureTable();
+  }
+
+  async #ensureTable() {
+    const ddl = `
+      CREATE TABLE IF NOT EXISTS ${this.tableName} (
+        id TEXT PRIMARY KEY,
+        event_type TEXT NOT NULL,
+        timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
+        severity TEXT,
+        tags JSONB,
+        payload JSONB,
+        correlation_id TEXT,
+        visibility JSONB,
+        recorded_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `;
+    await this.client.query(ddl);
+    // TODO(vaultfire-rewards-migration): backfill partitioning strategy once reward stream ledger moves on-chain.
+  }
+
+  async persist(entry, context = {}) {
+    if (!this.client) {
+      await this.init();
+    }
+    const statement = `
+      INSERT INTO ${this.tableName} (id, event_type, timestamp, severity, tags, payload, correlation_id, visibility)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      ON CONFLICT (id) DO NOTHING;
+    `;
+    const values = [
+      entry.id,
+      entry.eventType,
+      entry.timestamp,
+      entry.severity,
+      JSON.stringify(entry.tags || []),
+      JSON.stringify(entry.payload || {}),
+      entry.correlationId,
+      JSON.stringify(context.visibility || {}),
+    ];
+    await this.client.query(statement, values);
+  }
+
+  async flush() {
+    if (this.client && typeof this.client.end === 'function') {
+      await this.client.end();
+    }
+  }
+}
+
+class SupabaseTelemetryAdapter extends TelemetryPersistenceAdapter {
+  constructor({
+    config = {},
+    tableName = 'vaultfire_telemetry',
+    telemetry,
+    client,
+    clientFactory,
+  } = {}) {
+    super({ telemetry });
+    this.config = config;
+    this.tableName = tableName;
+    this.client = client || null;
+    this.clientFactory = clientFactory;
+  }
+
+  async init() {
+    if (this.client) {
+      return;
+    }
+    if (this.clientFactory) {
+      this.client = await this.clientFactory();
+      return;
+    }
+    // eslint-disable-next-line global-require
+    const { createClient } = require('@supabase/supabase-js');
+    const { url, serviceRoleKey } = this.config;
+    if (!url || !serviceRoleKey) {
+      throw new Error('Supabase adapter requires url and serviceRoleKey');
+    }
+    this.client = createClient(url, serviceRoleKey, this.config.options || {});
+  }
+
+  async persist(entry, context = {}) {
+    if (!this.client) {
+      await this.init();
+    }
+    const payload = {
+      id: entry.id,
+      event_type: entry.eventType,
+      timestamp: entry.timestamp,
+      severity: entry.severity,
+      tags: entry.tags || [],
+      payload: entry.payload || {},
+      correlation_id: entry.correlationId,
+      visibility: context.visibility || {},
+    };
+    const response = await this.client.from(this.tableName).insert(payload);
+    if (response.error) {
+      throw response.error;
+    }
+  }
+}
+
+function createTelemetryPersistence(config = {}) {
+  if (!config || config.type === 'json' || Object.keys(config).length === 0) {
+    return new JsonFileTelemetryAdapter(config.json || { baseDir: config.baseDir });
+  }
+  if (config.type === 'postgres') {
+    return new PostgresTelemetryAdapter({
+      config: config.connection || config.config || {},
+      tableName: config.tableName,
+      telemetry: config.telemetry,
+      clientFactory: config.clientFactory,
+    });
+  }
+  if (config.type === 'supabase') {
+    return new SupabaseTelemetryAdapter({
+      config,
+      tableName: config.tableName,
+      telemetry: config.telemetry,
+      client: config.client,
+      clientFactory: config.clientFactory,
+    });
+  }
+  return new JsonFileTelemetryAdapter(config.json || { baseDir: config.baseDir });
+}
+
+module.exports = {
+  TelemetryPersistenceAdapter,
+  JsonFileTelemetryAdapter,
+  PostgresTelemetryAdapter,
+  SupabaseTelemetryAdapter,
+  createTelemetryPersistence,
+};

--- a/services/trustSyncVerifier.js
+++ b/services/trustSyncVerifier.js
@@ -1,0 +1,69 @@
+class TrustSyncVerifier {
+  constructor({ telemetry, remote = {} } = {}) {
+    this.telemetry = telemetry || null;
+    this.remote = remote;
+    this.fetchImpl = remote.fetchImpl || (typeof fetch === 'function' ? fetch : require('node-fetch'));
+  }
+
+  record(event, payload, options) {
+    if (this.telemetry && typeof this.telemetry.record === 'function') {
+      this.telemetry.record(event, payload, options);
+    }
+  }
+
+  async verifyAnchor(anchor, context = {}) {
+    if (!this.remote || !this.remote.endpoint) {
+      this.record('trustSync.verification.skipped', { anchor, context }, {
+        tags: ['trust-sync', 'verification'],
+        visibility: { partner: false, ethics: true, audit: true },
+      });
+      return { status: 'skipped', reason: 'remote_verification_disabled' };
+    }
+
+    try {
+      const response = await this.fetchImpl(this.remote.endpoint, {
+        method: this.remote.method || 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(this.remote.apiKey ? { Authorization: `Bearer ${this.remote.apiKey}` } : {}),
+          ...(this.remote.headers || {}),
+        },
+        body: JSON.stringify({ anchor, context }),
+      });
+
+      if (!response.ok) {
+        const reason = `Remote verification failed with status ${response.status}`;
+        this.record('trustSync.verification.failed', { anchor, context, status: response.status }, {
+          tags: ['trust-sync', 'verification'],
+          visibility: { partner: false, ethics: true, audit: true },
+        });
+        return { status: 'pending', reason };
+      }
+
+      const result = await response.json().catch(() => ({ accepted: true }));
+      const accepted = result.accepted !== false;
+      if (accepted) {
+        this.record('trustSync.verification.accepted', { anchor, context, result }, {
+          tags: ['trust-sync', 'verification'],
+          visibility: { partner: false, ethics: true, audit: true },
+        });
+        return { status: 'accepted', result };
+      }
+
+      this.record('trustSync.verification.rejected', { anchor, context, result }, {
+        tags: ['trust-sync', 'verification'],
+        visibility: { partner: false, ethics: true, audit: true },
+      });
+      return { status: 'rejected', result };
+    } catch (error) {
+      this.record('trustSync.verification.deferred', { anchor, context, error: error.message }, {
+        tags: ['trust-sync', 'verification'],
+        visibility: { partner: false, ethics: true, audit: true },
+      });
+      // TODO(trust-sync-remote-migration): swap to async job queue when partner RPC exposes dedicated verification windows.
+      return { status: 'deferred', reason: error.message };
+    }
+  }
+}
+
+module.exports = TrustSyncVerifier;

--- a/tests/beliefSyncEngine.test.js
+++ b/tests/beliefSyncEngine.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const { BeliefSyncEngine } = require('../belief_sync_engine');
+
+const RELAY_DIR = path.join(__dirname, '..', 'logs', 'partner_relays');
+const RETRY_PATH = path.join(RELAY_DIR, 'retry-schedule.json');
+
+describe('BeliefSyncEngine remote relay scheduling', () => {
+  beforeEach(() => {
+    fs.rmSync(RELAY_DIR, { recursive: true, force: true });
+    fetchMock.resetMocks();
+  });
+
+  it('schedules retry entries when relay delivery fails', async () => {
+    fetchMock.mockResolvedValue({ ok: false });
+    const engine = new BeliefSyncEngine('session-1', '0xabcabcabcabcabcabcabcabcabcabcabcabcabca');
+    engine.registerExternalNode({ id: 'partner-a', endpoint: 'https://relay.invalid/payload' });
+
+    engine.syncChoice('fork-1', 'choice-a');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(fs.existsSync(RETRY_PATH)).toBe(true);
+    const schedule = JSON.parse(fs.readFileSync(RETRY_PATH, 'utf8'));
+    expect(schedule).toHaveLength(1);
+    expect(schedule[0].nodeId).toBe('partner-a');
+    expect(schedule[0].attempts).toBe(0);
+  });
+
+  it('retries scheduled entries and clears them on success', async () => {
+    fetchMock.mockResolvedValue({ ok: false });
+    const engine = new BeliefSyncEngine('session-2', '0x1234567890123456789012345678901234567890');
+    engine.registerExternalNode({ id: 'partner-b', endpoint: 'https://relay.invalid/payload' });
+
+    engine.syncChoice('fork-2', 'choice-b');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    let schedule = JSON.parse(fs.readFileSync(RETRY_PATH, 'utf8'));
+    expect(schedule).toHaveLength(1);
+    schedule[0].nextAttemptAt = new Date(Date.now() - 1000).toISOString();
+    fs.writeFileSync(RETRY_PATH, JSON.stringify(schedule, null, 2));
+
+    fetchMock.mockResolvedValueOnce({ ok: true });
+    const result = await engine.processRetryQueue({ now: Date.now() });
+    expect(result.attempted).toBe(1);
+    expect(result.delivered).toBe(1);
+
+    schedule = JSON.parse(fs.readFileSync(RETRY_PATH, 'utf8'));
+    expect(schedule).toHaveLength(0);
+  });
+});

--- a/tests/handshakeModules.test.js
+++ b/tests/handshakeModules.test.js
@@ -1,0 +1,51 @@
+const ApiKeyGate = require('../services/handshake/apiKeyGate');
+const GovernanceEnforcer = require('../services/handshake/governanceEnforcer');
+const HandshakeJWTAuthority = require('../services/handshake/jwtAuthority');
+const { SecretsManager } = require('../services/secretsManager');
+
+describe('Handshake module primitives', () => {
+  test('api key gate validates configured keys', () => {
+    const secretsManager = {
+      getSecret: (key) => {
+        if (key === 'VAULTFIRE_HANDSHAKE_API_KEYS') {
+          return 'alpha, beta';
+        }
+        return null;
+      },
+    };
+    const gate = new ApiKeyGate({ secretsManager });
+    const valid = gate.verify({ headers: { 'x-api-key': 'alpha' } });
+    expect(valid.valid).toBe(true);
+    const invalid = gate.verify({ headers: { 'x-api-key': 'gamma' } });
+    expect(invalid.valid).toBe(false);
+    expect(invalid.reason).toBe('invalid_key');
+  });
+
+  test('governance enforcer flags drift and multiplier floor', () => {
+    const enforcer = new GovernanceEnforcer({ thresholds: { multiplierCritical: 1, summaryWarning: 1.05 } });
+    const result = enforcer.assess({ multiplier: 0.8, summaryScore: 0.9 });
+    expect(result.status).toBe('blocked');
+    expect(result.alerts.some((alert) => alert.type === 'multiplier.floor')).toBe(true);
+    expect(result.alerts.some((alert) => alert.type === 'summary.threshold')).toBe(true);
+  });
+
+  test('jwt authority issues and verifies tokens with secrets manager', () => {
+    const secretsManager = new SecretsManager({
+      providers: [
+        {
+          getSecret: (key) => {
+            if (key === 'VAULTFIRE_HANDSHAKE_ACCESS_SECRET') {
+              return 'handshake-secret';
+            }
+            return null;
+          },
+        },
+      ],
+    });
+    const authority = new HandshakeJWTAuthority({ secretsManager });
+    const token = authority.issue({ wallet: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', role: 'partner', partnerId: 'test' });
+    const verification = authority.verify(token);
+    expect(verification.valid).toBe(true);
+    expect(verification.payload.partnerId).toBe('test');
+  });
+});

--- a/tests/telemetryLedger.test.js
+++ b/tests/telemetryLedger.test.js
@@ -59,4 +59,40 @@ describe('Multi-tier telemetry ledger', () => {
     expect(JSON.parse(Body).eventType).toBe('telemetry.event');
     expect(handler).toHaveBeenCalledWith(expect.objectContaining({ eventType: 'telemetry.event' }));
   });
+
+  it('persists records to a postgres adapter when configured', async () => {
+    const query = jest.fn().mockResolvedValue({});
+    const connect = jest.fn().mockResolvedValue({});
+    const end = jest.fn().mockResolvedValue({});
+    const clientFactory = async () => ({ query, connect, end });
+    const ledger = new MultiTierTelemetryLedger({
+      baseDir,
+      persistence: { type: 'postgres', clientFactory, tableName: 'telemetry_test' },
+    });
+
+    const entry = ledger.record('postgres.event', { ok: true }, { visibility: { partner: true } });
+    await ledger.flushExternal();
+
+    expect(connect).toHaveBeenCalled();
+    const insertCall = query.mock.calls.find(([statement]) => statement.includes('INSERT INTO telemetry_test'));
+    expect(insertCall).toBeDefined();
+    expect(insertCall[1][0]).toBe(entry.id);
+  });
+
+  it('persists records to a supabase adapter when configured', async () => {
+    const insert = jest.fn().mockResolvedValue({ data: [{}], error: null });
+    const from = jest.fn().mockReturnValue({ insert });
+    const clientFactory = async () => ({ from });
+    const ledger = new MultiTierTelemetryLedger({
+      baseDir,
+      persistence: { type: 'supabase', clientFactory, tableName: 'telemetry_test' },
+    });
+
+    ledger.record('supabase.event', { ok: true });
+
+    expect(from).toHaveBeenCalledWith('telemetry_test');
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.any(String), event_type: 'supabase.event' })
+    );
+  });
 });

--- a/tests/trustSync.test.js
+++ b/tests/trustSync.test.js
@@ -30,6 +30,14 @@ function createToken(overrides = {}) {
   });
 }
 
+function mockVerification(result = { accepted: true }, { status = 200 } = {}) {
+  fetchMock.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => result,
+  });
+}
+
 describe('Trust Sync protocol', () => {
   beforeAll(async () => {
     await identityStoreReady;
@@ -59,6 +67,7 @@ describe('Trust Sync protocol', () => {
 
     it('stores anchors at range boundaries and returns them decrypted', async () => {
       const token = createToken();
+      mockVerification();
       const create = await request(app)
         .post('/link-wallet')
         .set('Authorization', `Bearer ${token}`)
@@ -67,6 +76,7 @@ describe('Trust Sync protocol', () => {
       expect(create.body.anchor.beliefScore).toBe(1);
       expect(create.body.anchor.ensAlias).toBeNull();
       expect(create.body.anchor.originFingerprint).toHaveLength(64);
+      expect(create.body.verification.status).toBe('accepted');
 
       const fetchRes = await request(app)
         .get('/link-wallet')
@@ -115,11 +125,13 @@ describe('Trust Sync protocol', () => {
       partnerHooks.subscribe({ event: 'beliefBreach', partnerId: 'trust-partner', targetUrl: '' });
       partnerHooks.on('delivery:beliefBreach', (entry) => deliveries.push(entry));
 
+      mockVerification();
       const res = await request(app)
         .post('/link-wallet')
         .set('Authorization', `Bearer ${token}`)
         .send({ wallet: WALLET_BREACH, ens: 'breach.eth', beliefScore: 0.2 });
       expect(res.status).toBe(200);
+      expect(res.body.verification.status).toBe('accepted');
 
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(deliveries.some((entry) => entry.payload.beliefScore === 0.2)).toBe(true);
@@ -138,6 +150,15 @@ describe('Trust Sync protocol', () => {
       expect(res.status).toBe(201);
       expect(res.body.subscription.event).toBe('activation');
     });
+  });
+
+  it('previews reward stream wiring when viewing rewards', async () => {
+    const token = createToken();
+    const res = await request(app)
+      .get(`/vaultfire/rewards/${WALLET_REFRESH}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.streamPreview).toMatchObject({ status: 'pending-integration' });
   });
 
   describe('Signal Compass streaming', () => {
@@ -162,6 +183,7 @@ describe('Trust Sync protocol', () => {
         });
       });
 
+      mockVerification();
       await request(app)
         .post('/link-wallet')
         .set('Authorization', `Bearer ${token}`)
@@ -220,6 +242,7 @@ describe('Trust Sync protocol', () => {
         partnerId: 'trust-partner',
       });
 
+      mockVerification();
       const res = await request(app)
         .post('/vaultfire/mirror')
         .set('Authorization', `Bearer ${token}`)
@@ -227,5 +250,17 @@ describe('Trust Sync protocol', () => {
       expect(res.status).toBe(202);
       expect(res.body.summary.recommendedAction).toBeDefined();
     });
+  });
+
+  it('rejects anchors when remote verification denies the request', async () => {
+    const token = createToken();
+    mockVerification({ accepted: false, reason: 'mismatch' });
+    const res = await request(app)
+      .post('/link-wallet')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ wallet: WALLET_SECONDARY, beliefScore: 0.8 });
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('wallet.verification_rejected');
+    expect(res.body.verification.status).toBe('rejected');
   });
 });

--- a/tests/vaultfirerc.test.json
+++ b/tests/vaultfirerc.test.json
@@ -11,5 +11,11 @@
   },
   "mirror": {
     "outputChannel": "cli"
+  },
+  "verification": {
+    "remote": {
+      "endpoint": "https://verification.invalid/anchor",
+      "apiKey": "test-key"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a pluggable telemetry persistence layer with Postgres/Supabase adapters and durability tests
- scaffold relay retry scheduling, trust sync remote verification, and reward stream preview plumbing
- modularise partner handshake auth flows with shared secrets manager, socket relay hardening, and updated docs

## Testing
- npm test *(fails: environment is missing @babel/preset-env so Jest cannot start)*

------
https://chatgpt.com/codex/tasks/task_e_68db598d312c83228eeece18c5c8f17c