### PR TITLE
Finalize Vaultfire pilot configurations

### DIFF
--- a/SecureStore.py
+++ b/SecureStore.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 import json
 import hmac
 import hashlib
+import random
+import threading
 import time
+from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Iterable, Optional
+from typing import Callable, Deque, Iterable, Optional
+
+import atexit
 
 from mobile_mode import MOBILE_MODE
 
@@ -43,6 +48,10 @@ except Exception:  # pragma: no cover - fallback when full version unavailable
             retry_backoff: float = 0.05,
             retry_dir: str | Path | None = None,
             intent_logger: Optional[Callable[[dict], None]] = None,
+            telemetry_sink: Optional[Callable[[list[dict]], None]] = None,
+            telemetry_batch_size: int = 10,
+            telemetry_flush_interval: float = 2.5,
+            telemetry_jitter: float = 0.35,
         ) -> None:
             if len(key) not in (16, 24, 32):
                 raise ValueError("Key must be 16, 24, or 32 bytes for AES-GCM")
@@ -55,6 +64,17 @@ except Exception:  # pragma: no cover - fallback when full version unavailable
             self.retry_dir = retry_base.resolve()
             self.retry_dir.mkdir(parents=True, exist_ok=True)
             self.intent_logger = intent_logger
+            self.telemetry_sink = telemetry_sink
+            self.telemetry_batch_size = max(1, telemetry_batch_size)
+            self.telemetry_flush_interval = max(0.5, telemetry_flush_interval)
+            self.telemetry_jitter = max(0.0, min(1.0, telemetry_jitter))
+            self._telemetry_queue: Deque[dict] = deque()
+            self._telemetry_lock = threading.Lock()
+            self._telemetry_executor: ThreadPoolExecutor | None = (
+                ThreadPoolExecutor(max_workers=1) if telemetry_sink else None
+            )
+            self._telemetry_last_flush = time.perf_counter()
+            atexit.register(self.close)
 
         def _sign(self, payload: dict) -> str:
             msg = json.dumps(payload, sort_keys=True).encode()
@@ -86,11 +106,89 @@ except Exception:  # pragma: no cover - fallback when full version unavailable
             retry_path.write_text(json.dumps(payload, indent=2))
             return retry_path
 
+        def _compute_behavior_metrics(self, metadata: dict) -> dict:
+            score_raw = metadata.get("score", 0)
+            try:
+                score = float(score_raw)
+            except (TypeError, ValueError):
+                score = 0.0
+            score = max(0.0, min(score, 100.0))
+            tier = (metadata.get("tier") or "").lower()
+            tier_weight = 1.0 + min(0.35, len(tier) * 0.02)
+            belief_complexity = round((score / 100.0) * tier_weight, 4)
+            behavior_density = round(min(1.0, belief_complexity * 0.85 + 0.15), 4)
+            loyalty_sustain = round(min(1.0, 0.5 + (belief_complexity / 2.0)), 4)
+            return {
+                "beliefComplexityIndex": belief_complexity,
+                "behaviorDensityScore": behavior_density,
+                "loyaltySustainRate": loyalty_sustain,
+            }
+
+        def _enqueue_telemetry(self, event: str, metadata: dict, *, reason: str | None = None) -> None:
+            if not self.telemetry_sink or not self._telemetry_executor:
+                return
+            envelope = {
+                "event": event,
+                "timestamp": datetime.utcnow().isoformat(),
+                "wallet": metadata.get("wallet"),
+                "cid": metadata.get("cid"),
+                "tier": metadata.get("tier"),
+                "score": metadata.get("score"),
+                "reason": reason,
+                "metrics": self._compute_behavior_metrics(metadata),
+            }
+            with self._telemetry_lock:
+                self._telemetry_queue.append(envelope)
+            self._schedule_telemetry_flush()
+
+        def _schedule_telemetry_flush(self, *, force: bool = False) -> None:
+            if not self.telemetry_sink or not self._telemetry_executor:
+                return
+            should_flush = force
+            with self._telemetry_lock:
+                queue_size = len(self._telemetry_queue)
+                elapsed = time.perf_counter() - self._telemetry_last_flush
+                if force or queue_size >= self.telemetry_batch_size or elapsed >= self.telemetry_flush_interval:
+                    should_flush = True
+            if should_flush:
+                self._telemetry_executor.submit(self._flush_telemetry_worker, force)
+
+        def _flush_telemetry_worker(self, force: bool = False) -> None:
+            if not self.telemetry_sink:
+                return
+            if self.telemetry_jitter and not force:
+                jitter_window = self.telemetry_flush_interval * self.telemetry_jitter
+                time.sleep(random.uniform(0.0, jitter_window))
+            payloads = []
+            with self._telemetry_lock:
+                while self._telemetry_queue and (force or len(payloads) < self.telemetry_batch_size):
+                    payloads.append(self._telemetry_queue.popleft())
+                if payloads:
+                    self._telemetry_last_flush = time.perf_counter()
+            if not payloads:
+                return
+            try:
+                self.telemetry_sink(payloads)
+            except Exception:
+                with self._telemetry_lock:
+                    for item in reversed(payloads):
+                        self._telemetry_queue.appendleft(item)
+
+        def close(self) -> None:
+            if not self._telemetry_executor:
+                return
+            try:
+                self._flush_telemetry_worker(force=True)
+            finally:
+                self._telemetry_executor.shutdown(wait=False)
+                self._telemetry_executor = None
+
         def _attempt_store(self, file_path: Path, wallet: str, tier: str, score: int) -> dict:
             raw = file_path.read_bytes()
             cleaned = strip_exif(raw)
             content_hash = hashlib.sha256(cleaned).hexdigest()
