### PR TITLE
Ensure timestamps use UTC ISO format

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,10 @@
-import datetime
+from __future__ import annotations
 
-def get_timestamp():
-    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+from datetime import datetime, timezone
+
+
+def get_timestamp() -> str:
+    """Return the current UTC timestamp in ISO 8601 format."""
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    return now.isoformat()

--- a/tests/test_utils_timestamp.py
+++ b/tests/test_utils_timestamp.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+
+from utils import get_timestamp  # noqa: E402
+
+
+def test_get_timestamp_returns_iso8601_utc() -> None:
+    timestamp = get_timestamp()
+
+    parsed = datetime.fromisoformat(timestamp)
+
+    assert parsed.tzinfo == timezone.utc
+    assert timestamp.endswith("+00:00")


### PR DESCRIPTION
## Summary
- update the shared timestamp helper to emit timezone-aware ISO 8601 strings
- add a regression test asserting the helper returns UTC timestamps

## Testing
- pytest tests/test_humanity_mirror_pipeline.py tests/test_utils_timestamp.py

------
https://chatgpt.com/codex/tasks/task_e_68e0158801388322937f0c82e0d64bf4