### PR TITLE
Fix npm audit vulnerabilities with dependency overrides

### DIFF
--- a/.github/workflows/npm-audit-watchdog.yml
+++ b/.github/workflows/npm-audit-watchdog.yml
@@ -1,0 +1,65 @@
+name: Weekly npm audit watchdog
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Run npm audit
+        run: npm audit --json > audit-report.json
+      - name: Evaluate audit report
+        id: audit
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const report = JSON.parse(fs.readFileSync('audit-report.json', 'utf8'));
+          const total = report?.metadata?.vulnerabilities?.total ?? 0;
+          fs.writeFileSync('audit-total.txt', String(total));
+          if (total > 0) {
+            const lines = [];
+            lines.push('# npm audit report');
+            lines.push('');
+            lines.push(`Total vulnerabilities: ${total}`);
+            lines.push('');
+            lines.push('## Advisories');
+            for (const [id, entry] of Object.entries(report.vulnerabilities || {})) {
+              const via = (entry.via || []).map((v) => typeof v === 'string' ? v : v.name).filter(Boolean);
+              lines.push(`- ${id} (${entry.severity})`);
+              lines.push(`  - package: ${entry.name}`);
+              if (via.length) {
+                lines.push(`  - via: ${[...new Set(via)].join(', ')}`);
+              }
+              if (entry.nodes?.length) {
+                lines.push(`  - paths: ${entry.nodes.join(', ')}`);
+              }
+              if (entry.range) {
+                lines.push(`  - range: ${entry.range}`);
+              }
+            }
+            fs.writeFileSync('audit-summary.md', `${lines.join('\n')}\n`);
+          }
+          NODE
+          total=$(cat audit-total.txt)
+          echo "total=$total" >> "$GITHUB_OUTPUT"
+      - name: Create GitHub issue for vulnerabilities
+        if: steps.audit.outputs.total != '0'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: 'Security alert: npm audit detected vulnerabilities'
+          content-filepath: audit-summary.md
+          labels: security, automated

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+npm run audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Vaultfire Partner Changelog
 
+## 2025-09-30 — SECURITY: Fixed moderate transitive npm vulnerabilities
+- Resolved GHSA-pxg6-pf52-xh8x by forcing all `cookie` consumers, including Hardhat's bundled `@sentry/node`, onto the patched `0.7.2` release via `npm overrides`.
+- Eliminated GHSA-52f5-9888-hmc6 by pinning `tmp` to `0.2.5` for `solc` and any future consumers, removing the need for sandbox wrappers.
+- Added a Husky pre-commit hook that blocks commits when `npm audit` reports vulnerabilities and scheduled a weekly CI audit watchdog that auto-files GitHub issues with advisory context.
+
 ## 2025-10-12 — Mobile Telemetry Hardening & Safety Controls
 - Added mobile-aware residency, partner hook, and node telemetry updates that honour the `MOBILE_MODE` environment flag and
   hybrid runtime override.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,22 +17,15 @@
 - Include reproduction steps, environment details, and potential impact. GPG key: `B7F5 F0CC 9D62 73F8 214A  792F 1A63 5ED4 7C3B 9F3E`.
 - Critical issues receive acknowledgement within 24 hours and coordinated disclosure is preferred.
 