-            payload = encrypt_bytes(self.key, cleaned)
+            associated_data = json.dumps({"wallet": wallet, "tier": tier}).encode()
+            payload = encrypt_bytes(self.key, cleaned, associated_data=associated_data)
             ciphertext = payload.ciphertext
             cid = hashlib.sha256(payload.nonce + ciphertext).hexdigest()
             enc_path = self.bucket / f"{cid}.bin"
@@ -149,6 +247,7 @@ except Exception:  # pragma: no cover - fallback when full version unavailable
                         metadata["timestamp"] if chain_log else None,
                     )
                 self._record_intent("stored", metadata)
+                self._enqueue_telemetry("securestore.stored", metadata)
                 return metadata
 
             assert last_error is not None
@@ -161,6 +260,7 @@ except Exception:  # pragma: no cover - fallback when full version unavailable
             }
             self._record_intent("retry-buffered", metadata, reason=str(last_error))
             self._persist_retry_payload(metadata, last_error)
+            self._enqueue_telemetry("securestore.retry-buffered", metadata, reason=str(last_error))
             raise last_error
 
         def decrypt(self, cid: str, metadata: dict) -> bytes:
@@ -175,7 +275,8 @@ except Exception:  # pragma: no cover - fallback when full version unavailable
             if not nonce_hex:
                 raise ValueError("Missing nonce in metadata")
             nonce = bytes.fromhex(nonce_hex)
-            return decrypt_bytes(self.key, nonce, ciphertext)
+            associated_data = json.dumps({"wallet": metadata.get("wallet"), "tier": metadata.get("tier")}).encode()
+            return decrypt_bytes(self.key, nonce, ciphertext, associated_data=associated_data)
 
         def validate_pipeline(
             self,
@@ -205,6 +306,12 @@ except Exception:  # pragma: no cover - fallback when full version unavailable
                 "duration": duration,
                 "throughput": throughput,
             }
+
+        def __del__(self) -> None:  # pragma: no cover - best effort cleanup
+            try:
+                self.close()
+            except Exception:
+                pass
 
     def calculate_signature(key: bytes, payload: dict) -> str:
         """Return signature for ``payload`` using ``key``."""

--- a/cli/deployVaultfire.js
+++ b/cli/deployVaultfire.js
@@ -4,6 +4,20 @@ const path = require('path');
 const { Command } = require('commander');
 const YAML = require('yamljs');
 
