### PR TITLE
feat: harden trust sync and loyalty multiplier flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Vaultfire Partner Changelog
 
+## 2025-09-19 — v2.6.0-alpha Partner Readiness
+- Added `signalRelay.retry()` with exponential backoff and a circuit-breaker
+  guard to stabilise remote belief sync deliveries during partner outages.
+- Hardened Trust Sync verification by enforcing timestamp windows, replay
+  protection, and checksum fallbacks exposed via `trustSync.verify()`.
+- Introduced the JavaScript loyalty engine with on-chain multiplier wiring,
+  telemetry anchors, and the `calculateMultiplier()` interface for partner
+  reward orchestration.
+- Expanded Jest coverage with dedicated suites for the signal relay, Trust Sync
+  verifier, and loyalty engine multiplier mapping.
+
 ## 2025-08-15 — v1.2.0-rc Partner Hardening
 - Added `pilot-loader.js` with `VAULTFIRE_MODULE_SCOPE` controls so pilots boot only CLI, dashboard, and belief engines when `pilot_mode=true`.
 - Introduced governance config loader supporting `.govrc`/`--config-path=` overrides, default-threshold warnings, and `npm run audit:gov` self-audits.

--- a/auth/expressExample.js
+++ b/auth/expressExample.js
@@ -378,6 +378,8 @@ app.post(
       partnerId: req.user.partnerId,
       wallet,
       event: 'link-wallet',
+      timestamp: new Date().toISOString(),
+      telemetryId: fingerprint.fingerprint,
     });
 
     if (verification.status === 'rejected') {

--- a/belief_sync_engine.js
+++ b/belief_sync_engine.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const EventEmitter = require('events');
 
 const { createFingerprint } = require('./services/originFingerprint');
+const { createSignalRelay } = require('./services/signalRelay');
 
 const GLOBAL_BUS = new EventEmitter();
 
@@ -53,41 +54,6 @@ function _ensureRelayDir() {
   }
 }
 