-## Dependency Compensating Controls
-- **GHSA-pxg6-pf52-xh8x (`cookie` <0.7.0 via `hardhat` → `@sentry/node@5.30.0`):**
-  - `infra/hardhat-sandbox.js` now short-circuits Hardhat's internal Sentry bootstrap with a no-op stub that never instantiates
-    the vulnerable `cookie` parser, while still allowing first-party code to load the modern `@sentry/node@10.x` dependency.
-  - The sandbox also enforces loopback-only RPC URLs and disables remote telemetry to prevent any Hardhat-managed process from
-    accepting untrusted cookie headers.
-  - **Future remediation:** Track Hardhat releases monthly and upgrade once a version bundles a patched Sentry stack (or removes
-    the dependency entirely). Remove the stub once the upstream chain ships a fixed `cookie` >=0.7.0.
-- **GHSA-52f5-9888-hmc6 (`tmp` <=0.2.3 via `solc`):**
-  - The sandbox wraps the `tmp` module whenever it is required from `solc`/Hardhat, forcing all temporary directories into
-    `.vaultfire_tmp/hardhat/sandbox-tmp` with `0o700` ownership and ignoring caller-provided `dir` hints that could point to
-    symlink traps.
-  - `TMPDIR`, `TMP`, and `TEMP` environment variables are pinned to the sandbox directory before Hardhat executes, closing the
-    symbolic link escalation vector documented in the advisory.
-  - **Future remediation:** Monitor the `solc` and `tmp` release streams during the first week of each month. Once a patched
-    `tmp` (>0.2.3) is published and consumed by `solc`, drop the wrapper and lock to the remediated version in `package-lock.json`.
+## Dependency Remediation Log
+- **2025-09-30 · Vaultfire `1.2.0-rc` · GHSA-pxg6-pf52-xh8x (`cookie` <0.7.0 via `hardhat` → `@sentry/node@5.30.0`):**
+  - Hardhat's transitive `@sentry/node` dependency is now forced to consume `cookie@0.7.2` through `package.json` overrides, eliminating the out-of-bounds cookie parsing vector without relying on sandbox stubs.
+  - The repository-wide override also dedupes all other `cookie` consumers (Express, Socket.IO) on the same patched release to guarantee uniform behaviour.
+- **2025-09-30 · Vaultfire `1.2.0-rc` · GHSA-52f5-9888-hmc6 (`tmp` <=0.2.3 via `solc`):**
+  - `package.json` overrides pin `solc` to `tmp@0.2.5`, which contains the upstream directory traversal mitigation, removing the need for temporary directory guardrails.
+  - The standalone `tmp` override ensures any future consumer inherits the same patched baseline so symbolic link exploits remain blocked.
+
+Both advisories now resolve cleanly via `npm audit`, and the previous Hardhat sandbox remains available but is no longer required for mitigation.
 
 ## Governance Cadence
 - Run `npm run security:watch` at least once per week (automated via CI cron) to capture an `npm audit --json` snapshot in

--- a/__tests__/hardhatSandbox.test.js
+++ b/__tests__/hardhatSandbox.test.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const Module = require('module');
 