+const ROOT_DIR = path.join(__dirname, '..');
+
+function loadJson(filePath, fallback = {}) {
+  try {
+    const resolved = path.resolve(filePath);
+    if (!fs.existsSync(resolved)) {
+      return fallback;
+    }
+    return JSON.parse(fs.readFileSync(resolved, 'utf8'));
+  } catch (error) {
+    throw new Error(`Unable to parse JSON file ${filePath}: ${error.message}`);
+  }
+}
+
 function loadEnv(filePath) {
   const env = {};
   if (!fs.existsSync(filePath)) {
@@ -40,27 +54,64 @@ program
   .name('vaultfire-deploy')
   .description('Plan partner-ready Vaultfire deployments')
   .option('-e, --env <mode>', 'Environment mode', 'sandbox')
-  .option('-c, --config <file>', 'Path to service manifest', path.join(__dirname, '..', 'configs', 'deployment', 'telemetry.yaml'))
+  .option('-c, --config <file>', 'Path to service manifest', path.join(ROOT_DIR, 'configs', 'deployment', 'telemetry.yaml'))
   .option('--dry-run', 'Only render deployment plan', false)
   .option('--relay-config <file>', 'Webhook relay configuration file')
   .option('--rewards-config <file>', 'Reward stream configuration file')
+  .option('--handshake-config <file>', 'Handshake configuration file', path.join(ROOT_DIR, 'configs', 'deployment', 'handshake.yaml'))
   .parse(process.argv);
 
 const options = program.opts();
 
 function resolveEnvFile(mode) {
-  const baseDir = path.join(__dirname, '..', 'deploy');
+  const baseDir = path.join(ROOT_DIR, 'deploy');
   return path.join(baseDir, `.env.${mode}.example`);
+}
+
+function evaluateEthicsConfig(handshakeConfig) {
+  const ethics = handshakeConfig?.services?.handshake?.attestation || {};
+  return {
+    pluginId: ethics.pluginId || null,
+    manifestPath: ethics.manifestPath || null,
+    required: Boolean(ethics.required),
+  };
+}
+
+function evaluateBeliefMetrics(handshakeConfig) {
+  const metrics = handshakeConfig?.services?.handshake?.beliefComplexity?.metrics || [];
+  return metrics.map((metric) => ({
+    id: metric.id,
+    capture: metric.capture,
+  }));
+}
+
+function computeChangelogStatus(entries) {
+  if (!Array.isArray(entries)) {
+    return { finalized: null, pending: [] };
+  }
+  const pending = entries.filter((entry) => entry.update_block !== 'FINALIZED');
+  const finalized = [...entries]
+    .reverse()
+    .find((entry) => entry.update_block === 'FINALIZED');
+  return {
+    finalized,
+    pending,
+  };
 }
 
 try {
   const envFile = resolveEnvFile(options.env);
   const envVars = loadEnv(envFile);
   const primaryConfig = loadServiceConfig(options.config);
-  const relayConfig = loadServiceConfig(options.relayConfig || path.join(__dirname, '..', 'configs', 'deployment', 'relay.yaml'));
+  const relayConfig = loadServiceConfig(options.relayConfig || path.join(ROOT_DIR, 'configs', 'deployment', 'relay.yaml'));
   const rewardConfig = loadServiceConfig(
-    options.rewardsConfig || path.join(__dirname, '..', 'configs', 'deployment', 'reward-streams.yaml')
+    options.rewardsConfig || path.join(ROOT_DIR, 'configs', 'deployment', 'reward-streams.yaml')
   );
+  const handshakeConfig = loadServiceConfig(options.handshakeConfig);
+  const manifest = loadJson(path.join(ROOT_DIR, 'codex_manifest.json'));
+  const packageJson = loadJson(path.join(ROOT_DIR, 'package.json'));
+  const changelogEntries = loadJson(path.join(ROOT_DIR, 'changelog.json'), []);
+  const changelogStatus = computeChangelogStatus(changelogEntries);
 
   const summary = {
     mode: options.env,
@@ -69,6 +120,18 @@ try {
     telemetry: primaryConfig,
     relay: relayConfig,
     rewards: rewardConfig,
+    handshake: handshakeConfig,
+    ethics: evaluateEthicsConfig(handshakeConfig),
+    beliefMetrics: evaluateBeliefMetrics(handshakeConfig),
+    manifestIntegrity: {
+      status: manifest?.integrity_checks?.status || 'UNKNOWN',
+      checksum: manifest?.checksum || null,
+    },
+    versioning: {
+      packageVersion: packageJson.version,
+      finalizedChangelog: changelogStatus.finalized,
+      pendingChangelog: changelogStatus.pending.map((entry) => entry.change),
+    },
   };
 
   if (options.dryRun) {
@@ -79,6 +142,11 @@ try {
     console.log('Telemetry sink configuration:', summary.telemetry);
     console.log('Relay queue configuration:', summary.relay);
     console.log('Reward stream configuration:', summary.rewards);
+    console.log('Handshake configuration:', summary.handshake);
+    console.log('Ethics attestation policy:', summary.ethics);
+    console.log('Belief complexity metrics:', summary.beliefMetrics);
+    console.log('Manifest integrity status:', summary.manifestIntegrity);
+    console.log('Versioning + changelog status:', summary.versioning);
     console.log('To execute deployment, provide real credentials via environment variables and rerun with provider scripts.');
   }
 } catch (error) {

--- a/configs/deployment/handshake.yaml
+++ b/configs/deployment/handshake.yaml
@@ -1,4 +1,8 @@
-version: 1
+version: 2
+metadata:
+  revision: vaultfire-pilot-prod
+  lastUpdated: 2025-08-01T00:00:00Z
+  changelogRef: "Vaultfire v1.13 — belief multiplier module added"
 services:
   handshake:
     rotation:
@@ -12,7 +16,30 @@ services:
           value: vaultfire-rotation-q4
           activeFrom: 2024-10-01T00:00:00Z
           expiresAt: 2025-01-01T00:00:00Z
+    attestation:
+      pluginId: vaultfire-ethics-anchor
+      manifestPath: dashboard/dist/meta/ethics-manifest.json
+      required: true
+      ttlMinutes: 45
+    beliefComplexity:
+      telemetryChannel: telemetry.behavior
+      metrics:
+        - id: belief-complexity-index
+          capture: weighted
+        - id: belief-drift-delta
+          capture: differential
+        - id: trust-resonance
+          capture: rolling
     telemetryChannel: security.signature
     allowedDomains:
       - partners.vaultfire.app
       - vaultfire.app
+      - pilot.codex.vaultfire.app
+    sandbox:
+      enabled: true
+      allowedPartners:
+        - codex-labs
+        - beliefnet-scouts
+      behaviorAudit:
+        mode: mirrored
+        retentionDays: 14

--- a/configs/deployment/relay.yaml
+++ b/configs/deployment/relay.yaml
@@ -1,4 +1,7 @@
-version: 1
+version: 2
+metadata:
+  revision: vaultfire-pilot-prod
+  lastUpdated: 2025-08-01T00:00:00Z
 services:
   webhook-relay:
     maxRetries: 5
@@ -6,4 +9,22 @@ services:
     maxDelayMs: 15000
     jitter: 0.35
     concurrency: 8
-    telemetryChannel: webhook.delivery
+    queues:
+      production:
+        target: partners
+        deliveryGuarantee: at-least-once
+      sandbox:
+        target: sandbox
+        deliveryGuarantee: at-most-once
+        enabled: true
+    observability:
+      telemetryChannel: webhook.delivery
+      behaviorMetrics:
+        beliefComplexityStream: telemetry.behavior
+        loyaltySandboxFeed: telemetry.loyalty.sandbox
+      manifestIntegrity:
+        source: ../codex_manifest.json
+        requiredStatus: PASS
+    safeguards:
+      replayWindowMinutes: 20
+      enforceEthicsManifest: true

--- a/configs/deployment/reward-streams.yaml
+++ b/configs/deployment/reward-streams.yaml
@@ -1,4 +1,7 @@
-version: 1
+version: 2
+metadata:
+  revision: vaultfire-pilot-prod
+  lastUpdated: 2025-08-01T00:00:00Z
 services:
   reward-streams:
     ledger:
@@ -9,8 +12,22 @@ services:
     scheduling:
       intervalSeconds: 120
       jitter: 0.2
+      sandboxIntervalSeconds: 300
+    sandboxMode:
+      enabled: true
+      loyaltyPreviewCap: 250
+      cohortTag: codex-sandbox
+      expiryMinutes: 90
+    behaviorMetrics:
+      telemetryChannel: telemetry.loyalty.core
+      capture:
+        beliefComplexityIndex: true
+        behaviorDensityScore: true
+        loyaltySustainRate: true
     intents:
       - name: loyalty-bonus
         trigger: belief.score >= 0.8
       - name: partner-milestone
         trigger: partner.firstActivation
+      - name: sandbox-signal
+        trigger: sandboxMode.enabled && belief.score >= 0.6

--- a/configs/deployment/telemetry.yaml
+++ b/configs/deployment/telemetry.yaml
@@ -1,4 +1,7 @@
-version: 1
+version: 2
+metadata:
+  revision: vaultfire-pilot-prod
+  lastUpdated: 2025-08-01T00:00:00Z
 services:
   telemetry-ledger:
     persistence:
@@ -10,11 +13,28 @@ services:
         database: telemetry
         user: vaultfire
         password: change-me
+      retentionDays: 35
+    enrichment:
+      enableBeliefComplexity: true
+      fields:
+        - name: beliefComplexityIndex
+          source: handshake.beliefComplexity.metrics[0]
+        - name: behaviorDensityScore
+          source: reward-streams.behaviorMetrics.capture.behaviorDensityScore
+        - name: loyaltySustainRate
+          source: reward-streams.behaviorMetrics.capture.loyaltySustainRate
     sinks:
       - type: s3
         bucket: vaultfire-telemetry-archive
         prefix: partners/
       - type: firehose
         streamName: vaultfire-telemetry-stream
+      - type: realtime
+        channel: telemetry.behavior
+        batching:
+          intervalSeconds: 10
+          jitter: 0.4
+          maxBatchSize: 75
     failover:
       fallbackFile: ./logs/telemetry/persistence-failover.jsonl
+      beliefComplexitySnapshot: ./logs/telemetry/belief-complexity.jsonl

--- a/dashboard/src/services/api.js
+++ b/dashboard/src/services/api.js
@@ -6,8 +6,102 @@ const runtimeEnv =
   {};
 
 const API_BASE = runtimeEnv.VITE_VAULTFIRE_API || runtimeEnv.VAULTFIRE_API_BASE || 'http://localhost:4050';
+const DEFAULT_METADATA_BUDGET = 2400;
 let socket;
 let socketRefCount = 0;
+
+function estimateViewportBudget() {
+  if (typeof window !== 'undefined' && window.innerWidth && window.innerHeight) {
+    const area = window.innerWidth * window.innerHeight;
+    const normalized = Math.max(960, Math.floor(area * 0.45));
+    return Math.min(6400, normalized);
+  }
+  return DEFAULT_METADATA_BUDGET;
+}
+
+function clampMetadataForViewport(metadata) {
+  if (!metadata || typeof metadata !== 'object') {
+    return metadata;
+  }
+
+  const budget = estimateViewportBudget();
+  const serialized = JSON.stringify(metadata);
+  if (serialized.length <= budget) {
+    return metadata;
+  }
+
+  const trimmed = {};
+  let used = 2; // account for braces in JSON string
+  for (const [key, value] of Object.entries(metadata)) {
+    const chunk = JSON.stringify({ [key]: value });
+    const chunkSize = chunk.length;
+    if (used + chunkSize > budget) {
+      continue;
+    }
+    trimmed[key] = value;
+    used += chunkSize;
+  }
+
+  trimmed.__truncated__ = true;
+  trimmed.__originalBytes__ = serialized.length;
+  trimmed.__budget__ = budget;
+  return trimmed;
+}
+
+function enforceViewportBudget(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return payload;
+  }
+  const safePayload = { ...payload };
+  if (safePayload.metadata) {
+    safePayload.metadata = clampMetadataForViewport(safePayload.metadata);
+  }
+  if (safePayload.meta) {
+    safePayload.meta = clampMetadataForViewport(safePayload.meta);
+  }
+  return safePayload;
+}
+
+function isIosDevice() {
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') {
+    return false;
+  }
+  return /iPad|iPhone|iPod/.test(navigator.userAgent || '') && !window.MSStream;
+}
+
+function hintHapticFeedback(pattern = 'impactMedium') {
+  try {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    if (window.navigator?.vibrate) {
+      if (pattern === 'impactMedium') {
+        window.navigator.vibrate([12, 20, 12]);
+      } else {
+        window.navigator.vibrate(20);
+      }
+      return true;
+    }
+    const handler = window.webkit?.messageHandlers?.vaultfireHaptics;
+    if (handler?.postMessage && isIosDevice()) {
+      handler.postMessage({ type: pattern });
+      return true;
+    }
+  } catch (error) {
+    console.warn('Unable to dispatch haptic feedback hint', error);
+  }
+  return false;
+}
+
+function shouldTriggerHaptics(options, payload) {
+  if (options && Object.prototype.hasOwnProperty.call(options, 'triggerHaptics')) {
+    return Boolean(options.triggerHaptics);
+  }
+  if (payload && typeof payload === 'object' && payload.metadata?.triggerHaptics === false) {
+    return false;
+  }
+  return true;
+}
 
 async function request(path, { method = 'GET', body, headers } = {}) {
   const requestHeaders = { 'Content-Type': 'application/json', ...(headers || {}) };
@@ -48,12 +142,17 @@ function releaseSocket() {
   }
 }
 
-export async function syncBeliefPayload(payload, { mode } = {}) {
+export async function syncBeliefPayload(payload, { mode, triggerHaptics } = {}) {
   const headers = {};
   if (mode) {
     headers['X-Vaultfire-Mode'] = mode;
   }
-  return request('/vaultfire/sync-belief', { method: 'POST', body: payload, headers });
+  const safePayload = enforceViewportBudget(payload);
+  const response = await request('/vaultfire/sync-belief', { method: 'POST', body: safePayload, headers });
+  if (shouldTriggerHaptics({ triggerHaptics }, safePayload)) {
+    hintHapticFeedback('impactMedium');
+  }
+  return response;
 }
 
 export async function fetchSyncStatus() {
@@ -138,5 +237,8 @@ if (typeof module !== 'undefined') {
     fetchSecurityPosture,
     fetchHandshakeSecret,
     fetchStagingProfiles,
+    enforceViewportBudget,
+    clampMetadataForViewport,
+    hintHapticFeedback,
   };
 }

--- a/dashboard/vite.config.mjs
+++ b/dashboard/vite.config.mjs
@@ -4,25 +4,64 @@ import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
 
+const ETHICS_SOURCE_PATH = path.resolve(__dirname, '../ethics/core_v2.mdx');
+const DEV_META_DIR = path.resolve(__dirname, '.dev-meta');
+
+function ensureEthicsManifest(targetDir, commandLabel = 'build') {
+  if (!fs.existsSync(ETHICS_SOURCE_PATH)) {
+    console.warn('[vaultfire-ethics-anchor] ethics source not found, skipping manifest generation');
+    return;
+  }
+
+  const content = fs.readFileSync(ETHICS_SOURCE_PATH);
+  const hash = crypto.createHash('sha256').update(content).digest('hex');
+  const payload = {
+    source: 'ethics/core_v2.mdx',
+    hash,
+    generatedAt: new Date().toISOString(),
+    command: commandLabel,
+  };
+
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(path.join(targetDir, 'ethics-manifest.json'), JSON.stringify(payload, null, 2));
+}
+
 function ethicsAnchorPlugin() {
+  let targetDir = path.resolve(__dirname, 'dist/meta');
+  let commandLabel = 'build';
+
   return {
     name: 'vaultfire-ethics-anchor',
-    apply: 'build',
-    closeBundle() {
-      const sourcePath = path.resolve(__dirname, '../ethics/core_v2.mdx');
-      if (!fs.existsSync(sourcePath)) {
-        return;
+    enforce: 'post',
+    configResolved(resolvedConfig) {
+      commandLabel = resolvedConfig.command;
+      const buildOutDir = resolvedConfig.build?.outDir || 'dist';
+      targetDir =
+        resolvedConfig.command === 'build'
+          ? path.resolve(resolvedConfig.root, buildOutDir, 'meta')
+          : DEV_META_DIR;
+
+      if (process.env.VITE_DISABLE_ETHICS_PLUGIN) {
+        console.warn('[vaultfire-ethics-anchor] Ethics metadata plugin cannot be disabled; ignoring VITE_DISABLE_ETHICS_PLUGIN flag.');
       }
-      const distDir = path.resolve(__dirname, 'dist/meta');
-      const content = fs.readFileSync(sourcePath);
-      const hash = crypto.createHash('sha256').update(content).digest('hex');
-      const payload = {
-        source: 'ethics/core_v2.mdx',
-        hash,
-        generatedAt: new Date().toISOString(),
-      };
-      fs.mkdirSync(distDir, { recursive: true });
-      fs.writeFileSync(path.join(distDir, 'ethics-manifest.json'), JSON.stringify(payload, null, 2));
+    },
+    buildStart() {
+      ensureEthicsManifest(targetDir, commandLabel);
+    },
+    closeBundle() {
+      ensureEthicsManifest(targetDir, 'build');
+    },
+    configureServer(server) {
+      ensureEthicsManifest(targetDir, 'serve');
+      server.middlewares.use('/meta/ethics-manifest.json', (req, res, next) => {
+        const manifestPath = path.join(targetDir, 'ethics-manifest.json');
+        if (fs.existsSync(manifestPath)) {
+          res.setHeader('Content-Type', 'application/json');
+          res.end(fs.readFileSync(manifestPath));
+          return;
+        }
+        next();
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary
- elevate deployment YAMLs with production metadata, sandbox partner paths, and belief-complexity telemetry wiring
- enforce the ethics manifest plugin across dashboard builds while trimming mobile metadata payloads and adding haptic hints
- harden the CLI bootstrap and SecureStore fallback with manifest/changelog awareness, encrypted associated data, and jittered telemetry flushing

## Testing
- npm test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbbfb30d148322a3b3c3a0cebf43bc