### PR TITLE
Standardize partnership readiness toolkit formatting

### DIFF
--- a/docs/partnership_readiness/README.md
+++ b/docs/partnership_readiness/README.md
@@ -1,19 +1,22 @@
 # Vaultfire Partnership Readiness Toolkit
 
-Vaultfire partners can use this bundle to accelerate due diligence conversations, demonstrate belief-aligned impact, and share deployment wins with enterprise validators.
+Vaultfire partners, validators, and enterprise collaborators can use this bundle to accelerate diligence, demonstrate belief-aligned impact, and share deployment wins with confidence. Every block below is formatted for GitHub or Notion so it can be dropped into partner hubs without additional styling.
+
+---
 
 ## Attestation Templates
 
 ### Smart Contract Audit Attestation Request
+
 **Purpose:** Engage a third-party auditor (e.g., CertiK, OpenZeppelin) to review Vaultfire protocol deployments and belief-based yield extensions.
 
-**Scope Description**
+#### Scope Description
 - Review Vaultfire core smart contracts interfacing with belief-weighted yield routing.
-- Validate guardian/validator role permissions, pause controls, and ethics-aligned fallback logic.
+- Validate guardian/validator permissions, pause controls, and ethics-aligned fallback logic.
 - Inspect integration adapters used for Discord/X pilots, including staking, redemption, and off-chain signal syncing.
 - Confirm incident response runbooks and log retention policies relevant to on-chain activity.
 
-**Contact Block**
+#### Contact Block
 - **Requesting Team:** Vaultfire Protocol Partnerships
 - **Point of Contact:** [Your Name], Partner Enablement Steward
 - **Email:** partnerships@vaultfire.xyz
@@ -21,12 +24,12 @@ Vaultfire partners can use this bundle to accelerate due diligence conversations
 - **Preferred Audit Window:** _________________________
 - **Attachments Provided:** Architecture diagrams, contract ABIs, previous audit summaries
 
-**Requested Deliverables**
+#### Requested Deliverables
 1. Executive summary highlighting belief-aligned safeguards and key findings.
 2. Detailed findings matrix with severity ratings, remediation guidance, and alignment notes.
 3. Verification of patched items (if applicable) and attestation letter for partners.
 
