### PR TITLE
Add simulated pilot engagement kit documentation

### DIFF
--- a/pilot-kit/intake-form.md
+++ b/pilot-kit/intake-form.md
@@ -1,0 +1,27 @@
+# Vaultfire Partner Intake Form – Simulated Pilot
+
+> **Reminder:** This form supports a simulation-only engagement. No production activation will occur without separate approval.
+
+- **Organization Name:** `____________________________`
+- **Primary Contact Lead:** `____________________________`
+- **Area of Focus / Mission Signal:** `______________________________________________`
+
+## Simulated Use Case Interest
+- [ ] XP system simulation
+- [ ] Loyalty loop simulation
+- [ ] Governance override rehearsal
+
+## Preferred Feedback Format
+- [ ] JSON exports
+- [ ] CSV exports
+- [ ] Grafana dashboard snapshots
+
+## Pilot Window (Simulation)
+- **Preferred Start:** `____________________`
+- **Preferred End:** `____________________`
+
+## Additional Notes
+`________________________________________________________________________________`
+`________________________________________________________________________________`
+
+> **Co-Design Invitation:** Partners are encouraged to annotate ethics considerations or bespoke governance needs so we can adapt the simulated pathways collaboratively.

--- a/pilot-kit/milestones.md
+++ b/pilot-kit/milestones.md
@@ -1,0 +1,11 @@
+# Vaultfire Scoped Pilot Engagement – Simulated Phase Milestones
+
+| Milestone | Status | Lead Role | Notes |
+| --- | --- | --- | --- |
+| CLI belief engine readiness | Complete | Sandbox Orchestrator | Verified simulation CLI stack with belief-first logging; no production connectors engaged. |
+| XP reward simulation | Complete | XP Systems Steward | Synthetic XP accrual scenarios executed with partner-visible dashboards for review. |
+| DB migration path test | Pending | Data Infrastructure Lead | Awaiting partner-supplied schema requirements for simulated migration rehearsal. |
+| Governance override co-design | In Progress | Governance Ethicist | Drafting override framework collaboratively; simulation workshops scheduled. |
+| Production reference publishing | Not Started | Compliance Liaison | To be authored post-simulation once production alignment is formally greenlit. |
+
+> **Simulation Context:** Each milestone references sandbox-only activity. Progression to production requires a separate approval track.

--- a/pilot-kit/overview.md
+++ b/pilot-kit/overview.md
@@ -1,0 +1,20 @@
+# Vaultfire Scoped Pilot Engagement – Simulated Phase
+
+**Status:** Simulation-only sandbox engagement approved through Codex review. No live production deployment is active.
+
+## Pilot Summary
+- **Pilot Type:** Controlled sandbox simulation with belief-first instrumentation.
+- **Ethics Signal:** Full transparency on simulated scope; telemetry captured only within the sandbox boundary.
+- **Partner Invitation:** Co-design welcome throughout the simulated phase to reinforce Vaultfire values of honesty, rigor, co-creation, and non-hype credibility.
+
+## Objectives
+1. **XP System Testing:** Validate simulated XP accrual logic and monitor belief-engine adjustments without touching production data.
+2. **Telemetry Flow Validation:** Confirm telemetry pathways, retention rules, and opt-in consent posture using synthetic signals only.
+3. **Governance Override Sketch:** Draft override decision trees collaboratively with partners to rehearse escalation patterns before any real-world activation.
+
+## Deliverables
+- **Simulated Use Case Walkthroughs (3):** XP loyalty cycle, governance escalation rehearsal, and telemetry ethics review.
+- **CLI Logs:** Captured from the Vaultfire CLI belief engine operating in sandbox mode, annotated for partner review.
+- **Feedback Form:** Structured response template for partner reflections, insights, and ethics notes.
+
+> **Simulation Notice:** All assets, data points, and learnings remain within the scoped simulation until a separate production readiness approval is granted.

--- a/pilot-kit/readiness-summary.md
+++ b/pilot-kit/readiness-summary.md
@@ -1,0 +1,13 @@
+# Vaultfire Deployment Readiness Summary – Simulated Phase
+
+> **Truth Signal:** Checklist reflects sandbox status only. Production deployment remains out of scope until future approval.
+
+- [x] CLI + plugin architecture ✅ – Validated in simulation with belief engine hooks and partner-visible logs.
+- [ ] Governance override design 🟡 – In-progress co-design; simulation flow charts under ethics review.
+- [x] Telemetry simulation logs ✅ – Captured and archived from sandbox runs with opt-in confirmations.
+- [ ] Live user deployment ❌ – Not initiated; simulated actors only.
+- [x] Use case documentation ✅ – Drafts for XP, loyalty, and governance simulations prepared for partner feedback.
+- [x] Ethics framework codified ✅ – Ghostkey ethics clauses acknowledged and referenced in simulation artifacts.
+- [ ] External validation (SOC2-lite) 🟡 – Pending; to be scheduled post-simulation with partner consent.
+
+> **Next Step:** Confirm partner feedback loops and schedule governance override workshop before requesting production clearance.


### PR DESCRIPTION
## Summary
- add a simulated phase partner overview for the Vaultfire pilot
- document milestone tracker and intake template for sandbox collaboration
- record deployment readiness checklist emphasizing simulation-only scope

## Testing
- `npm run lint:syntax`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68ddccded9fc8322824b57a42efcc377