### PR TITLE
Add relay reliability roadmap and reward stream prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ Automation touchpoints remain unchanged: GitHub Actions runs tests (`.github/wor
 - Surfaces personal multiplier, tier, partner sync stream, mirror reflections, and BeliefVote history.
 - Consumes the Partner Sync API securely and subscribes to Socket.IO for live updates.
 
+## 📦 Streaming Rewards Roadmap
+- Prototype contract: [`contracts/RewardStream.sol`](./contracts/RewardStream.sol) – manages multiplier updates for future streaming payouts.
+- Integration interface: [`src/rewards/contractInterface.js`](./src/rewards/contractInterface.js) – simulates RPC calls until the chain deployment is finalized.
+- Roadmap reference: [`docs/gamified_yield_layer.md`](./docs/gamified_yield_layer.md) – outlines the loyalty mechanics the stream will eventually power.
+- TODO: Treasury vault orchestration and distribution logic for automated multiplier settlements.
+
 ### 🧪 Codex Integrity Test Suite (`tests/integrity.test.js`)
 - Jest-powered guardrails validating wallet-only identity, mirror math, CLI vote flow, and dashboard truth.
 - Emits `codex-integrity.json` with pass/fail metadata after each run for audit trails.

--- a/__tests__/relay.test.js
+++ b/__tests__/relay.test.js
@@ -1,0 +1,88 @@
+const { describe, it, expect, jest } = require('@jest/globals');
+
+describe('Relay reliability fallback and retry', () => {
+  function createRelay({ sendFn, redisClient, scheduleRetry }) {
+    const primaryQueue = [];
+
+    return {
+      enqueue(message) {
+        primaryQueue.push({ ...message, attempts: 0 });
+      },
+      async processPrimary() {
+        if (primaryQueue.length === 0) return null;
+        const job = primaryQueue.shift();
+        try {
+          await sendFn(job);
+          return 'delivered';
+        } catch (error) {
+          const nextAttempt = job.attempts + 1;
+          const payload = { ...job, attempts: nextAttempt };
+          redisClient.lpush('relay:fallback', JSON.stringify(payload));
+          const delay = Math.min(5 * 60 * 1000, 2 ** nextAttempt * 1000);
+          scheduleRetry(payload, delay, error);
+          return 'fallback';
+        }
+      },
+      async processFallback() {
+        const serialized = redisClient.rpop('relay:fallback');
+        if (!serialized) return null;
+        const job = JSON.parse(serialized);
+        try {
+          await sendFn(job);
+          return 'replayed';
+        } catch (error) {
+          const nextAttempt = job.attempts + 1;
+          const payload = { ...job, attempts: nextAttempt };
+          redisClient.lpush('relay:fallback', JSON.stringify(payload));
+          const delay = Math.min(5 * 60 * 1000, 2 ** nextAttempt * 1000);
+          scheduleRetry(payload, delay, error);
+          return 'fallback';
+        }
+      },
+    };
+  }
+
+  function createRedisMock() {
+    const queues = { 'relay:fallback': [] };
+    return {
+      lpush(queue, value) {
+        queues[queue] = queues[queue] || [];
+        queues[queue].unshift(value);
+        return queues[queue].length;
+      },
+      rpop(queue) {
+        queues[queue] = queues[queue] || [];
+        return queues[queue].pop() || null;
+      },
+      size(queue) {
+        return (queues[queue] || []).length;
+      },
+    };
+  }
+
+  it('queues failed messages to fallback and retries with backoff', async () => {
+    const redisMock = createRedisMock();
+    const scheduleRetry = jest.fn();
+    const sendFn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('network failure'))
+      .mockResolvedValueOnce('ok');
+
+    const relay = createRelay({ sendFn, redisClient: redisMock, scheduleRetry });
+    relay.enqueue({ id: 'job-1', payload: 'encrypted-payload' });
+
+    const primaryResult = await relay.processPrimary();
+    expect(primaryResult).toBe('fallback');
+    expect(redisMock.size('relay:fallback')).toBe(1);
+    expect(scheduleRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'job-1', attempts: 1 }),
+      2000,
+      expect.any(Error)
+    );
+
+    const fallbackResult = await relay.processFallback();
+    expect(fallbackResult).toBe('replayed');
+    expect(redisMock.size('relay:fallback')).toBe(0);
+    expect(sendFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/contracts/RewardStream.sol
+++ b/contracts/RewardStream.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract RewardStream {
+    address public admin;
+    mapping(address => uint256) private multipliers;
+
+    event MultiplierUpdated(address indexed user, uint256 multiplier);
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "not-authorized");
+        _;
+    }
+
+    constructor(address adminAddress) {
+        require(adminAddress != address(0), "admin-required");
+        admin = adminAddress;
+    }
+
+    function updateMultiplier(address user, uint256 multiplier) external onlyAdmin {
+        require(user != address(0), "user-required");
+        multipliers[user] = multiplier;
+        emit MultiplierUpdated(user, multiplier);
+    }
+
+    function getMultiplier(address user) external view returns (uint256) {
+        return multipliers[user];
+    }
+}

--- a/docs/relay-reliability.md
+++ b/docs/relay-reliability.md
@@ -1,0 +1,18 @@
+# Relay Reliability Roadmap
+
+## Current Fallback Queue Strategy
+- Primary relay channel streams encrypted payloads directly to partner webhooks.
+- On transient failures, the payload is mirrored into the existing fallback queue for manual replay by the ops team.
+- Operators monitor the fallback queue using the telemetry ledger and re-dispatch items during scheduled reliability sweeps.
+
+## Identified Gaps
+- The fallback queue does not currently support automated retries for encrypted relay jobs.
+- Messages remain in the queue until an operator intervenes, delaying downstream reconciliation windows.
+- There is no telemetry annotation linking fallback events to the originating relay span.
+
+## Proposal: Redis-Powered Retry Layer
+- Introduce a dedicated Redis stream that tracks retry attempts alongside payload metadata.
+- Apply exponential backoff beginning at 2 seconds and capping at 5 minutes to avoid saturation of partner endpoints.
+- Encrypt payloads at rest in Redis using envelope encryption to preserve existing security guarantees.
+- Emit structured telemetry (`relay.retry.enqueued`, `relay.retry.success`, `relay.retry.exhausted`) for observability and SLA reporting.
+- Auto-evict jobs that exceed the maximum retry threshold, notifying the ops channel for manual investigation.

--- a/docs/trust-sync.md
+++ b/docs/trust-sync.md
@@ -1,0 +1,16 @@
+# Trust Sync External Validation
+
+## Current Local Log Flow
+- Trust Sync stores anchor verification attempts in the local telemetry ledger for fast operator review.
+- Each anchor is annotated with decision metadata (accepted, rejected, deferred) and correlated with the originating wallet session.
+- Local log retention is capped at 30 days and replicated to the internal observability cluster during nightly syncs.
+
+## Roadmap: Remote RPC Expansion
+- Establish an external RPC verifier that can replay trust anchors against partner attestations.
+- Expose a signed webhook that partners can implement to confirm anchor authenticity during replay.
+- Support batched verification windows so partners can preflight large data migrations before going live.
+
+## External Attestation Partners (Planned)
+- **Summit Relay Cooperative** – pioneering cross-relay audit trails for encrypted payloads.
+- **Aurora Grid Validators** – providing zero-knowledge attestations for cross-chain sessions.
+- **Lumen Compliance Collective** – delivering jurisdiction-specific audit receipts for regulated markets.

--- a/src/rewards/contractInterface.js
+++ b/src/rewards/contractInterface.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * Placeholder interface for interacting with the on-chain reward stream contract.
+ * Swap these implementations with actual RPC calls when the RewardStream.sol contract
+ * is deployed to a configured network.
+ */
+class RewardContractInterface {
+  constructor({ provider, contractAddress }) {
+    this.provider = provider || null;
+    this.contractAddress = contractAddress || null;
+    this._multipliers = new Map();
+  }
+
+  /**
+   * Simulates sending an updated multiplier to the reward stream contract.
+   * @param {string} address - Wallet address receiving the reward multiplier.
+   * @param {number} multiplier - Multiplier factor (e.g., 1.0 = 100%).
+   */
+  async sendMultiplierUpdate(address, multiplier) {
+    if (!address) throw new Error('address-required');
+    if (typeof multiplier !== 'number' || Number.isNaN(multiplier)) {
+      throw new Error('invalid-multiplier');
+    }
+
+    this._multipliers.set(address.toLowerCase(), multiplier);
+    return {
+      hash: `0x${Math.random().toString(16).slice(2, 10)}`,
+      status: 'simulated',
+      address,
+      multiplier,
+    };
+  }
+
+  /**
+   * Retrieves the multiplier associated with the provided wallet address.
+   * @param {string} address
+   * @returns {Promise<number | null>}
+   */
+  async getUserMultiplier(address) {
+    if (!address) throw new Error('address-required');
+    const value = this._multipliers.get(address.toLowerCase());
+    return value ?? null;
+  }
+
+  /**
+   * Placeholder for future ERC-1155/721 streaming logic.
+   * Extend this method once the contract exposes NFT-based yield accrual.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  async streamTokenizedRewards(/* params */) {
+    throw new Error('reward-streaming-not-implemented');
+  }
+}
+
+module.exports = RewardContractInterface;

--- a/src/trust-sync/externalRPCVerifier.js
+++ b/src/trust-sync/externalRPCVerifier.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const SAMPLE_TELEMETRY = Object.freeze({
+  anchorsValidated: 3,
+  rejectedAnchors: 0,
+  lastAttestationBlock: 18765432,
+  partner: 'Summit Relay Cooperative',
+});
+
+/**
+ * Simulates verifying a remote signature for a trust anchor.
+ * @param {string} payloadHash - Hex-encoded hash of the anchor payload.
+ * @param {string} signature - Signature returned by the partner RPC.
+ * @returns {{ valid: boolean, reason?: string }}
+ */
+function verifySignature(payloadHash, signature) {
+  if (!payloadHash || !signature) {
+    return { valid: false, reason: 'missing-parameters' };
+  }
+
+  // Simple deterministic mock: signatures ending with even digit pass.
+  const lastChar = signature.slice(-1);
+  const evenDigit = ['0', '2', '4', '6', '8'].includes(lastChar);
+  return evenDigit
+    ? { valid: true }
+    : { valid: false, reason: 'remote-verifier-rejection' };
+}
+
+/**
+ * Returns a mocked telemetry payload from the remote trust verifier.
+ * @returns {Promise<object>}
+ */
+async function fetchRemoteTelemetry() {
+  return { ...SAMPLE_TELEMETRY, fetchedAt: new Date().toISOString() };
+}
+
+module.exports = {
+  verifySignature,
+  fetchRemoteTelemetry,
+};


### PR DESCRIPTION
## Summary
- document the relay reliability plan and add a jest simulation covering fallback and retry behaviour
- outline external RPC validation expansion with new trust sync documentation and verifier stubs
- prototype on-chain reward integrations with a solidity stub, js contract interface, and README roadmap updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc2adbd52483229e8f979af32cea00