### PR TITLE
Ensure enterprise mission control always seeds default mission tags

### DIFF
--- a/tests/test_enterprise_mission_control.py
+++ b/tests/test_enterprise_mission_control.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from vaultfire.enterprise import EnterpriseMissionControl
+from vaultfire._purposeful_scale import DEFAULT_MISSION_TAGS
 
 
 @pytest.fixture()
@@ -79,3 +80,35 @@ def test_compile_alignment_checklist_handles_missing_values(mission_control: Ent
 
     assert checklist[0]["all_satisfied"] is False
     assert checklist[0]["checks"][0]["observed"] == {}
+
+
+def test_assess_partner_always_seeds_default_mission_tags(
+    tmp_path: Path, commitments_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, list[str]] = {}
+
+    def fake_authorize(identity, operation, extra_tags=None):
+        extra_list = list(extra_tags or [])
+        captured["extra_tags"] = extra_list
+        request = {
+            "mission_tags": extra_list,
+            "declared_purpose": identity.get("declaredPurpose"),
+            "belief_density": 0.91,
+            "operation_user": identity.get("wallet"),
+        }
+        trace = {"approved": True, "alignment_guard": {"status": "approved"}}
+        return True, None, request, trace
+
+    monkeypatch.setattr("vaultfire.enterprise.mission_control.authorize_scale", fake_authorize)
+    controller = EnterpriseMissionControl(
+        commitments_path=commitments_file,
+        log_path=tmp_path / "mission_control.json",
+        extra_tags=("enterprise", "activation"),
+    )
+
+    controller.assess_partner({"wallet": "0xpartner"}, log=False)
+
+    assert captured["extra_tags"][: len(DEFAULT_MISSION_TAGS)] == list(DEFAULT_MISSION_TAGS)
+    assert len({tag for tag in captured["extra_tags"] if tag in DEFAULT_MISSION_TAGS}) == len(
+        DEFAULT_MISSION_TAGS
+    )

--- a/vaultfire/enterprise/mission_control.py
+++ b/vaultfire/enterprise/mission_control.py
@@ -276,12 +276,25 @@ class EnterpriseMissionControl:
             return str(self.log_path)
 
     def _resolve_extra_tags(self) -> List[str]:
+        base_tags = list(DEFAULT_MISSION_TAGS)
         if self.extra_tags is None:
-            return list(DEFAULT_MISSION_TAGS)
-        if isinstance(self.extra_tags, str):
-            return [*DEFAULT_MISSION_TAGS, self.extra_tags]
-        resolved = [tag for tag in self.extra_tags if isinstance(tag, str) and tag.strip()]
-        return resolved or list(DEFAULT_MISSION_TAGS)
+            extras: Iterable[str] = ()
+        elif isinstance(self.extra_tags, str):
+            extras = (self.extra_tags,)
+        else:
+            extras = (
+                tag.strip()
+                for tag in self.extra_tags
+                if isinstance(tag, str) and tag.strip()
+            )
+
+        ordered: List[str] = []
+        seen = set()
+        for tag in [*base_tags, *extras]:
+            if tag not in seen:
+                ordered.append(tag)
+                seen.add(tag)
+        return ordered
 
 
 __all__ = ["EnterpriseMissionControl"]


### PR DESCRIPTION
## Summary
- ensure `EnterpriseMissionControl` always sends the default Vaultfire mission tags alongside any extra enterprise tags
- add a regression test that captures the behaviour to prevent future regressions

## Testing
- pytest tests/test_vaultfire_enterprise.py tests/alignment_guard_test.py tests/origin_guard_test.py tests/test_humanity_mirror_pipeline.py tests/test_enterprise_mission_control.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1763ddb483229e8e5dc1ee09b1ca