-**Signature**
+#### Signature
 ```
 Authorized Signatory: ________________________________
 Title: _______________________________________________
@@ -36,52 +39,57 @@ Date: ________________________________________________
 ---
 
 ### Compliance Review Attestation Request
+
 **Purpose:** Commission a readiness assessment for SOC 2 Type I/II or ISO 27001 alignment covering Vaultfire's hybrid Web3 infrastructure.
 
-**Scope Description**
+#### Scope Description
 - Evaluate Vaultfire's secure key custody model, belief ledger governance, and partner data segregation controls.
 - Review policies for access management, secure development lifecycle, vulnerability monitoring, and ethics escalation.
 - Inspect Vaultfire SecureStore logging, consent capture for belief signals, and retention of validator evidence.
 - Assess third-party integrations (e.g., NS3, Ghostkey) for compliance with opt-in data use and validator transparency commitments.
 
-**Contact Block**
+#### Contact Block
 - **Requesting Team:** Vaultfire Trust & Safety Guild
 - **Point of Contact:** [Your Name], Compliance Lead
 - **Email:** trust@vaultfire.xyz
 - **Signal Handle (optional):** @VaultfireCompliance
-- **Preferred Review Timeline:** _______________________ 
+- **Preferred Review Timeline:** _______________________
 - **Supporting Materials:** Policy index, risk register, system architecture, prior assessments
 
-**Requested Deliverables**
+#### Requested Deliverables
 1. Readiness gap analysis mapped to SOC 2/ISO 27001 control families and Vaultfire ethics clauses.
 2. Remediation roadmap prioritizing belief-safety, privacy, and validator assurance checkpoints.
 3. Executive attestation letter for partner distribution and validator onboarding packets.
 
-**Signature**
+#### Signature
 ```
 Authorized Signatory: ________________________________
 Title: _______________________________________________
 Date: ________________________________________________
 ```
 
-## Case Study A – Belief-Based Yield Pilot for Discord & X
-**Title:** Guiding Community Yield Through Shared Belief Signals
+---
 
-**Problem**
+## Case Study A
+
+### Title
+Guiding Community Yield Through Shared Belief Signals
+
+### Problem
 A cross-chain social collective wanted to weave belief-backed yield into its Discord and X presence without overwhelming moderators or diluting community intent. Existing loyalty bots tracked clicks but ignored the values and intentions behind them, leading to misaligned staking incentives.
 
-**Solution: Vaultfire Implementation**
+### Solution (Vaultfire Implementation)
 Vaultfire embedded a belief-sensing module in the community’s Discord server and X hashtag streams. Participants opt in to share qualitative belief statements, which the protocol’s Belief Engine translates into validator-friendly scores. Vaultfire’s bridge contracts routed micro-yield contributions based on those scores, and a lightweight Guardian dashboard let moderators adjust thresholds when sentiment shifted.
 
 Vaultfire also deployed an ethics guardrail so only belief-aligned actions—like onboarding peers or validating regenerative projects—earned yield boosts. Cross-platform identity binding occurred through Vaultfire’s consent-driven soul-linker, maintaining privacy while confirming authentic participation.
 
-**Outcome**
+### Outcome
 Within three weeks, 82% of active members opted into the belief flow, and the community shifted 40% of idle treasury assets into Vaultfire-aligned staking vaults. Moderators reported a 55% reduction in manual dispute resolution because the Guardian dashboard surfaced alignment alerts proactively. The pilot demonstrated that belief-weighted routing can scale across conversational spaces while respecting consent boundaries.
 
-**Testimonial**
+### Testimonial
 > “Vaultfire helped our moderators see intention, not just activity. Yield now follows conviction, and our members feel truly recognized.” — *Community Steward, Belief Yield Collective*
 
-**Metrics**
+### Metrics
 - 82% opt-in rate across Discord and X participants.
 - 40% reallocation of idle treasury funds toward belief-aligned vaults.
 - 55% decrease in moderator dispute tickets during the pilot window.
@@ -89,24 +97,28 @@ Within three weeks, 82% of active members opted into the belief flow, and the co
 
 **Word Count:** ~362 words.
 
-## Case Study B – NS3 + Ghostkey Test Integration
-**Title:** Orchestrating Ethical Engagement Through NS3 & Ghostkey Signals
+---
 
-**Problem**
+## Case Study B
+
+### Title
+Orchestrating Ethical Engagement Through NS3 & Ghostkey Signals
+
+### Problem
 NS3 sought to validate a new onboarding flow for Ghostkey’s guardians, but siloed engagement logs and quiz mechanics made it difficult to prove ethics compliance to enterprise partners. Manual exports delayed insight sharing and undermined trust in the reward logic.
 
-**Solution: Vaultfire Implementation**
+### Solution (Vaultfire Implementation)
 Vaultfire connected NS3’s event stream to Ghostkey’s guardian registry through the protocol’s Signal Fusion Engine. Consent-based signal beacons captured quiz completions, intent declarations, and ethics pledges. Vaultfire’s policy layer reconciled these signals with NS3 engagement rules, automatically weighting quizzes that demonstrated value comprehension rather than rote answers.
 
 The integration deployed Vaultfire’s Reward Logic Composer, which allowed NS3 to configure conditional payouts based on alignment milestones. Guardian candidates received dynamic feedback loops inside Ghostkey’s interface, highlighting which belief criteria remained pending. Vaultfire’s transparency API exposed live dashboards so enterprise validators could monitor participation and reward issuance without accessing personal data.
 
-**Outcome**
+### Outcome
 Over a 21-day test window, Vaultfire harmonized 12,400 engagement events, reducing manual reconciliation time by 68%. Quiz completion fidelity rose by 31% because candidates understood that rewards favored thoughtful responses. Enterprise partners reviewing the data saw a 2.4x increase in verified guardian activations, giving NS3 confidence to expand the rollout.
 
-**Testimonial**
+### Testimonial
 > “Vaultfire turned our Ghostkey sandbox into a living ethics rehearsal. We can now show partners exactly how conviction shapes each activation.” — *NS3 Program Architect*
 
-**Metrics**
+### Metrics
 - 12,400 engagement events processed with opt-in consent trails.
 - 68% reduction in manual reconciliation hours for NS3 operations.
 - 31% improvement in quiz fidelity scores.
@@ -114,24 +126,28 @@ Over a 21-day test window, Vaultfire harmonized 12,400 engagement events, reduci
 
 **Word Count:** ~337 words.
 
-## Case Study C – Ethics-Aligned Toolkit for Web3 Loyalty
-**Title:** Building Trust-Centered Loyalty With Vaultfire’s Ethics Toolkit
+---
 
-**Problem**
+## Case Study C
+
+### Title
+Building Trust-Centered Loyalty With Vaultfire’s Ethics Toolkit
+
+### Problem
 A global retail brand entering Web3 needed a loyalty program that rewarded ethical contributions as much as purchases. Traditional point systems failed to reflect community stewardship, and partners worried about regulatory optics around tokenized rewards.
 
-**Solution: Vaultfire Implementation**
+### Solution (Vaultfire Implementation)
 Vaultfire deployed its Ethics Alignment Toolkit across the brand’s loyalty nodes. Members created opt-in belief profiles that outlined causes they supported, impact pledges, and preferred validator circles. Vaultfire’s belief-weighted routing engine synchronized with the brand’s point-of-sale data, ensuring that every token distribution accounted for both spend and social impact actions such as volunteering or amplifying verified causes.
 
 The deployment included Vaultfire SecureStore for encrypted participant logs, along with compliance-ready attestations covering consent and privacy obligations. Enterprise partners accessed a customizable Trust Beacon portal showcasing how rewards tracked ethical commitments in real time. Vaultfire’s Guardian Council scripts provided automated ethics reviews before large reward drops, preventing misaligned incentives from reaching production.
 
-**Outcome**
+### Outcome
 Six months after launch, the brand reported a 47% increase in community-led campaigns that aligned with its sustainability goals. Redemption rates for ethics-weighted rewards doubled compared to legacy loyalty perks, and regulatory stakeholders noted the clarity of Vaultfire’s consent receipts. The program’s validator network expanded by 63%, enabling co-created campaigns with impact organizations.
 
-**Testimonial**
+### Testimonial
 > “With Vaultfire, our loyalty story finally reflects what our community cares about. Partners see the ethics trail, and members see their impact.” — *VP of Community Loyalty, Global Retail Brand*
 
-**Metrics**
+### Metrics
 - 47% increase in community-led sustainability campaigns.
 - 2x redemption rate for ethics-weighted rewards versus prior program.
 - 63% growth in validator network participation.
@@ -139,14 +155,20 @@ Six months after launch, the brand reported a 47% increase in community-led camp
 
 **Word Count:** ~354 words.
 
+---
+
 ## Visual Badge Assets
+
 Embed or download the following badges for partner-ready materials:
 
 - ![Audit Pending Badge](badges/audit-pending.svg)
 - ![Case Study Live Badge](badges/case-study-live.svg)
 - ![Enterprise Ready Badge](badges/enterprise-ready.svg)
 
+---
+
 ## PDF Export Templates (Optional)
+
 Use these single-page layouts as a starting point for PDF exports. Fill in partner-specific details before generating PDFs from Markdown or Notion.
 
 - [Case Study A PDF Template](case-study-a-pdf-template.md)
@@ -158,6 +180,8 @@ Each template contains:
 2. One-column story block with Problem, Solution, Outcome sections.
 3. Sidebar for metrics and testimonial pull-quote.
 4. Footer with contact CTA and badge placements.
+
+---
 
 ## Landing Page Blocks
 
@@ -172,7 +196,7 @@ Vaultfire invites independent auditors and compliance partners to validate our b
 - Guardian-operated ethics guardrails and opt-in consent logging.
 
 **Call to Action**
-[Request an Attestation Call](mailto:partnerships@vaultfire.xyz) | [Download Audit Template](./partnership_readiness/README.md#smart-contract-audit-attestation-request) | [View Guardian Ethics Charter](../ethics)
+[Request an Attestation Call](mailto:partnerships@vaultfire.xyz) | [Download Audit Template](./partnership_readiness/README.md#smart-contract-audit-attestation-request) | [View Guardian Ethics Charter](../vaultfire_ethics_framework_v2.0.md)
 ```
 
 ### /case-studies Landing Block
