### PR TITLE
feat: add ops observability and governance audit trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,43 @@ When `pilot_mode=true` in the environment the loader automatically falls back to
                                    └─────────────────────────────┘
 ```
 
+## Quick Infra Model
+
+```mermaid
+flowchart LR
+  subgraph CI[CI/CD Hooks]
+    gha[GitHub Actions]
+    prbot[Compliance Bot]
+  end
+  subgraph Cloud[Vaultfire Deployment]
+    api[(Trust Sync API)]
+    sync[(Partner Sync Service)]
+    queue[(Webhook Queue)]
+    telemetry[(Telemetry Ledger)]
+    metrics[(Ops Metrics Exporter)]
+  end
+  subgraph Integrations[Partner Surface]
+    webhooks{{Signed Webhooks}}
+    dashboards[[Partner Dashboards]]
+    auditors[[Governance Reviewers]]
+  end
+
+  gha -->|lint/test| api
+  gha -->|bundle chart| sync
+  prbot -->|audit log check| auditors
+  api --> queue --> webhooks
+  sync --> queue
+  api --> telemetry
+  sync --> telemetry
+  telemetry --> metrics --> dashboards
+  auditors -. governance snapshots .-> telemetry
+```
+
+- **Terraform**: `infra/mvd.tf` provisions an AWS Fargate baseline (VPC, load balancer, task definitions, secrets) for the Trust Sync API and Partner Sync services.
+- **Helm (optional)**: `charts/vaultfire/` packages the same services plus a metrics Service and ServiceMonitor for Kubernetes clusters.
+- **CI/CD Hooks**: GitHub Actions trigger container builds, Terraform plans, Helm releases, and validate `governance/auditLog.json` updates before production rollouts.
+- **Metrics Fan-out**: The shared Ops Metrics exporter feeds `/metrics/ops` while structured telemetry continues to stream through `MultiTierTelemetryLedger` sinks.
+
 ## Module Guide
 
 ### 📦 Partner Sync Interface (`partnerSync.js`)

--- a/auth/expressExample.js
+++ b/auth/expressExample.js
@@ -19,6 +19,7 @@ const { createFingerprint } = require('../services/originFingerprint');
 const { loadTrustSyncConfig } = require('../config/trustSyncConfig');
 const TrustSyncVerifier = require('../services/trustSyncVerifier');
 const RewardStreamPlanner = require('../services/rewardStreamPlanner');
+const { createOpsMetrics } = require('../services/opsMetrics');
 
 const app = express();
 const port = process.env.PORT || 4002;
@@ -32,7 +33,8 @@ const telemetryLedger = new MultiTierTelemetryLedger(trustConfig.telemetry);
 const identityStore = new EncryptedIdentityStore(trustConfig.identityStore, telemetryLedger);
 const identityStoreReady = identityStore.init();
 const signalCompass = new SignalCompass({ telemetry: telemetryLedger, ...(trustConfig.signalCompass || {}) });
-const partnerHooks = new PartnerHookRegistry({ telemetry: telemetryLedger });
+const opsMetrics = createOpsMetrics();
+const partnerHooks = new PartnerHookRegistry({ telemetry: telemetryLedger, metrics: opsMetrics });
 const mirrorAgent = new AIMirrorAgent({ telemetry: telemetryLedger, ...(trustConfig.mirror || {}) });
 const trustVerifier = new TrustSyncVerifier({
   telemetry: telemetryLedger,
@@ -98,6 +100,11 @@ try {
 }
 
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+
+app.get('/metrics/ops', async (req, res) => {
+  res.set('Content-Type', opsMetrics.contentType());
+  res.send(await opsMetrics.metricsSnapshot());
+});
 
 app.get('/health', (req, res) => {
   res.json({
@@ -524,4 +531,5 @@ module.exports = {
   identityStoreReady,
   mirrorAgent,
   createServer,
+  opsMetrics,
 };

--- a/charts/vaultfire/Chart.yaml
+++ b/charts/vaultfire/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: vaultfire
+version: 0.1.0
+description: Helm chart for Vaultfire Trust Sync + Partner Sync services with Ops metrics exporter.
+appVersion: "3.0.0"
+keywords:
+  - vaultfire
+  - partner-sync
+  - observability
+type: application

--- a/charts/vaultfire/templates/_helpers.tpl
+++ b/charts/vaultfire/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{- define "vaultfire.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "vaultfire.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "vaultfire.labels" -}}
+app.kubernetes.io/name: {{ include "vaultfire.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "vaultfire.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vaultfire.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "vaultfire.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- printf "%s-sa" (include "vaultfire.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/vaultfire/templates/deployment.yaml
+++ b/charts/vaultfire/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vaultfire.fullname" . }}
+  labels:
+    {{- include "vaultfire.labels" . | nindent 4 }}
+spec:
+  replicas: {{ if .Values.autoscaling.enabled }}{{ .Values.autoscaling.minReplicas }}{{ else }}{{ .Values.desiredCount | default 2 }}{{ end }}
+  selector:
+    matchLabels:
+      {{- include "vaultfire.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "vaultfire.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "vaultfire.serviceAccountName" . }}
+      containers:
+        - name: trust-sync
+          image: {{ .Values.image.trustSync }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.trustSyncPort }}
+              name: trust-sync
+          env:
+            - name: PORT
+              value: "{{ .Values.service.trustSyncPort }}"
+            {{- range .Values.env.trustSync }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: trust-sync
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: trust-sync
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+        - name: partner-sync
+          image: {{ .Values.image.partnerSync }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.partnerSyncPort }}
+              name: partner-sync
+          env:
+            - name: PARTNER_SYNC_PORT
+              value: "{{ .Values.service.partnerSyncPort }}"
+            {{- range .Values.env.partnerSync }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: partner-sync
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: partner-sync
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/vaultfire/templates/service.yaml
+++ b/charts/vaultfire/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vaultfire.fullname" . }}
+  labels:
+    {{- include "vaultfire.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "vaultfire.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: trust-sync
+      port: {{ .Values.service.trustSyncPort }}
+      targetPort: trust-sync
+    - name: partner-sync
+      port: {{ .Values.service.partnerSyncPort }}
+      targetPort: partner-sync
+    - name: metrics
+      port: {{ .Values.service.metricsPort }}
+      targetPort: trust-sync

--- a/charts/vaultfire/templates/serviceaccount.yaml
+++ b/charts/vaultfire/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vaultfire.serviceAccountName" . }}
+  labels:
+    {{- include "vaultfire.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/vaultfire/templates/servicemonitor.yaml
+++ b/charts/vaultfire/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "vaultfire.fullname" . }}
+  labels:
+    {{- include "vaultfire.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.metrics.serviceMonitor.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "vaultfire.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: trust-sync
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      path: {{ .Values.metrics.path }}
+    - port: partner-sync
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      path: {{ .Values.metrics.path }}
+{{- end }}

--- a/charts/vaultfire/values.yaml
+++ b/charts/vaultfire/values.yaml
@@ -1,0 +1,46 @@
+image:
+  trustSync: public.ecr.aws/vaultfire/trust-sync:latest
+  partnerSync: public.ecr.aws/vaultfire/partner-sync:latest
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+
+service:
+  type: ClusterIP
+  trustSyncPort: 4002
+  partnerSyncPort: 4050
+  metricsPort: 9090
+
+desiredCount: 2
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: vaultfire.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources: {}
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+
+env:
+  trustSync: []
+  partnerSync: []
+
+metrics:
+  enabled: true
+  path: /metrics/ops
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    additionalLabels: {}

--- a/docs/compliance-review.md
+++ b/docs/compliance-review.md
@@ -1,0 +1,49 @@
+# Partner Compliance Review Guide
+
+This guide aligns Vaultfire controls with partner audit expectations and the new governance audit trail.
+
+## Preparation Checklist
+
+1. **Telemetry Verification**
+   - Confirm `/metrics/ops` is exposed from both the Trust Sync API (`auth/expressExample.js`) and Partner Sync service (`partnerSync.js`).
+   - Validate `security.posture.changed` entries are present in the telemetry logs after rotating handshake secrets.
+2. **Governance Configuration**
+   - Run `npm run audit:gov` (or `node governance/governance-core.js --audit`) to produce the latest governance assessment.
+   - Review the generated entry in `governance/auditLog.json` for the `governance.audit.summary` decision type.
+3. **Webhook Assurance**
+   - Inspect `vaultfire_webhook_delivery_queue_depth` and retry counters to confirm queue stability.
+   - Trigger a simulated webhook delivery failure and verify `ops.webhookQueue.retry` events.
+4. **Documentation Package**
+   - Collect the latest `docs/observability.md`, this guide, and `governance/runbooks.md` for partner distribution.
+
+## Review Flow
+
+| Stage | Owner | Evidence |
+|-------|-------|----------|
+| Kick-off | Partner Success | Observability documentation and audit log snapshot |
+| Technical Validation | Partner Engineering | Metrics scrape reports + webhook retry drill output |
+| Governance Sign-off | Compliance Lead | `governance/auditLog.json` entries + `npm run audit:gov` output |
+
+## Audit Log Expectations
+
+All governance events append to `governance/auditLog.json` using the schema:
+
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "decisionType": "<event>",
+  "actorWallet": "<wallet or null>",
+  "policyChange": "<status>",
+  "notes": "<context>"
+}
+```
+
+Partners should archive this log per engagement or configure automated exports via GitOps or S3 replication.
+
+## Escalation Paths
+
+- **Telemetry anomalies:** Notify Reliability Engineering; include queue depth graphs and retry counts.
+- **Governance failures:** Escalate to Compliance Lead with the associated audit log entry IDs.
+- **Posture mismatches:** Coordinate with Security Operations to validate secret rotation sources.
+
+For day-of-review coordination, pair this guide with `governance/runbooks.md`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,50 @@
+# Operational Observability
+
+Vaultfire services expose production-aligned telemetry through both structured logs and Prometheus metrics. This document outlines the default metrics, how to ingest them, and guidance for partner visibility.
+
+## Metrics Endpoints
+
+| Service | Endpoint | Notes |
+|---------|----------|-------|
+| `auth/expressExample.js` | `GET /metrics/ops` | Returns Prometheus text format metrics for queue depth, retries, posture changes, and default Node process series. |
+| `partnerSync.js` | `GET /metrics/ops` | Mirrors the API sample endpoint and includes the same operational gauges and counters. |
+
+All endpoints return `text/plain` content using the Prometheus exposition format. Scrape intervals of 15–30 seconds work well in test environments; production partners typically scrape every 5 seconds during launch windows and back off to 30 seconds during steady state.
+
+## Metric Catalogue
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `vaultfire_webhook_delivery_queue_depth{state="queued"}` | Gauge | Pending webhook deliveries waiting to be processed. |
+| `vaultfire_webhook_delivery_queue_depth{state="in_flight"}` | Gauge | Deliveries actively being attempted. |
+| `vaultfire_webhook_delivery_retries_total{reason="retryable"}` | Counter | Number of retry attempts triggered by transient errors. The `reason` label captures HTTP or network error categories when available. |
+| `vaultfire_webhook_delivery_outcomes_total{status="delivered"}` | Counter | Terminal delivery outcomes grouped by status (e.g. `delivered`, `error:500`, `failed:network-error`). |
+| `vaultfire_security_posture_changes_total{status="rotating"}` | Counter | Count of security posture transitions observed across governance refreshes. A `legacy` status indicates handshake secrets are optional. |
+
+Metrics originate from the shared `OpsMetrics` registry (`services/opsMetrics.js`). Each service reuses the registry so partners can plug the same exporter into internal observability stacks.
+
+## Structured Telemetry Extensions
+
+Telemetry events recorded via `MultiTierTelemetryLedger` now include:
+
+- `ops.webhookQueue.depth` – emitted whenever the combined queue and in-flight depth changes.
+- `ops.webhookQueue.retry` – emitted for each retry attempt with the latest attempt count and last error.
+- `ops.webhookQueue.delivery` – emitted when a delivery completes with final status and attempts.
+- `security.posture.changed` – emitted when handshake posture changes from legacy to rotating (or vice versa).
+
+Events surface in partner, ethics, and audit logs according to the configured visibility settings. Partners can stream these logs into SIEM tooling or leverage the bundled `partnerHooks` service for webhook-based notifications.
+
+## Alerting Suggestions
+
+1. **Queue Backlog:** Alert when `vaultfire_webhook_delivery_queue_depth{state="queued"}` exceeds 50 for more than 5 minutes.
+2. **Retry Storm:** Alert when the 5-minute rate of `vaultfire_webhook_delivery_retries_total` jumps above 10 per minute.
+3. **Posture Drift:** Alert when `vaultfire_security_posture_changes_total` increments unexpectedly outside scheduled rotations.
+4. **Delivery Failures:** Track ratios of `vaultfire_webhook_delivery_outcomes_total{status!~"delivered"}` to successful deliveries.
+
+## Exporting to Partner Systems
+
+- **Prometheus / Thanos:** Add scrape configs pointing at the `/metrics/ops` endpoints. TLS termination can be provided via API Gateway or Ingress controllers.
+- **Datadog:** Use the Prometheus integration or an OpenMetrics check with the same endpoints.
+- **Grafana Cloud:** Configure Grafana Agent/Alloy to scrape and forward metrics, then build dashboards highlighting queue pressure, retry ratios, and governance posture transitions.
+
+For more detail on compliance visibility, see `docs/compliance-review.md` and `governance/runbooks.md`.

