### PR TITLE
Enable Node.js CI workflow and fix hanging tests

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -1,0 +1,25 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        env:
+          CI: true
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Vaultfire Protocol 🔥
 [![Last Test](https://img.shields.io/badge/last_test-%E2%9C%85-2ea44f?logo=github)](./logs/test-report.json)
+![Node.js CI](https://github.com/ghostkey316/vaultfire/actions/workflows/node-test.yml/badge.svg)
 **Belief-secured intelligence for partners who lead with ethics.**
 
 ## Project Overview

--- a/tests/integrity.test.js
+++ b/tests/integrity.test.js
@@ -22,6 +22,29 @@ fs.mkdirSync(tmpDir, { recursive: true });
 
 const integrityResults = [];
 
+const activePartnerSyncServers = new Set();
+
+function createTestPartnerSyncServer(options) {
+  const server = createPartnerSyncServer(options);
+  activePartnerSyncServers.add(server);
+  return server;
+}
+
+afterEach(() => {
+  activePartnerSyncServers.forEach((server) => {
+    if (server?.manifestFailover?.close) {
+      server.manifestFailover.close();
+    }
+    if (server?.io) {
+      server.io.removeAllListeners();
+      if (typeof server.io.close === 'function') {
+        server.io.close();
+      }
+    }
+  });
+  activePartnerSyncServers.clear();
+});
+
 function recordResult(name, passed, details) {
   integrityResults.push({ name, passed, details: details || null });
 }
@@ -142,7 +165,7 @@ defineIntegrityTest('CLI vote flow integrity', async () => {
 });
 
 defineIntegrityTest('Handshake discovery rejects unauthenticated access', async () => {
-  const server = createPartnerSyncServer({
+  const server = createTestPartnerSyncServer({
     telemetryPath: path.join(tmpDir, 'handshake-unauth-log.json'),
     votesPath: path.join(tmpDir, 'handshake-unauth-votes.json'),
     storageOptions: { provider: 'memory', readOnly: false },
@@ -164,7 +187,7 @@ defineIntegrityTest('Dashboard data reflects correct backend truth', async () =>
   const votesPath = path.join(tmpDir, 'sync-votes.json');
   fs.writeFileSync(votesPath, JSON.stringify([], null, 2));
 
-  const server = createPartnerSyncServer({
+  const server = createTestPartnerSyncServer({
     telemetryPath,
     votesPath,
     storageOptions: { provider: 'memory', readOnly: false },
@@ -270,7 +293,7 @@ defineIntegrityTest('Dashboard data reflects correct backend truth', async () =>
 });
 
 defineIntegrityTest('Rotation status admin route requires elevated access', async () => {
-  const server = createPartnerSyncServer({
+  const server = createTestPartnerSyncServer({
     telemetryPath: path.join(tmpDir, 'rotation-log.json'),
     votesPath: path.join(tmpDir, 'rotation-votes.json'),
     storageOptions: { provider: 'memory', readOnly: false },


### PR DESCRIPTION
## Summary
- add a focused Node.js GitHub Actions workflow that runs npm ci and npm test on pushes and pull requests
to main
- ensure integrity tests close manifest failover watchers so Jest exits cleanly
- surface the workflow status in the README with a badge

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc236c2ea883229b2783c465bc1d84