-function _loadRetrySchedule() {
-  if (!fs.existsSync(RETRY_SCHEDULE_PATH)) {
-    return [];
-  }
-  try {
-    const raw = fs.readFileSync(RETRY_SCHEDULE_PATH, 'utf8');
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch (error) {
-    return [];
-  }
-}
-
-function _writeRetrySchedule(entries) {
-  _ensureRelayDir();
-  fs.writeFileSync(RETRY_SCHEDULE_PATH, JSON.stringify(entries, null, 2));
-}
-
-function _scheduleRemoteRetry(node, payload, { attempts = 0, delayMs } = {}) {
-  const queue = _loadRetrySchedule();
-  const baseDelay = delayMs || Math.min(60 * 60 * 1000, 60 * 1000 * 2 ** attempts);
-  const scheduled = {
-    id: crypto.randomUUID(),
-    nodeId: node.id || node.partnerId || 'unknown',
-    endpoint: node.endpoint || null,
-    payload,
-    attempts,
-    nextAttemptAt: new Date(Date.now() + baseDelay).toISOString(),
-  };
-  queue.push(scheduled);
-  _writeRetrySchedule(queue);
-  return scheduled;
-  // TODO(remote-relay-roadmap): escalate retries to remote scheduler once governance approves cross-region relay orchestration.
-}
-
 function _encryptRelayPayload(entry, key) {
   if (!key) {
     return { mode: 'plain', payload: Buffer.from(JSON.stringify(entry)).toString('base64') };
@@ -109,26 +75,6 @@ function _encryptRelayPayload(entry, key) {
   }
 }
 
-async function _sendToEndpoint(endpoint, payload) {
-  if (!endpoint) {
-    return false;
-  }
-  try {
-    const fetchImpl = typeof fetch === 'function' ? fetch : require('node-fetch');
-    const response = await fetchImpl(endpoint, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Vaultfire-Signal': 'belief-sync',
-      },
-      body: JSON.stringify(payload),
-    });
-    return response.ok;
-  } catch (error) {
-    return false;
-  }
-}
-
 function _writeRelayFallback(node, entry) {
   _ensureRelayDir();
   const relayPath = path.join(RELAY_DIR, `${node.id || node.partnerId || 'partner'}.jsonl`);
@@ -147,6 +93,17 @@ class BeliefSyncEngine extends EventEmitter {
     this.session_id = session_id;
     this.ghost_id = ghost_id;
     this.partnerNodes = _loadPartnerNodes();
+    this.signalRelay = createSignalRelay({
+      queueFilePath: RETRY_SCHEDULE_PATH,
+      fallbackWriter: (node, payload) => {
+        try {
+          _writeRelayFallback(node, payload);
+        } catch (error) {
+          // ignore fallback write errors to keep relay attempts non-blocking
+        }
+      },
+      nowFn: () => Date.now(),
+    });
     GLOBAL_BUS.on('sync', e => {
       if (e.session_id === this.session_id && e.ghost_id !== this.ghost_id) {
         this.emit('sync', e);
@@ -191,12 +148,10 @@ class BeliefSyncEngine extends EventEmitter {
       return;
     }
     await Promise.all(
-      this.partnerNodes.map(async node => {
-        const ok = await _sendToEndpoint(node.endpoint, payload);
-        if (!ok) {
-          _writeRelayFallback(node, payload);
-          _scheduleRemoteRetry(node, payload, { attempts: 0 });
-        }
+      this.partnerNodes.map(async (node) => {
+        await this.signalRelay.dispatch(node, payload, {
+          telemetryId: entry.session_id,
+        });
       })
     );
   }
@@ -228,49 +183,7 @@ class BeliefSyncEngine extends EventEmitter {
   }
 
   async processRetryQueue({ now = Date.now(), maxAttempts = 5 } = {}) {
-    const queue = _loadRetrySchedule();
-    if (!queue.length) {
-      return { attempted: 0, delivered: 0, remaining: 0 };
-    }
-    const keep = [];
-    let attempted = 0;
-    let delivered = 0;
-    const nowTs = typeof now === 'number' ? now : new Date(now).getTime();
-
-    for (const job of queue) {
-      const nextAttemptTs = new Date(job.nextAttemptAt).getTime();
-      if (Number.isNaN(nextAttemptTs) || nextAttemptTs > nowTs) {
-        keep.push(job);
-        continue;
-      }
-      attempted += 1;
-      const ok = await _sendToEndpoint(job.endpoint, job.payload);
-      if (ok) {
-        delivered += 1;
-        continue;
-      }
-      const attempts = (job.attempts || 0) + 1;
-      if (attempts >= maxAttempts) {
-        const fallbackRecord = {
-          timestamp: new Date(nowTs).toISOString(),
-          node: job.nodeId,
-          endpoint: job.endpoint,
-          status: 'exhausted',
-          attempts,
-        };
-        _writeRelayFallback({ id: job.nodeId, endpoint: job.endpoint }, fallbackRecord);
-        continue;
-      }
-      const delay = Math.min(2 ** attempts * 60 * 1000, 6 * 60 * 60 * 1000);
-      keep.push({
-        ...job,
-        attempts,
-        nextAttemptAt: new Date(nowTs + delay).toISOString(),
-      });
-    }
-
-    _writeRetrySchedule(keep);
-    return { attempted, delivered, remaining: keep.length };
+    return this.signalRelay.retry({ now, maxAttempts });
   }
 }
 

--- a/docs/ghostkey_growth_protocol.md
+++ b/docs/ghostkey_growth_protocol.md
@@ -9,3 +9,13 @@ The Growth Protocol sets expectations for sustainable expansion.
 - **Ethics Anchored** – growth never overrides the Ethics Framework v2.0.
 
 Use the provided SDK endpoints to sync loyalty scores and integrate multiplier toggles within your applications.
+
+### `calculateMultiplier()`
+
+Vaultfire partners can call `calculateMultiplier(addressOrTelemetryId)` to obtain
+the latest loyalty multiplier. The engine cross-references belief sync
+telemetry IDs with registered wallets, applies the gas-efficient behaviour tier
+mapping, and multiplies the result by the current on-chain multiplier from the
+`GhostkeyLoyaltyLock` contract. The response includes the resolved address,
+tier label, tier multiplier, on-chain multiplier, and ISO timestamp for the
+last behavioural update so reward systems can audit every step in the chain.

--- a/docs/identity-linking.md
+++ b/docs/identity-linking.md
@@ -61,6 +61,19 @@ payloads to the remote verifier and includes the verdict in the response. A
 rejected verdict returns HTTP `409` so client SDKs can surface actionable
 messages. <!-- TODO(trust-sync-remote-migration): wire verifier retries into job queue -->
 
+### `trustSync.verify()`
+
+`trustSync.verify()` enforces timestamp validation and replay protection before
+dispatching the payload. Anchors must include an ISO timestamp within ±2
+minutes of the verifier's clock or they are immediately rejected. The verifier
+computes a deterministic replay key from the anchor fingerprint and partner
+context. Any subsequent call within the configured replay window returns
+`{ status: "rejected", reason: "replay_detected" }` and records telemetry for
+investigation. When the remote endpoint is unavailable the verifier now returns
+`{ status: 'pending' | 'deferred', checksum }` where `checksum` is a SHA-256
+digest of the payload. Partners can use that checksum to confirm the fallback
+entry matches the original request before re-processing it offline.
+
 ```json
 {
   "trustSync": {

--- a/docs/runbooks/belief-engine.md
+++ b/docs/runbooks/belief-engine.md
@@ -14,4 +14,4 @@
 ## Recovery Steps
 - Inspect `logs/partner_relays/*.jsonl` for buffered payloads and relay them after restoring connectivity.
 - Clear or amend `partner_port/external_nodes.json` to remove stale endpoints before re-registering nodes.
-- Execute `BeliefSyncEngine.processRetryQueue()` with a controlled `now` timestamp to drain accumulated retries.
+- Execute `signalRelay.retry({ now })` (via `BeliefSyncEngine.processRetryQueue`) with a controlled timestamp to drain queued deliveries and honour circuit breaker cooldowns.

--- a/services/loyaltyEngine.js
+++ b/services/loyaltyEngine.js
@@ -1,0 +1,187 @@
+const { Contract } = require('ethers');
+
+const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+const DEFAULT_TIERS = [
+  { tier: 'ember', minScore: 0, multiplier: 1 },
+  { tier: 'spark', minScore: 25, multiplier: 1.05 },
+  { tier: 'flame', minScore: 50, multiplier: 1.12 },
+  { tier: 'blaze', minScore: 75, multiplier: 1.25 },
+  { tier: 'phoenix', minScore: 90, multiplier: 1.4 },
+];
+
+class LoyaltyEngine {
+  constructor({
+    provider = null,
+    contractAddress = null,
+    contractInterface = ['function getMultiplier(address user) view returns (uint256)'],
+    telemetry = null,
+    tiers = DEFAULT_TIERS,
+    nowFn = () => Date.now(),
+    contractFactory = null,
+  } = {}) {
+    this.provider = provider;
+    this.contractAddress = contractAddress;
+    this.contractInterface = contractInterface;
+    this.telemetry = telemetry || null;
+    this.behaviorScores = new Map();
+    this.anchors = new Map();
+    this.now = typeof nowFn === 'function' ? nowFn : () => Date.now();
+    this.tierTable = this.#buildTierTable(tiers);
+    this.contract = null;
+    this.contractFactory =
+      typeof contractFactory === 'function'
+        ? contractFactory
+        : (address, iface, providerRef) => new Contract(address, iface, providerRef);
+    // TODO: reward scaling review (governance calibration pending)
+  }
+
+  #buildTierTable(tiers) {
+    const valid = Array.isArray(tiers) ? tiers : DEFAULT_TIERS;
+    const cleaned = valid
+      .map((entry) => ({
+        tier: entry.tier || 'unranked',
+        minScore: typeof entry.minScore === 'number' ? entry.minScore : 0,
+        multiplier: typeof entry.multiplier === 'number' ? entry.multiplier : 1,
+      }))
+      .sort((a, b) => a.minScore - b.minScore);
+    if (!cleaned.length) {
+      return DEFAULT_TIERS.slice();
+    }
+    return cleaned;
+  }
+
+  #normalizeAddress(address) {
+    if (!address || typeof address !== 'string') {
+      return null;
+    }
+    return address.toLowerCase();
+  }
+
+  #record(event, payload) {
+    if (this.telemetry && typeof this.telemetry.record === 'function') {
+      this.telemetry.record(event, payload, {
+        tags: ['loyalty', 'multiplier'],
+        visibility: { partner: true, ethics: false, audit: true },
+      });
+    }
+  }
+
+  #resolveTier(score) {
+    const value = Number.isFinite(score) ? score : 0;
+    let low = 0;
+    let high = this.tierTable.length - 1;
+    let result = this.tierTable[0];
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      const candidate = this.tierTable[mid];
+      if (value >= candidate.minScore) {
+        result = candidate;
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+    return result;
+  }
+
+  registerAnchor(telemetryId, address) {
+    const normalizedAddress = this.#normalizeAddress(address);
+    if (!telemetryId || !normalizedAddress) {
+      return null;
+    }
+    this.anchors.set(String(telemetryId), normalizedAddress);
+    return { telemetryId: String(telemetryId), address: normalizedAddress };
+  }
+
+  registerBehaviorScore(address, score, { telemetryId = null, metadata = null } = {}) {
+    const normalizedAddress = this.#normalizeAddress(address);
+    if (!normalizedAddress) {
+      throw new Error('Address is required to register behavior metrics.');
+    }
+    const numericScore = Number.isFinite(score) ? Number(score) : 0;
+    const entry = {
+      score: numericScore,
+      telemetryId: telemetryId ? String(telemetryId) : null,
+      updatedAt: new Date(this.now()).toISOString(),
+      metadata: metadata || null,
+    };
+    this.behaviorScores.set(normalizedAddress, entry);
+    if (entry.telemetryId) {
+      this.anchors.set(entry.telemetryId, normalizedAddress);
+    }
+    this.#record('loyalty.behavior.recorded', {
+      address: normalizedAddress,
+      telemetryId: entry.telemetryId,
+      score: numericScore,
+    });
+    return entry;
+  }
+
+  #resolveAddress(key) {
+    if (!key) {
+      return null;
+    }
+    if (typeof key === 'string' && ADDRESS_REGEX.test(key)) {
+      return key.toLowerCase();
+    }
+    const lookupKey = String(key);
+    if (this.anchors.has(lookupKey)) {
+      return this.anchors.get(lookupKey);
+    }
+    return null;
+  }
+
+  async #fetchOnChainMultiplier(address) {
+    if (!address || !this.provider || !this.contractAddress) {
+      return 1;
+    }
+    if (!this.contract) {
+      this.contract = this.contractFactory(this.contractAddress, this.contractInterface, this.provider);
+    }
+    try {
+      const raw = await this.contract.getMultiplier(address);
+      if (typeof raw === 'bigint') {
+        return Number(raw);
+      }
+      if (typeof raw === 'object' && raw !== null && typeof raw.toString === 'function') {
+        return Number(raw.toString());
+      }
+      const numeric = Number(raw);
+      return Number.isFinite(numeric) ? numeric : 1;
+    } catch (error) {
+      this.#record('loyalty.multiplier.onchain_error', {
+        address,
+        error: error.message,
+      });
+      return 1;
+    }
+  }
+
+  async calculateMultiplier(key) {
+    const address = this.#resolveAddress(key);
+    const behavior = address ? this.behaviorScores.get(address) : null;
+    const telemetryId = behavior?.telemetryId || (typeof key === 'string' && !ADDRESS_REGEX.test(key) ? String(key) : null);
+    const score = behavior?.score ?? 0;
+    const tier = this.#resolveTier(score);
+    const onChainMultiplier = await this.#fetchOnChainMultiplier(address);
+    const combined = Number((tier.multiplier * onChainMultiplier).toFixed(4));
+    const result = {
+      address,
+      multiplier: combined,
+      tier: tier.tier,
+      tierMultiplier: tier.multiplier,
+      onChainMultiplier,
+      telemetryId,
+      score,
+      updatedAt: behavior?.updatedAt || null,
+    };
+    this.#record('loyalty.multiplier.calculated', result);
+    return result;
+  }
+}
+
+module.exports = {
+  LoyaltyEngine,
+  DEFAULT_TIERS,
+};

--- a/services/signalRelay.js
+++ b/services/signalRelay.js
@@ -1,0 +1,344 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+function ensureDir(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+class SignalRelay {
+  constructor({
+    fetchImpl,
+    queueFilePath = null,
+    storage = null,
+    fallbackWriter = null,
+    telemetry = null,
+    randomFn = Math.random,
+    maxAttempts = 5,
+    baseDelayMs = 60 * 1000,
+    backoffFactor = 2,
+    maxDelayMs = 6 * 60 * 60 * 1000,
+    jitter = 0.25,
+    nowFn = () => Date.now(),
+    circuitBreaker = {},
+  } = {}) {
+    this.fetch =
+      typeof fetchImpl === 'function'
+        ? fetchImpl
+        : typeof fetch === 'function'
+        ? fetch
+        : require('node-fetch');
+    this.telemetry = telemetry || null;
+    this.randomFn = typeof randomFn === 'function' ? randomFn : Math.random;
+    this.maxAttempts = Math.max(1, maxAttempts || 1);
+    this.baseDelayMs = Math.max(10, baseDelayMs || 10);
+    this.backoffFactor = Math.max(1, backoffFactor || 1);
+    this.maxDelayMs = Math.max(this.baseDelayMs, maxDelayMs || this.baseDelayMs);
+    this.jitter = Math.max(0, jitter || 0);
+    this.now = typeof nowFn === 'function' ? nowFn : () => Date.now();
+    this.fallbackWriter = typeof fallbackWriter === 'function' ? fallbackWriter : null;
+    this.queueFilePath = queueFilePath;
+    this.memoryQueue = [];
+    this.storage = storage || this.#createStorage(queueFilePath);
+    this.circuitBreaker = {
+      failureThreshold: Math.max(1, circuitBreaker.failureThreshold || 3),
+      cooldownMs: Math.max(1000, circuitBreaker.cooldownMs || 60 * 1000),
+    };
+    this.circuitState = new Map();
+  }
+
+  #createStorage(queueFilePath) {
+    if (!queueFilePath) {
+      return {
+        read: () => this.memoryQueue.slice(),
+        write: (entries) => {
+          this.memoryQueue = Array.isArray(entries) ? entries.slice() : [];
+        },
+      };
+    }
+    return {
+      read: () => {
+        if (!fs.existsSync(queueFilePath)) {
+          return [];
+        }
+        try {
+          const raw = fs.readFileSync(queueFilePath, 'utf8');
+          const parsed = JSON.parse(raw);
+          return Array.isArray(parsed) ? parsed : [];
+        } catch (error) {
+          return [];
+        }
+      },
+      write: (entries) => {
+        ensureDir(path.dirname(queueFilePath));
+        fs.writeFileSync(queueFilePath, JSON.stringify(entries, null, 2));
+      },
+    };
+  }
+
+  #computeDelay(attempts) {
+    const exponent = Math.max(0, attempts - 1);
+    const base = Math.min(this.maxDelayMs, this.baseDelayMs * this.backoffFactor ** exponent);
+    const jitterValue = base * this.jitter * this.randomFn();
+    return Math.min(this.maxDelayMs, base + jitterValue);
+  }
+
+  #loadQueue() {
+    return this.storage.read();
+  }
+
+  #writeQueue(entries) {
+    this.storage.write(entries);
+  }
+
+  #getCircuit(nodeId) {
+    return (
+      this.circuitState.get(nodeId) || {
+        state: 'closed',
+        failures: 0,
+        openedAt: null,
+      }
+    );
+  }
+
+  #snapshotCircuit(nodeId) {
+    const { state, failures, openedAt } = this.#getCircuit(nodeId);
+    return {
+      state,
+      failures,
+      openedAt,
+    };
+  }
+
+  #allowAttempt(nodeId, nowTs) {
+    const state = this.#getCircuit(nodeId);
+    if (state.state === 'open') {
+      if (state.openedAt && nowTs - state.openedAt >= this.circuitBreaker.cooldownMs) {
+        state.state = 'half-open';
+        this.circuitState.set(nodeId, state);
+        return { allow: true, state: state.state };
+      }
+      const retryAt = (state.openedAt || nowTs) + this.circuitBreaker.cooldownMs;
+      return { allow: false, state: state.state, retryAt };
+    }
+    return { allow: true, state: state.state };
+  }
+
+  #registerSuccess(nodeId) {
+    this.circuitState.set(nodeId, {
+      state: 'closed',
+      failures: 0,
+      openedAt: null,
+    });
+  }
+
+  #registerFailure(nodeId, nowTs) {
+    const state = this.#getCircuit(nodeId);
+    if (state.state === 'half-open') {
+      state.state = 'open';
+      state.openedAt = nowTs;
+      state.failures = this.circuitBreaker.failureThreshold;
+    } else {
+      state.failures = (state.failures || 0) + 1;
+      if (state.failures >= this.circuitBreaker.failureThreshold) {
+        state.state = 'open';
+        state.openedAt = nowTs;
+      }
+    }
+    this.circuitState.set(nodeId, state);
+    return state;
+  }
+
+  #applyCircuitDelay(nodeId, targetTs, nowTs) {
+    const state = this.#getCircuit(nodeId);
+    if (state.state !== 'open') {
+      return targetTs;
+    }
+    const reopenAt = (state.openedAt || nowTs) + this.circuitBreaker.cooldownMs;
+    return Math.max(targetTs, reopenAt);
+  }
+
+  async #send(endpoint, payload) {
+    if (!endpoint) {
+      return { ok: false, status: 0, error: 'missing-endpoint' };
+    }
+    try {
+      const response = await this.fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Vaultfire-Signal': 'belief-sync',
+        },
+        body: JSON.stringify(payload),
+      });
+      return { ok: response.ok, status: response.status };
+    } catch (error) {
+      return { ok: false, status: 0, error: error?.message || 'network-error' };
+    }
+  }
+
+  #record(event, payload) {
+    if (this.telemetry && typeof this.telemetry.record === 'function') {
+      this.telemetry.record(event, payload, {
+        tags: ['signal', 'relay'],
+        visibility: { partner: true, ethics: true, audit: true },
+      });
+    }
+  }
+
+  async dispatch(node, payload, { telemetryId = null } = {}) {
+    const nodeId = node?.id || node?.partnerId || 'unknown';
+    const nowTs = this.now();
+    const result = await this.#send(node?.endpoint, payload);
+    if (result.ok) {
+      this.#registerSuccess(nodeId);
+      this.#record('signal.relay.delivered', {
+        nodeId,
+        endpoint: node?.endpoint || null,
+        telemetryId,
+        attempts: 0,
+        dispatchedAt: new Date(nowTs).toISOString(),
+      });
+      return { status: 'delivered', attempts: 0 };
+    }
+
+    this.#registerFailure(nodeId, nowTs);
+
+    const delay = this.#computeDelay(1);
+    const nextAttemptTs = this.#applyCircuitDelay(nodeId, nowTs + delay, nowTs);
+
+    const queue = this.#loadQueue();
+    const job = {
+      id: crypto.randomUUID ? crypto.randomUUID() : crypto.randomBytes(16).toString('hex'),
+      nodeId,
+      endpoint: node?.endpoint || null,
+      payload,
+      attempts: 0,
+      telemetryId,
+      nextAttemptAt: new Date(nextAttemptTs).toISOString(),
+      createdAt: new Date(nowTs).toISOString(),
+      lastError: result.error || `status:${result.status}`,
+      circuitState: this.#snapshotCircuit(nodeId),
+    };
+    queue.push(job);
+    this.#writeQueue(queue);
+
+    if (this.fallbackWriter) {
+      try {
+        this.fallbackWriter(node || { id: nodeId }, payload, { status: 'queued' });
+      } catch (error) {
+        // Ignore fallback errors to keep relay flow resilient
+      }
+    }
+
+    this.#record('signal.relay.scheduled', {
+      nodeId,
+      endpoint: node?.endpoint || null,
+      telemetryId,
+      attempts: 0,
+      nextAttemptAt: job.nextAttemptAt,
+      error: job.lastError,
+      circuit: job.circuitState,
+    });
+
+    return { status: 'scheduled', attempts: 0, job };
+  }
+
+  async retry({ now = this.now(), maxAttempts = this.maxAttempts } = {}) {
+    const nowTs = typeof now === 'number' ? now : new Date(now).getTime();
+    const queue = this.#loadQueue();
+    if (!queue.length) {
+      return { attempted: 0, delivered: 0, remaining: 0 };
+    }
+
+    const keep = [];
+    let attempted = 0;
+    let delivered = 0;
+
+    for (const job of queue) {
+      const dueTs = new Date(job.nextAttemptAt).getTime();
+      if (Number.isNaN(dueTs) || dueTs > nowTs) {
+        keep.push(job);
+        continue;
+      }
+
+      const nodeId = job.nodeId || 'unknown';
+      const circuit = this.#allowAttempt(nodeId, nowTs);
+      if (!circuit.allow) {
+        const retryAt = circuit.retryAt || nowTs + this.circuitBreaker.cooldownMs;
+        keep.push({
+          ...job,
+          nextAttemptAt: new Date(retryAt).toISOString(),
+          circuitState: this.#snapshotCircuit(nodeId),
+        });
+        continue;
+      }
+
+      attempted += 1;
+      const result = await this.#send(job.endpoint, job.payload);
+      if (result.ok) {
+        delivered += 1;
+        this.#registerSuccess(nodeId);
+        this.#record('signal.relay.delivered', {
+          nodeId,
+          endpoint: job.endpoint,
+          telemetryId: job.telemetryId || null,
+          attempts: job.attempts + 1,
+          dispatchedAt: new Date(this.now()).toISOString(),
+        });
+        continue;
+      }
+
+      const attempts = (job.attempts || 0) + 1;
+      const failureTime = this.now();
+      this.#registerFailure(nodeId, failureTime);
+      const errorCode = result.error || `status:${result.status}`;
+
+      if (attempts >= maxAttempts) {
+        if (this.fallbackWriter) {
+          try {
+            this.fallbackWriter(
+              { id: nodeId, endpoint: job.endpoint },
+              job.payload,
+              { status: 'exhausted', error: errorCode }
+            );
+          } catch (error) {
+            // ignore fallback failure
+          }
+        }
+        this.#record('signal.relay.failed', {
+          nodeId,
+          endpoint: job.endpoint,
+          telemetryId: job.telemetryId || null,
+          attempts,
+          error: errorCode,
+        });
+        continue;
+      }
+
+      const delay = this.#computeDelay(attempts + 1);
+      const nextAttempt = this.#applyCircuitDelay(nodeId, failureTime + delay, failureTime);
+      keep.push({
+        ...job,
+        attempts,
+        nextAttemptAt: new Date(nextAttempt).toISOString(),
+        lastError: errorCode,
+        circuitState: this.#snapshotCircuit(nodeId),
+      });
+    }
+
+    this.#writeQueue(keep);
+    return { attempted, delivered, remaining: keep.length };
+  }
+}
+
+function createSignalRelay(options) {
+  return new SignalRelay(options);
+}
+
+module.exports = {
+  SignalRelay,
+  createSignalRelay,
+};

--- a/services/trustSyncVerifier.js
+++ b/services/trustSyncVerifier.js
@@ -1,14 +1,73 @@
+const crypto = require('crypto');
+
 class TrustSyncVerifier {
   constructor({ telemetry, remote = {} } = {}) {
     this.telemetry = telemetry || null;
-    this.remote = remote;
-    this.fetchImpl = remote.fetchImpl || (typeof fetch === 'function' ? fetch : require('node-fetch'));
+    this.remote = remote || {};
+    this.fetchImpl = this.remote.fetchImpl || (typeof fetch === 'function' ? fetch : require('node-fetch'));
+    this.clockSkewMs = typeof this.remote.clockSkewMs === 'number' ? this.remote.clockSkewMs : 2 * 60 * 1000;
+    this.replayWindowMs = typeof this.remote.replayWindowMs === 'number' ? this.remote.replayWindowMs : 10 * 60 * 1000;
+    this.maxReplayEntries = typeof this.remote.maxReplayEntries === 'number' ? this.remote.maxReplayEntries : 500;
+    this.now = typeof this.remote.nowFn === 'function' ? this.remote.nowFn : () => Date.now();
+    this.replayCache = new Map();
   }
 
   record(event, payload, options) {
     if (this.telemetry && typeof this.telemetry.record === 'function') {
       this.telemetry.record(event, payload, options);
     }
+  }
+
+  #normalizeTimestamp(timestamp) {
+    if (!timestamp) {
+      return null;
+    }
+    const parsed = Date.parse(timestamp);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  #pruneReplayCache(nowTs) {
+    for (const [key, entry] of this.replayCache.entries()) {
+      if (nowTs - entry.timestamp > this.replayWindowMs) {
+        this.replayCache.delete(key);
+      }
+    }
+    while (this.replayCache.size > this.maxReplayEntries) {
+      const oldestKey = this.replayCache.keys().next().value;
+      this.replayCache.delete(oldestKey);
+    }
+  }
+
+  #makeReplayKey(anchor, context) {
+    const payload = {
+      wallet: anchor?.wallet || '',
+      fingerprint: anchor?.originFingerprint || '',
+      belief: anchor?.beliefScore ?? '',
+      partner: context.partnerId || '',
+      event: context.event || '',
+      telemetryId: context.telemetryId || '',
+    };
+    return crypto.createHash('sha256').update(JSON.stringify(payload)).digest('hex');
+  }
+
+  #isReplay(key, timestamp) {
+    const entry = this.replayCache.get(key);
+    if (!entry) {
+      return false;
+    }
+    if (timestamp - entry.timestamp > this.replayWindowMs) {
+      return false;
+    }
+    return entry.status === 'accepted' || entry.status === 'rejected';
+  }
+
+  #storeReplayKey(key, timestamp, status) {
+    this.replayCache.set(key, { timestamp, status });
+    this.#pruneReplayCache(timestamp);
+  }
+
+  #checksum(payload) {
+    return crypto.createHash('sha256').update(JSON.stringify(payload)).digest('hex');
   }
 
   async verifyAnchor(anchor, context = {}) {
@@ -20,7 +79,40 @@ class TrustSyncVerifier {
       return { status: 'skipped', reason: 'remote_verification_disabled' };
     }
 
+    const nowTs = this.now();
+    const normalizedContext = { ...context };
+    const timestampIso = normalizedContext.timestamp || new Date(nowTs).toISOString();
+    normalizedContext.timestamp = timestampIso;
+    const timestampMs = this.#normalizeTimestamp(timestampIso);
+    if (timestampMs === null || Math.abs(timestampMs - nowTs) > this.clockSkewMs) {
+      this.record(
+        'trustSync.verification.rejected',
+        { anchor, context: normalizedContext, reason: 'timestamp_out_of_range' },
+        {
+          tags: ['trust-sync', 'verification'],
+          visibility: { partner: false, ethics: true, audit: true },
+        }
+      );
+      return { status: 'rejected', reason: 'timestamp_out_of_range' };
+    }
+
+    const replayKey = this.#makeReplayKey(anchor, normalizedContext);
+    this.#pruneReplayCache(timestampMs);
+    if (this.#isReplay(replayKey, timestampMs)) {
+      this.record(
+        'trustSync.verification.replay',
+        { anchor, context: normalizedContext },
+        {
+          tags: ['trust-sync', 'verification'],
+          visibility: { partner: false, ethics: true, audit: true },
+        }
+      );
+      this.#storeReplayKey(replayKey, timestampMs, 'rejected');
+      return { status: 'rejected', reason: 'replay_detected' };
+    }
+
     try {
+      const payload = { anchor, context: normalizedContext };
       const response = await this.fetchImpl(this.remote.endpoint, {
         method: this.remote.method || 'POST',
         headers: {
@@ -28,40 +120,47 @@ class TrustSyncVerifier {
           ...(this.remote.apiKey ? { Authorization: `Bearer ${this.remote.apiKey}` } : {}),
           ...(this.remote.headers || {}),
         },
-        body: JSON.stringify({ anchor, context }),
+        body: JSON.stringify(payload),
       });
 
       if (!response.ok) {
         const reason = `Remote verification failed with status ${response.status}`;
-        this.record('trustSync.verification.failed', { anchor, context, status: response.status }, {
+        const checksum = this.#checksum(payload);
+        this.#storeReplayKey(replayKey, timestampMs, 'pending');
+        this.record('trustSync.verification.failed', { anchor, context: normalizedContext, status: response.status, checksum }, {
           tags: ['trust-sync', 'verification'],
           visibility: { partner: false, ethics: true, audit: true },
         });
-        return { status: 'pending', reason };
+        return { status: 'pending', reason, checksum };
       }
 
       const result = await response.json().catch(() => ({ accepted: true }));
       const accepted = result.accepted !== false;
       if (accepted) {
-        this.record('trustSync.verification.accepted', { anchor, context, result }, {
+        this.#storeReplayKey(replayKey, timestampMs, 'accepted');
+        this.record('trustSync.verification.accepted', { anchor, context: normalizedContext, result }, {
           tags: ['trust-sync', 'verification'],
           visibility: { partner: false, ethics: true, audit: true },
         });
         return { status: 'accepted', result };
       }
 
-      this.record('trustSync.verification.rejected', { anchor, context, result }, {
+      this.#storeReplayKey(replayKey, timestampMs, 'rejected');
+      this.record('trustSync.verification.rejected', { anchor, context: normalizedContext, result }, {
         tags: ['trust-sync', 'verification'],
         visibility: { partner: false, ethics: true, audit: true },
       });
       return { status: 'rejected', result };
     } catch (error) {
-      this.record('trustSync.verification.deferred', { anchor, context, error: error.message }, {
+      const payload = { anchor, context: normalizedContext };
+      const checksum = this.#checksum(payload);
+      this.#storeReplayKey(replayKey, timestampMs, 'pending');
+      this.record('trustSync.verification.deferred', { anchor, context: normalizedContext, error: error.message, checksum }, {
         tags: ['trust-sync', 'verification'],
         visibility: { partner: false, ethics: true, audit: true },
       });
       // TODO(trust-sync-remote-migration): swap to async job queue when partner RPC exposes dedicated verification windows.
-      return { status: 'deferred', reason: error.message };
+      return { status: 'deferred', reason: error.message, checksum };
     }
   }
 }

--- a/tests/loyaltyEngine.test.js
+++ b/tests/loyaltyEngine.test.js
@@ -1,0 +1,49 @@
+const { LoyaltyEngine, DEFAULT_TIERS } = require('../services/loyaltyEngine');
+
+describe('LoyaltyEngine', () => {
+  const createEngine = (options = {}) =>
+    new LoyaltyEngine({
+      ...options,
+      provider: options.provider ?? {},
+      contractAddress: '0x0000000000000000000000000000000000000001',
+    });
+
+  it('registers behavior scores and resolves tiers via address', async () => {
+    const engine = createEngine({ contractFactory: () => ({ getMultiplier: async () => 1 }) });
+    engine.registerBehaviorScore('0xabcDEFabcdefABCDefabcdefabcdefabcdefabcd', 82);
+    const result = await engine.calculateMultiplier('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd');
+    expect(result.tier).toBe('blaze');
+    expect(result.multiplier).toBeCloseTo(
+      DEFAULT_TIERS.find((tier) => tier.tier === 'blaze').multiplier,
+      5
+    );
+  });
+
+  it('links telemetry anchors to addresses and exposes calculateMultiplier for telemetry ids', async () => {
+    const engine = createEngine({ contractFactory: () => ({ getMultiplier: async () => 1 }) });
+    engine.registerBehaviorScore('0x9999999999999999999999999999999999999999', 45, { telemetryId: 'session-123' });
+    const result = await engine.calculateMultiplier('session-123');
+    expect(result.address).toBe('0x9999999999999999999999999999999999999999');
+    expect(result.telemetryId).toBe('session-123');
+    expect(result.tier).toBe('spark');
+  });
+
+  it('combines on-chain multipliers with tiered multipliers', async () => {
+    const engine = createEngine({
+      provider: {},
+      contractFactory: () => ({ getMultiplier: async () => 2 }),
+    });
+    engine.registerBehaviorScore('0x5555555555555555555555555555555555555555', 30);
+    const result = await engine.calculateMultiplier('0x5555555555555555555555555555555555555555');
+    expect(result.onChainMultiplier).toBe(2);
+    expect(result.multiplier).toBeCloseTo(2 * result.tierMultiplier, 5);
+  });
+
+  it('falls back to baseline multiplier when on-chain calls fail', async () => {
+    const engine = createEngine({
+      contractFactory: () => ({ getMultiplier: async () => { throw new Error('offline'); } }),
+    });
+    const result = await engine.calculateMultiplier('0x1111111111111111111111111111111111111111');
+    expect(result.multiplier).toBeCloseTo(1, 5);
+  });
+});

--- a/tests/signalRelay.test.js
+++ b/tests/signalRelay.test.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { SignalRelay } = require('../services/signalRelay');
+
+describe('SignalRelay', () => {
+  let queueDir;
+  let queuePath;
+  let currentTime;
+  let fetchMock;
+
+  beforeEach(() => {
+    queueDir = fs.mkdtempSync(path.join(os.tmpdir(), 'signal-relay-'));
+    queuePath = path.join(queueDir, 'queue.json');
+    currentTime = 1_000;
+    fetchMock = jest.fn();
+  });
+
+  afterEach(() => {
+    fs.rmSync(queueDir, { recursive: true, force: true });
+  });
+
+  function createRelay(overrides = {}) {
+    return new SignalRelay({
+      fetchImpl: fetchMock,
+      queueFilePath: queuePath,
+      nowFn: () => currentTime,
+      randomFn: () => 0,
+      baseDelayMs: 1_000,
+      circuitBreaker: { failureThreshold: 2, cooldownMs: 5_000 },
+      ...overrides,
+    });
+  }
+
+  it('queues failed dispatches with exponential backoff and circuit snapshots', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+    const relay = createRelay();
+
+    await relay.dispatch({ id: 'alpha', endpoint: 'https://invalid.example' }, { hello: 'world' }, { telemetryId: 'telemetry-1' });
+    let queue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
+    expect(queue).toHaveLength(1);
+    expect(queue[0].attempts).toBe(0);
+    expect(queue[0].circuitState.state).toBe('closed');
+    expect(queue[0].nextAttemptAt).toBe(new Date(currentTime + 1_000).toISOString());
+
+    currentTime = 2_000;
+    await relay.dispatch({ id: 'alpha', endpoint: 'https://invalid.example' }, { hello: 'world' });
+    queue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
+    expect(queue).toHaveLength(2);
+    const latest = queue[1];
+    expect(latest.circuitState.state).toBe('open');
+    expect(new Date(latest.nextAttemptAt).getTime()).toBe(2_000 + 5_000);
+  });
+
+  it('retries queued jobs and clears them on success', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+    const relay = createRelay();
+
+    await relay.dispatch({ id: 'beta', endpoint: 'https://invalid.example' }, { ping: true });
+    let queue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
+    expect(queue).toHaveLength(1);
+
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    currentTime = Date.parse(queue[0].nextAttemptAt) + 1;
+    const outcome = await relay.retry({ now: currentTime });
+    expect(outcome.attempted).toBe(1);
+    expect(outcome.delivered).toBe(1);
+    queue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
+    expect(queue).toHaveLength(0);
+  });
+
+  it('reschedules retries when circuit breaker remains open', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+    const relay = createRelay();
+
+    await relay.dispatch({ id: 'gamma', endpoint: 'https://invalid.example' }, { ping: true });
+    currentTime += 1_000;
+    await relay.dispatch({ id: 'gamma', endpoint: 'https://invalid.example' }, { ping: true });
+
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+    currentTime += 1_000;
+    let queue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
+    queue = queue.map((job) => ({ ...job, nextAttemptAt: new Date(currentTime - 100).toISOString() }));
+    fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2));
+
+    const result = await relay.retry({ now: currentTime });
+    expect(result.attempted).toBe(0);
+    const updated = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
+    expect(new Date(updated[0].nextAttemptAt).getTime()).toBeGreaterThan(currentTime);
+  });
+});

--- a/tests/trustSyncVerifier.test.js
+++ b/tests/trustSyncVerifier.test.js
@@ -1,0 +1,57 @@
+const TrustSyncVerifier = require('../services/trustSyncVerifier');
+
+describe('TrustSyncVerifier', () => {
+  const anchor = { wallet: '0xabc', beliefScore: 0.8, originFingerprint: 'fingerprint' };
+  const contextBase = { partnerId: 'partner-1', event: 'link-wallet', telemetryId: 'telemetry-1' };
+
+  it('skips verification when remote endpoint is disabled', async () => {
+    const verifier = new TrustSyncVerifier();
+    const result = await verifier.verifyAnchor(anchor, contextBase);
+    expect(result.status).toBe('skipped');
+  });
+
+  it('rejects anchors with timestamps outside the allowed skew', async () => {
+    const verifier = new TrustSyncVerifier({
+      remote: { endpoint: 'https://example.com/verify', fetchImpl: jest.fn() },
+    });
+    const result = await verifier.verifyAnchor(anchor, {
+      ...contextBase,
+      timestamp: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    });
+    expect(result.status).toBe('rejected');
+    expect(result.reason).toBe('timestamp_out_of_range');
+  });
+
+  it('detects replay attempts within the replay window', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ accepted: true }) });
+    const verifier = new TrustSyncVerifier({
+      remote: { endpoint: 'https://example.com/verify', fetchImpl, replayWindowMs: 60_000 },
+    });
+    const timestamp = new Date().toISOString();
+    const first = await verifier.verifyAnchor(anchor, { ...contextBase, timestamp });
+    expect(first.status).toBe('accepted');
+    const second = await verifier.verifyAnchor(anchor, { ...contextBase, timestamp });
+    expect(second.status).toBe('rejected');
+    expect(second.reason).toBe('replay_detected');
+  });
+
+  it('returns checksum metadata when remote verification fails', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+    const verifier = new TrustSyncVerifier({
+      remote: { endpoint: 'https://example.com/verify', fetchImpl },
+    });
+    const result = await verifier.verifyAnchor(anchor, contextBase);
+    expect(result.status).toBe('pending');
+    expect(result.checksum).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('surfaces checksum on network errors and defers verification', async () => {
+    const fetchImpl = jest.fn().mockRejectedValue(new Error('offline'));
+    const verifier = new TrustSyncVerifier({
+      remote: { endpoint: 'https://example.com/verify', fetchImpl },
+    });
+    const result = await verifier.verifyAnchor(anchor, contextBase);
+    expect(result.status).toBe('deferred');
+    expect(result.checksum).toMatch(/^[a-f0-9]{64}$/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated signal relay with exponential backoff, circuit breaker handling, and belief sync integration
- extend Trust Sync verification with timestamp validation, replay protection, and checksum fallbacks, wiring telemetry IDs through the API
- introduce a loyalty engine that maps behaviour tiers to on-chain multipliers and document the new interfaces

## Testing
- npm test -- --runTestsByPath tests/signalRelay.test.js tests/loyaltyEngine.test.js tests/trustSyncVerifier.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dbf9919d748322a218b4aacaceae30