--- a/governance/auditLog.json
+++ b/governance/auditLog.json
@@ -1,0 +1,9 @@
+[
+  {
+    "timestamp": "2024-01-01T00:00:00.000Z",
+    "decisionType": "init.bootstrap",
+    "actorWallet": null,
+    "policyChange": "audit-log-initialised",
+    "notes": "Baseline entry establishing the governance audit log schema."
+  }
+]

--- a/governance/auditLogger.js
+++ b/governance/auditLogger.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function ensureFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '[]\n', 'utf8');
+  }
+}
+
+function safeRead(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8').trim();
+    if (!raw) {
+      return [];
+    }
+    return JSON.parse(raw);
+  } catch (error) {
+    return [];
+  }
+}
+
+class AuditLogger {
+  constructor({ filePath = path.join(__dirname, 'auditLog.json'), now } = {}) {
+    this.filePath = filePath;
+    this.now = typeof now === 'function' ? now : () => new Date();
+    ensureFile(this.filePath);
+  }
+
+  logDecision({ decisionType, actorWallet, policyChange, notes } = {}) {
+    const entry = {
+      timestamp: this.now().toISOString(),
+      decisionType: decisionType || 'unspecified',
+      actorWallet: actorWallet || null,
+      policyChange: policyChange || null,
+      notes: notes || null,
+    };
+    const history = safeRead(this.filePath);
+    history.push(entry);
+    fs.writeFileSync(this.filePath, `${JSON.stringify(history, null, 2)}\n`, 'utf8');
+    return entry;
+  }
+
+  getEntries() {
+    return safeRead(this.filePath);
+  }
+}
+
+function createAuditLogger(options = {}) {
+  return new AuditLogger(options);
+}
+
+module.exports = {
+  AuditLogger,
+  createAuditLogger,
+};
+