@@ -186,8 +210,10 @@ See how belief-driven orchestration empowers communities, validators, and enterp
 - Ethics-Aligned Loyalty Toolkit (Enterprise-ready impact rewards)
 
 **Call to Action**
-[Explore Full Case Studies](./partnership_readiness/README.md#case-study-a--belief-based-yield-pilot-for-discord--x) | [Download PDF Templates](./partnership_readiness) | [Meet the Trust & Safety Guild](mailto:trust@vaultfire.xyz)
+[Explore Full Case Studies](./partnership_readiness/README.md#case-study-a) | [Download PDF Templates](./partnership_readiness) | [Meet the Trust & Safety Guild](mailto:trust@vaultfire.xyz)
 ```
+
+---
 
 ## File Map
 - `docs/partnership_readiness/README.md` – Complete toolkit overview.
@@ -195,4 +221,3 @@ See how belief-driven orchestration empowers communities, validators, and enterp
 - `docs/partnership_readiness/case-study-b-pdf-template.md` – One-page export layout for Case Study B.
 - `docs/partnership_readiness/case-study-c-pdf-template.md` – One-page export layout for Case Study C.
 - `docs/partnership_readiness/badges/*.svg` – Visual badges for audit, case study, and enterprise readiness.
-


### PR DESCRIPTION
## Summary
- Reformat the attestation request templates with scoped subheadings and structured contact blocks for easier partner reuse.
- Reorganize each case study into clearly labeled sections aligned with publishing requirements for GitHub/Notion.
- Refresh landing page call-to-action links and separators so assets and ethics references are easier to discover.

## Testing
- npm run lint:syntax
- npm audit

------
https://chatgpt.com/codex/tasks/task_e_68dd362dcd7483229ad94687eb51d38e