@@ -44,17 +45,28 @@ describe('hardhat sandbox module guards', () => {
 
     const extractPath = (result) => (typeof result === 'string' ? result : result && result.name);
     const defaultDir = extractPath(tmpModule.dirSync());
-    const maliciousDir = extractPath(tmpModule.dirSync({ dir: '/tmp/evil', unsafeCleanup: true }));
-
     expect(defaultDir).toBeTruthy();
-    expect(maliciousDir).toBeTruthy();
-    expect(defaultDir.startsWith(sandbox.tmpDir)).toBe(true);
-    expect(maliciousDir.startsWith(sandbox.tmpDir)).toBe(true);
+    const acceptedRoots = [sandbox.tmpDir, os.tmpdir()].filter(Boolean);
+    expect(acceptedRoots.some((root) => defaultDir.startsWith(root))).toBe(true);
     expect(fs.statSync(defaultDir).isDirectory()).toBe(true);
-    expect(fs.statSync(maliciousDir).isDirectory()).toBe(true);
+
+    const maliciousInvocation = () => tmpModule.dirSync({ dir: '/tmp/evil', unsafeCleanup: true });
+
+    if (tmpModule.__vaultfireGuarded) {
+      const sanitizedDir = extractPath(maliciousInvocation());
+      expect(sanitizedDir.startsWith(sandbox.tmpDir)).toBe(true);
+      expect(fs.statSync(sanitizedDir).isDirectory()).toBe(true);
+      fs.rmSync(sanitizedDir, { recursive: true, force: true });
+    } else {
+      try {
+        maliciousInvocation();
+        throw new Error('expected tmp to reject unsafe dir override');
+      } catch (error) {
+        expect(error.message).toMatch(/dir option must be relative|ENOENT/);
+      }
+    }
 
     fs.rmSync(defaultDir, { recursive: true, force: true });
-    fs.rmSync(maliciousDir, { recursive: true, force: true });
   });
 
   test('stubs hardhat scoped sentry client without affecting global usage', () => {

--- a/infra/hardhat-sandbox.js
+++ b/infra/hardhat-sandbox.js
@@ -4,6 +4,37 @@ const fs = require('fs');
 const path = require('path');
 const Module = require('module');
 
+function isVersionAtLeast(version, baseline) {
+  if (!version) {
+    return false;
+  }
+
+  const parse = (input) =>
+    String(input)
+      .split('-')[0]
+      .split('.')
+      .map((segment) => {
+        const value = Number.parseInt(segment, 10);
+        return Number.isNaN(value) ? 0 : value;
+      });
+
+  const left = parse(version);
+  const right = parse(baseline);
+  const length = Math.max(left.length, right.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const delta = (left[index] || 0) - (right[index] || 0);
+    if (delta > 0) {
+      return true;
+    }
+    if (delta < 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 const HARDHAT_TAG = `${path.sep}node_modules${path.sep}hardhat${path.sep}`;
 const SOLC_TAG = `${path.sep}node_modules${path.sep}solc${path.sep}`;
 
@@ -54,6 +85,18 @@ function createSentryStub() {
 
 function createSafeTmpWrapper(tmpModule, baseDir) {
   if (!tmpModule || tmpModule.__vaultfireGuarded) {
+    return tmpModule;
+  }
+
+  let tmpVersion = null;
+  try {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    tmpVersion = require('tmp/package.json').version;
+  } catch (error) {
+    tmpVersion = null;
+  }
+
+  if (isVersionAtLeast(tmpVersion, '0.2.4')) {
     return tmpModule;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@vitejs/plugin-react": "^5.0.4",
         "babel-jest": "^29.6.1",
         "hardhat": "^2.22.7",
+        "husky": "^9.1.6",
         "jest": "^29.6.1",
         "jest-fetch-mock": "^3.0.3",
         "mock-fs": "^5.2.0",
@@ -7592,9 +7593,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8137,15 +8138,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/engine.io/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/engine.io/node_modules/debug": {
@@ -9694,16 +9686,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/hardhat/node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/hardhat/node_modules/ethereum-cryptography": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
@@ -10123,6 +10105,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -12557,16 +12555,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -15011,16 +14999,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "postinstall": "node scripts/check-mobile-optional.js",
     "deploy:sandbox": "node cli/deployVaultfire.js --env sandbox",
     "deploy:production": "node cli/deployVaultfire.js --env production",
+    "audit": "npm audit",
     "audit:gov": "node governance/governance-core.js --audit",
-    "security:watch": "node tools/security-watch.js"
+    "security:watch": "node tools/security-watch.js",
+    "prepare": "husky"
   },
   "keywords": [],
   "author": "",
@@ -40,6 +42,7 @@
     "@types/node": "^22.9.0",
     "@vitejs/plugin-react": "^5.0.4",
     "babel-jest": "^29.6.1",
+    "husky": "^9.1.6",
     "hardhat": "^2.22.7",
     "jest": "^29.6.1",
     "jest-fetch-mock": "^3.0.3",
@@ -74,6 +77,16 @@
     "socket.io-client": "^4.7.5",
     "swagger-ui-express": "^4.6.3",
     "yamljs": "^0.3.0"
+  },
+  "overrides": {
+    "@sentry/node": {
+      "cookie": "^0.7.2"
+    },
+    "solc": {
+      "tmp": "^0.2.5"
+    },
+    "tmp": "^0.2.5",
+    "cookie": "^0.7.2"
   },
   "peerDependencies": {
     "@supabase/supabase-js": "^2.43.1",


### PR DESCRIPTION
## Summary
- pin patched `cookie` and `tmp` versions via npm overrides and add a Husky pre-commit audit gate
- document the GHSA advisories in SECURITY.md and CHANGELOG.md with the remediation details
- add a scheduled GitHub Action to run npm audit weekly and file issues when new advisories appear

## Testing
- `npm test`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68dc6ba214a0832289651e0a70b415ec