--- a/governance/governance-core.js
+++ b/governance/governance-core.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const YAML = require('yamljs');
+const { createAuditLogger } = require('./auditLogger');
 
 const DEFAULT_THRESHOLDS = {
   multiplierCritical: 1.0,
@@ -74,7 +75,7 @@ function resolveConfigPath({ argv = process.argv, cwd = process.cwd() } = {}) {
 }
 
 function loadGovernanceConfig(options = {}) {
-  const { argv = process.argv, cwd = process.cwd(), defaultConfig = DEFAULT_CONFIG } = options;
+  const { argv = process.argv, cwd = process.cwd(), defaultConfig = DEFAULT_CONFIG, auditLogger } = options;
   const configPath = resolveConfigPath({ argv, cwd });
   let loadedConfig = { ...defaultConfig };
   let usingDefaults = true;
@@ -109,11 +110,22 @@ function loadGovernanceConfig(options = {}) {
     );
   }
 
-  return {
+  const result = {
     config: loadedConfig,
     source,
     usingDefaults,
   };
+
+  if (auditLogger) {
+    auditLogger.logDecision({
+      decisionType: 'governance.config.load',
+      actorWallet: null,
+      policyChange: source,
+      notes: JSON.stringify({ usingDefaults, thresholds }),
+    });
+  }
+
+  return result;
 }
 
 function auditGovernanceConfig(config = {}) {
@@ -186,8 +198,8 @@ function logRuntimeEvent(message, { level = 'info', details = {}, config = DEFAU
   return entry;
 }
 
-function runAudit(argv = process.argv) {
-  const { config } = loadGovernanceConfig({ argv });
+function runAudit(argv = process.argv, { auditLogger } = {}) {
+  const { config } = loadGovernanceConfig({ argv, auditLogger });
   const outcome = auditGovernanceConfig(config);
   config.auditPassed = outcome.ok && outcome.errors.length === 0;
   const logLevel = outcome.ok ? 'info' : 'error';
@@ -195,6 +207,12 @@ function runAudit(argv = process.argv) {
     level: logLevel,
     details: outcome,
     config,
+  });
+  auditLogger?.logDecision({
+    decisionType: 'governance.audit.summary',
+    actorWallet: null,
+    policyChange: outcome.ok ? 'approved' : 'blocked',
+    notes: JSON.stringify(outcome),
   });
   if (!outcome.ok) {
     outcome.errors.forEach((error) => {
@@ -205,14 +223,15 @@ function runAudit(argv = process.argv) {
 }
 
 if (require.main === module) {
+  const auditLogger = createAuditLogger();
   const shouldAudit = process.argv.slice(2).some((token) => token === '--audit');
   if (shouldAudit) {
-    const outcome = runAudit(process.argv);
+    const outcome = runAudit(process.argv, { auditLogger });
     if (!outcome.ok) {
       process.exitCode = 1;
     }
   } else {
-    const { config, source } = loadGovernanceConfig({ argv: process.argv });
+    const { config, source } = loadGovernanceConfig({ argv: process.argv, auditLogger });
     logRuntimeEvent('governance.config.loaded', {
       details: { source },
       config,

--- a/governance/runbooks.md
+++ b/governance/runbooks.md
@@ -1,0 +1,26 @@
+# Governance Runbooks Overview
+
+Use these runbooks alongside `docs/compliance-review.md` to satisfy partner audit checkpoints.
+
+## Daily Governance Checklist
+
+1. Run `npm run audit:gov` and review console output for warnings.
+2. Confirm a new entry exists in `governance/auditLog.json` with `decisionType` `governance.audit.summary`.
+3. Distribute the audit summary to compliance distribution lists.
+
+## Emergency Policy Override
+
+1. Document the request details in your internal ticketing system.
+2. Update the relevant policy file or `.govrc` override.
+3. Execute `node governance/governance-core.js --audit --config-path=<override>`.
+4. Review `governance/auditLog.json` for the appended decision entry.
+5. Notify partners by linking the audit log entry and `/metrics/ops` snapshots from both core services.
+
+## Posture Rotation Validation
+
+1. Rotate handshake secrets via your chosen secret manager.
+2. Call `/vaultfire/handshake` on `partnerSync.js` to confirm the new posture.
+3. Check telemetry for `security.posture.changed` events and verify `vaultfire_security_posture_changes_total` increased.
+4. Capture the audit log reference and circulate to compliance leads.
+
+Refer back to `docs/observability.md` for metric names and `docs/compliance-review.md` for review-day sequencing.

--- a/infra/mvd.tf
+++ b/infra/mvd.tf
@@ -1,0 +1,371 @@
+terraform {
+  required_version = ">= 1.4.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+variable "region" {
+  description = "AWS region to deploy the minimum viable Vaultfire stack."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Deployment environment label used for tagging."
+  type        = string
+  default     = "mvd"
+}
+
+variable "service_name" {
+  description = "Base name applied to ECS services and load balancers."
+  type        = string
+  default     = "vaultfire"
+}
+
+variable "container_image" {
+  description = "Container image for the Trust Sync API."
+  type        = string
+  default     = "public.ecr.aws/vaultfire/trust-sync:latest"
+}
+
+variable "partner_sync_container_image" {
+  description = "Container image for the Partner Sync service."
+  type        = string
+  default     = "public.ecr.aws/vaultfire/partner-sync:latest"
+}
+
+variable "desired_count" {
+  description = "Number of Fargate tasks to run."
+  type        = number
+  default     = 2
+}
+
+locals {
+  name = "${var.service_name}-${var.environment}"
+  tags = {
+    Project     = "Vaultfire"
+    Environment = var.environment
+  }
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = "10.40.0.0/16"
+  enable_dns_hostnames = true
+  tags                 = merge(local.tags, { Name = "${local.name}-vpc" })
+}
+
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = cidrsubnet(aws_vpc.this.cidr_block, 4, count.index)
+  map_public_ip_on_launch = true
+  availability_zone       = element(data.aws_availability_zones.available.names, count.index)
+  tags                    = merge(local.tags, { Name = "${local.name}-public-${count.index}" })
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(local.tags, { Name = "${local.name}-igw" })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(local.tags, { Name = "${local.name}-public-rt" })
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${local.name}-alb"
+  description = "Allow inbound HTTP"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 81
+    to_port     = 81
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.tags, { Name = "${local.name}-alb-sg" })
+}
+
+resource "aws_security_group" "service" {
+  name        = "${local.name}-svc"
+  description = "Allow traffic from the ALB"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description      = "Trust Sync"
+    from_port        = 4002
+    to_port          = 4002
+    protocol         = "tcp"
+    security_groups  = [aws_security_group.alb.id]
+  }
+
+  ingress {
+    description      = "Partner Sync"
+    from_port        = 4050
+    to_port          = 4050
+    protocol         = "tcp"
+    security_groups  = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.tags, { Name = "${local.name}-svc-sg" })
+}
+
+resource "aws_lb" "this" {
+  name               = substr("${local.name}-alb", 0, 32)
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = aws_subnet.public[*].id
+  tags               = merge(local.tags, { Name = "${local.name}-alb" })
+}
+
+resource "aws_lb_target_group" "trust_sync" {
+  name        = substr("${local.name}-trust", 0, 32)
+  port        = 4002
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.this.id
+  target_type = "ip"
+  health_check {
+    path                = "/health"
+    matcher             = "200"
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+    timeout             = 5
+    interval            = 30
+  }
+  tags = local.tags
+}
+
+resource "aws_lb_target_group" "partner_sync" {
+  name        = substr("${local.name}-partner", 0, 32)
+  port        = 4050
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.this.id
+  target_type = "ip"
+  health_check {
+    path                = "/status"
+    matcher             = "200"
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+    timeout             = 5
+    interval            = 30
+  }
+  tags = local.tags
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.trust_sync.arn
+  }
+}
+
+resource "aws_lb_listener" "partner" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 81
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.partner_sync.arn
+  }
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = "${local.name}-cluster"
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${local.name}"
+  retention_in_days = 14
+  tags              = local.tags
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${local.name}-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "ecs_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = local.name
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  execution_role_arn       = aws_iam_role.task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "trust-sync"
+      image     = var.container_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = 4002
+          hostPort      = 4002
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        {
+          name  = "PORT"
+          value = "4002"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-region        = var.region
+          awslogs-stream-prefix = "trust-sync"
+        }
+      }
+    },
+    {
+      name      = "partner-sync"
+      image     = var.partner_sync_container_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = 4050
+          hostPort      = 4050
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        {
+          name  = "PARTNER_SYNC_PORT"
+          value = "4050"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-region        = var.region
+          awslogs-stream-prefix = "partner-sync"
+        }
+      }
+    }
+  ])
+
+  tags = local.tags
+}
+
+resource "aws_ecs_service" "this" {
+  name            = "${local.name}-service"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = aws_subnet.public[*].id
+    security_groups = [aws_security_group.service.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.trust_sync.arn
+    container_name   = "trust-sync"
+    container_port   = 4002
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.partner_sync.arn
+    container_name   = "partner-sync"
+    container_port   = 4050
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  tags = local.tags
+}
+
+output "alb_dns_name" {
+  description = "DNS name for the Application Load Balancer."
+  value       = aws_lb.this.dns_name
+}
+
+output "metrics_endpoints" {
+  description = "Path mappings for scraping Prometheus metrics."
+  value = {
+    trust_sync   = "http://${aws_lb.this.dns_name}/metrics/ops"
+    partner_sync = "http://${aws_lb.this.dns_name}:81/metrics/ops"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^5.8.0",
         "node-fetch": "^2.6.7",
+        "prom-client": "^15.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sentiment": "^5.0.2",
@@ -2659,6 +2660,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -3497,6 +3507,12 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -6708,6 +6724,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-polyfill": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
@@ -7670,6 +7699,15 @@
       },
       "peerDependencies": {
         "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^6.10.0",
     "jsonwebtoken": "^9.0.2",
+    "prom-client": "^15.1.2",
     "mongodb": "^5.8.0",
     "node-fetch": "^2.6.7",
     "react": "^18.2.0",

--- a/partnerSync.js
+++ b/partnerSync.js
@@ -26,6 +26,8 @@ const ApiKeyGate = require('./services/handshake/apiKeyGate');
 const GovernanceEnforcer = require('./services/handshake/governanceEnforcer');
 const { loadGovernanceConfig } = require('./governance/governance-core');
 const SocketRelay = require('./services/handshake/socketRelay');
+const { createOpsMetrics } = require('./services/opsMetrics');
+const { createAuditLogger } = require('./governance/auditLogger');
 
 const PROTOCOL_MANIFEST_PATH = path.join(__dirname, 'manifest.json');
 const DEFAULT_MANIFEST_METADATA = {
@@ -98,6 +100,7 @@ function createPartnerSyncServer({
   deliveryQueue,
   sessionTtlMs = DEFAULT_SESSION_TTL_MS,
   governance = {},
+  auditLogger: providedAuditLogger,
 } = {}) {
   const app = express();
   const httpServer = http.createServer(app);
@@ -106,6 +109,8 @@ function createPartnerSyncServer({
   });
 
   const resolvedTelemetry = ensureTelemetry(telemetry);
+  const opsMetrics = createOpsMetrics();
+  const auditLogger = providedAuditLogger || createAuditLogger();
   const manifestFailover = createManifestFailover({
     manifestPath: PROTOCOL_MANIFEST_PATH,
     defaults: DEFAULT_MANIFEST_METADATA,
@@ -117,7 +122,7 @@ function createPartnerSyncServer({
   const discoveryTokenService = jwtAuthority.tokenService;
   const apiKeyGate = new ApiKeyGate({ secretsManager, telemetry: resolvedTelemetry });
   const securityPosture =
-    securityPostureManager || new SecurityPostureManager({ telemetry: resolvedTelemetry });
+    securityPostureManager || new SecurityPostureManager({ telemetry: resolvedTelemetry, opsMetrics });
   const engine = new BeliefMirrorEngine({ telemetryPath });
   const resolvedVotesPath = votesPath || path.join(__dirname, 'votes.json');
   const partnerStorage = createPartnerStorage({
@@ -134,7 +139,8 @@ function createPartnerSyncServer({
     telemetry: resolvedTelemetry,
   });
   const voteRepository = new VoteRepository({ filePath: resolvedVotesPath });
-  const webhookQueue = deliveryQueue || new WebhookDeliveryQueue();
+  const webhookQueue =
+    deliveryQueue || new WebhookDeliveryQueue({ telemetry: resolvedTelemetry, metrics: opsMetrics });
   const webhookSubscriptions = webhookTargets
     .map((target, index) => normalizeWebhookTarget(target, index))
     .filter((entry) => entry && entry.targetUrl);
@@ -151,6 +157,7 @@ function createPartnerSyncServer({
     audit: {
       passed: governanceAudit,
     },
+    auditLogger,
   });
   socketRelay.register({ jwtAuthority, apiKeyGate });
 
@@ -322,6 +329,11 @@ function createPartnerSyncServer({
 
   app.use(limiter);
   app.use(express.json({ limit: '1mb' }));
+
+  app.get('/metrics/ops', async (req, res) => {
+    res.set('Content-Type', opsMetrics.contentType());
+    res.send(await opsMetrics.metricsSnapshot());
+  });
 
   app.get('/vaultfire/handshake', (req, res) => {
     try {
@@ -557,6 +569,17 @@ function createPartnerSyncServer({
               visibility: { partner: false, ethics: true, audit: true },
             }
           );
+          auditLogger.logDecision({
+            decisionType: `governance.alert.${alert.type}`,
+            actorWallet: entry.wallet,
+            policyChange: enforcement.status,
+            notes: JSON.stringify({
+              tier: entry.tier,
+              multiplier: entry.multiplier,
+              beliefScore: summary.beliefScore,
+              severity: alert.severity || null,
+            }),
+          });
         });
         await Promise.all(governanceAlerts.map((alert) => notifyWebhooks('governance.alert', alert)));
         socketRelay.emit('governance-alert', governanceAlerts);
@@ -702,8 +725,9 @@ if (require.main === module) {
     ? process.env.PARTNER_SYNC_WEBHOOKS.split(',').map((target) => target.trim()).filter(Boolean)
     : [];
 
-  const { config: governanceConfig } = loadGovernanceConfig({ argv: process.argv });
-  const server = createPartnerSyncServer({ webhookTargets, governance: governanceConfig });
+  const auditLogger = createAuditLogger();
+  const { config: governanceConfig } = loadGovernanceConfig({ argv: process.argv, auditLogger });
+  const server = createPartnerSyncServer({ webhookTargets, governance: governanceConfig, auditLogger });
   const port = process.env.PARTNER_SYNC_PORT ? Number(process.env.PARTNER_SYNC_PORT) : 4050;
   server
     .start({ port })

--- a/services/deliveryQueue.js
+++ b/services/deliveryQueue.js
@@ -13,6 +13,8 @@ class WebhookDeliveryQueue {
     maxDelayMs = 10000,
     jitter = 0.25,
     randomFn = Math.random,
+    telemetry = null,
+    metrics = null,
   } = {}) {
     this.fetch = fetchImpl;
     this.maxRetries = maxRetries;
@@ -23,6 +25,10 @@ class WebhookDeliveryQueue {
     this.queue = [];
     this.processingPromise = null;
     this.pending = new Set();
+    this.telemetry = telemetry || null;
+    this.metrics = metrics || null;
+    this.lastDepth = 0;
+    this.#emitDepth();
   }
 
   #computeDelay(attempt) {
@@ -124,10 +130,12 @@ class WebhookDeliveryQueue {
     job.resolve = (result) => {
       resolve(result);
       this.pending.delete(promise);
+      this.#emitDepth();
     };
     this.pending.add(promise);
 
     this.queue.push(job);
+    this.#emitDepth();
     this.#ensureProcessing();
     return promise;
   }
@@ -147,12 +155,16 @@ class WebhookDeliveryQueue {
         job.lastError = outcome.error;
         job.nextAttempt = Date.now() + this.#computeDelay(job.attempt);
         this.queue.push(job);
+        this.#recordRetry({ job, outcome });
+        this.#emitDepth();
         continue;
       }
 
       const status = outcome.completed
         ? outcome.status
         : `failed:${outcome.error || 'exhausted'}`;
+
+      this.#recordCompletion({ job, status, outcome });
 
       job.resolve({
         partnerId: job.partnerId,
@@ -165,6 +177,66 @@ class WebhookDeliveryQueue {
         lastError: outcome.error,
         completedAt: new Date().toISOString(),
       });
+    }
+  }
+
+  #emitDepth() {
+    const snapshot = { queued: this.queue.length, inFlight: this.pending.size };
+    const total = snapshot.queued + snapshot.inFlight;
+    if (this.metrics?.updateQueueDepth) {
+      this.metrics.updateQueueDepth(snapshot);
+    }
+    if (this.telemetry && this.lastDepth !== total) {
+      this.telemetry.record('ops.webhookQueue.depth', snapshot, {
+        tags: ['ops', 'webhooks'],
+        visibility: { partner: false, ethics: true, audit: true },
+      });
+      this.lastDepth = total;
+    }
+  }
+
+  #recordRetry({ job, outcome }) {
+    if (this.metrics?.incrementRetry) {
+      this.metrics.incrementRetry(outcome.error || 'retryable');
+    }
+    if (this.telemetry) {
+      this.telemetry.record(
+        'ops.webhookQueue.retry',
+        {
+          partnerId: job.partnerId,
+          event: job.event,
+          targetUrl: job.targetUrl,
+          attempt: job.attempt,
+          error: outcome.error,
+        },
+        {
+          tags: ['ops', 'webhooks'],
+          visibility: { partner: false, ethics: true, audit: true },
+        }
+      );
+    }
+  }
+
+  #recordCompletion({ job, status, outcome }) {
+    if (this.metrics?.recordOutcome) {
+      this.metrics.recordOutcome(status);
+    }
+    if (this.telemetry) {
+      this.telemetry.record(
+        'ops.webhookQueue.delivery',
+        {
+          partnerId: job.partnerId,
+          event: job.event,
+          targetUrl: job.targetUrl,
+          status,
+          attempts: job.attempt,
+          lastError: outcome.error,
+        },
+        {
+          tags: ['ops', 'webhooks'],
+          visibility: { partner: true, ethics: true, audit: true },
+        }
+      );
     }
   }
 

--- a/services/handshake/governanceEnforcer.js
+++ b/services/handshake/governanceEnforcer.js
@@ -1,5 +1,5 @@
 class GovernanceEnforcer {
-  constructor({ telemetry, thresholds, audit } = {}) {
+  constructor({ telemetry, thresholds, audit, auditLogger } = {}) {
     this.telemetry = telemetry || null;
     this.thresholds = {
       multiplierCritical: thresholds?.multiplierCritical ?? 1,
@@ -8,6 +8,7 @@ class GovernanceEnforcer {
     this.audit = {
       passed: audit?.passed ?? false,
     };
+    this.auditLogger = auditLogger || null;
   }
 
   #telemetryConfig() {
@@ -37,6 +38,14 @@ class GovernanceEnforcer {
       : alerts.length
       ? 'warning'
       : 'ok';
+    if (alerts.length && this.auditLogger) {
+      this.auditLogger.logDecision({
+        decisionType: 'governance.enforcer.alert',
+        actorWallet: null,
+        policyChange: status,
+        notes: JSON.stringify({ alerts, thresholds: this.thresholds }),
+      });
+    }
     return { status, alerts };
     // TODO(governance-dao-thresholds): wire DAO-configured dynamic thresholds once partner councils expose signed snapshots.
   }

--- a/services/opsMetrics.js
+++ b/services/opsMetrics.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const client = require('prom-client');
+
+class OpsMetrics {
+  constructor({ registerDefaultMetrics = true } = {}) {
+    this.registry = new client.Registry();
+    if (registerDefaultMetrics) {
+      client.collectDefaultMetrics({ register: this.registry });
+    }
+
+    this.queueDepthGauge = new client.Gauge({
+      name: 'vaultfire_webhook_delivery_queue_depth',
+      help: 'Number of webhook deliveries queued or in-flight.',
+      registers: [this.registry],
+      labelNames: ['state'],
+    });
+
+    this.queueRetryCounter = new client.Counter({
+      name: 'vaultfire_webhook_delivery_retries_total',
+      help: 'Count of webhook delivery retry attempts.',
+      registers: [this.registry],
+      labelNames: ['reason'],
+    });
+
+    this.queueOutcomeCounter = new client.Counter({
+      name: 'vaultfire_webhook_delivery_outcomes_total',
+      help: 'Count of webhook delivery outcomes grouped by status.',
+      registers: [this.registry],
+      labelNames: ['status'],
+    });
+
+    this.postureChangeCounter = new client.Counter({
+      name: 'vaultfire_security_posture_changes_total',
+      help: 'Number of security posture change events observed.',
+      registers: [this.registry],
+      labelNames: ['status'],
+    });
+  }
+
+  updateQueueDepth({ queued, inFlight }) {
+    const pending = Number.isFinite(queued) ? queued : 0;
+    const active = Number.isFinite(inFlight) ? inFlight : 0;
+    this.queueDepthGauge.set({ state: 'queued' }, pending);
+    this.queueDepthGauge.set({ state: 'in_flight' }, active);
+  }
+
+  incrementRetry(reason = 'retryable') {
+    this.queueRetryCounter.inc({ reason });
+  }
+
+  recordOutcome(status = 'unknown') {
+    this.queueOutcomeCounter.inc({ status });
+  }
+
+  recordPostureChange(status = 'unknown') {
+    this.postureChangeCounter.inc({ status });
+  }
+
+  async metricsSnapshot() {
+    return this.registry.metrics();
+  }
+
+  contentType() {
+    return this.registry.contentType;
+  }
+}
+
+function createOpsMetrics(options = {}) {
+  return new OpsMetrics(options);
+}
+
+module.exports = {
+  OpsMetrics,
+  createOpsMetrics,
+};
+

--- a/services/partnerHooks.js
+++ b/services/partnerHooks.js
@@ -8,11 +8,12 @@ const EVENTS = {
 };
 
 class PartnerHookRegistry extends EventEmitter {
-  constructor({ telemetry, deliveryQueue } = {}) {
+  constructor({ telemetry, deliveryQueue, metrics } = {}) {
     super();
     this.telemetry = telemetry;
     this.subscriptions = new Map();
-    this.deliveryQueue = deliveryQueue || new WebhookDeliveryQueue();
+    this.deliveryQueue = deliveryQueue || new WebhookDeliveryQueue({ telemetry, metrics });
+    this.metrics = metrics || null;
   }
 
   subscribe({ partnerId, event, targetUrl, metadata = {} }) {

--- a/services/securityPosture.js
+++ b/services/securityPosture.js
@@ -21,14 +21,17 @@ function toBuffer(value) {
 }
 
 class SecurityPostureManager {
-  constructor({ telemetry } = {}) {
+  constructor({ telemetry, opsMetrics } = {}) {
     this.telemetry = telemetry || null;
+    this.opsMetrics = opsMetrics || null;
+    this.lastPostureFingerprint = null;
     this.refresh();
   }
 
   refresh() {
     this.config = loadSecurityConfig();
     this.rotation = resolveActiveSecret(this.config);
+    this.#maybeCapturePosture(this.#buildHandshakeSnapshot());
   }
 
   getActiveSecret() {
@@ -47,7 +50,7 @@ class SecurityPostureManager {
     return Boolean(this.getActiveSecret()?.value);
   }
 
-  getHandshakeSnapshot() {
+  #buildHandshakeSnapshot() {
     const current = this.getActiveSecret();
     return {
       status: current ? 'rotating' : 'legacy',
@@ -59,6 +62,12 @@ class SecurityPostureManager {
         allowLegacyHandshake: this.allowsLegacyHandshake(),
       },
     };
+  }
+
+  getHandshakeSnapshot() {
+    const snapshot = this.#buildHandshakeSnapshot();
+    this.#maybeCapturePosture(snapshot);
+    return snapshot;
   }
 
   getRotationStatus() {
@@ -101,6 +110,27 @@ class SecurityPostureManager {
       visibility: { partner: false, ethics: true, audit: true },
     };
     this.telemetry.record(event, payload, options || defaultOptions);
+  }
+
+  #maybeCapturePosture(snapshot) {
+    if (!snapshot) {
+      return;
+    }
+    const fingerprint = JSON.stringify({
+      status: snapshot.status,
+      requiresHandshake: snapshot.requiresHandshake,
+      posture: snapshot.posture,
+    });
+    if (fingerprint === this.lastPostureFingerprint) {
+      return;
+    }
+    this.lastPostureFingerprint = fingerprint;
+    this.opsMetrics?.recordPostureChange(snapshot.status);
+    this.#record('security.posture.changed', {
+      status: snapshot.status,
+      requiresHandshake: snapshot.requiresHandshake,
+      posture: snapshot.posture,
+    });
   }
 
   #candidateSecrets() {


### PR DESCRIPTION
## Summary
- add a shared OpsMetrics registry with Prometheus exporter endpoints and instrument the webhook queue, security posture, and partner sync telemetry
- wire a governance audit logger across config loads and alert hooks and document the partner compliance review workflow
- provide deployment artifacts including Terraform minimum viable infrastructure and an optional Vaultfire Helm chart

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc21cbbd0483228d17b6e0dfa3c03c