### PR TITLE
Add live pilot testnet pipeline with telemetry and dashboard

### DIFF
--- a/dashboards/live_test_dashboard.py
+++ b/dashboards/live_test_dashboard.py
@@ -1,0 +1,62 @@
+"""Streamlit dashboard for live telemetry visibility."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import streamlit as st
+
+LOG_PATH = Path(__file__).resolve().parents[1] / "logs" / "pilot_live_metrics.json"
+TRACE_LOG = Path(__file__).resolve().parents[1] / "logs" / "live_pilot_traces.log"
+
+st.set_page_config(page_title="Vaultfire Live Pilot Dashboard", layout="wide")
+st.title("Vaultfire Live Pilot Dashboard")
+
+st.sidebar.header("Telemetry Controls")
+refresh_rate = st.sidebar.slider("Auto-refresh (seconds)", min_value=5, max_value=120, value=30, step=5)
+
+
+def load_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        try:
+            return json.load(handle)
+        except json.JSONDecodeError:
+            return {}
+
+
+def load_recent_traces(limit: int = 25) -> list[str]:
+    if not TRACE_LOG.exists():
+        return []
+    lines = TRACE_LOG.read_text(encoding="utf-8").strip().splitlines()
+    return list(reversed([line for line in lines if line.strip()]))[:limit]
+
+
+summary = load_json(LOG_PATH)
+if not summary:
+    st.warning("No telemetry summary found yet. Trigger an activation flow to populate metrics.")
+else:
+    meta_col, totals_col = st.columns(2)
+    meta_col.metric("Last Export", summary.get("last_exported_at", "unknown"))
+    totals = summary.get("event_totals", {})
+    totals_col.metric("Tracked Event Types", len(totals))
+
+    st.subheader("Event Totals")
+    st.json(totals)
+
+    st.subheader("Recent Trace Identifiers")
+    st.write(summary.get("recent_traces", []))
+
+st.sidebar.write("Last refresh: ", datetime.utcnow().strftime("%Y-%m-%d %H:%M:%SZ"))
+st.sidebar.info("Telemetry summaries auto-publish every 24h or faster if configured.")
+st.sidebar.code(f"Refresh every {refresh_rate} seconds")
+
+recent_logs = load_recent_traces()
+if recent_logs:
+    st.subheader("Raw Trace Log (latest 25 entries)")
+    for entry in recent_logs:
+        st.code(entry)
+else:
+    st.info("Trace log is empty. Once the pilot is running, traces will appear here.")

--- a/live_test_pilot/__init__.py
+++ b/live_test_pilot/__init__.py
@@ -1,0 +1,6 @@
+"""Live test pilot deployment package."""
+
+from .config import LiveTestConfig, load_config
+from .telemetry import telemetry_manager
+
+__all__ = ["LiveTestConfig", "load_config", "telemetry_manager"]

--- a/live_test_pilot/api.py
+++ b/live_test_pilot/api.py
@@ -1,0 +1,156 @@
+"""FastAPI surface for the live pilot testnet."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+from .config import LiveTestConfig, load_config
+from .pipeline import LiveTestPipeline
+from .telemetry import TelemetryManager, telemetry_manager
+
+
+class ActivationRequest(BaseModel):
+    pilot_signal_hash: str = Field(..., description="Synthetic pilot signal hash")
+    wallet_id: str = Field(..., description="Synthetic wallet identifier")
+
+
+class AttestationRequest(BaseModel):
+    metrics: Dict[str, Any]
+
+
+class LiveTelemetryState(BaseModel):
+    event_totals: Dict[str, int]
+    recent_traces: list[str]
+    last_exported_at: str
+    ci_cd_audit_hook: str
+
+
+def get_pipeline(request: Request) -> LiveTestPipeline:
+    pipeline = getattr(request.app.state, "live_pipeline", None)
+    if pipeline is None:
+        raise HTTPException(status_code=500, detail="Live pipeline not initialised")
+    return pipeline
+
+
+def create_app(*, config: LiveTestConfig | None = None, telemetry: TelemetryManager | None = None) -> FastAPI:
+    cfg = config or load_config()
+    telemetry_ref = telemetry or telemetry_manager
+    telemetry_ref.configure_interval(cfg.telemetry_interval_seconds)
+
+    app = FastAPI(
+        title="Vaultfire Live Pilot",
+        description="Sandboxed live testnet with telemetry-backed activation flows.",
+        version="0.1.0",
+        contact={"name": "Vaultfire Compliance Sandbox", "email": "audit@vaultfire.local"},
+        openapi_tags=[
+            {"name": "activation", "description": "Activation to yield flows"},
+            {"name": "attestation", "description": "Telemetry-backed attestations"},
+            {"name": "telemetry", "description": "Live telemetry and dashboards"},
+        ],
+    )
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    app.state.telemetry = telemetry_ref
+    app.state.config = cfg
+    app.state.audit_metadata = cfg.audit_metadata
+    app.state.live_pipeline = None
+
+    @app.middleware("http")
+    async def trace_requests(request: Request, call_next):
+        start = datetime.utcnow().isoformat() + "Z"
+        trace_id = telemetry_ref.record_event(
+            "http_request",
+            {
+                "path": request.url.path,
+                "method": request.method,
+                "start": start,
+                "client": request.client.host if request.client else "unknown",
+            },
+        )
+        request.state.trace_id = trace_id
+        response = await call_next(request)
+        telemetry_ref.record_event(
+            "http_response",
+            {
+                "path": request.url.path,
+                "method": request.method,
+                "status_code": response.status_code,
+                "trace_id": trace_id,
+            },
+        )
+        response.headers["X-Live-Test-Trace"] = trace_id
+        response.headers["X-Audit-Hook"] = cfg.audit_metadata.get("hook", "unset")
+        return response
+
+    @app.on_event("startup")
+    async def startup_event() -> None:
+        if not cfg.live_test_flag:
+            raise RuntimeError("Configuration live_test_flag must be enabled for live pilot")
+        telemetry_ref.start_background_exporter(interval_seconds=cfg.telemetry_interval_seconds)
+        telemetry_ref.record_event(
+            "startup",
+            {
+                "system": cfg.system_name,
+                "live_test_flag": cfg.live_test_flag,
+                "audit_provider": cfg.audit_metadata.get("provider"),
+            },
+        )
+        telemetry_ref.export_summary()
+        app.state.live_pipeline = LiveTestPipeline(config=cfg, telemetry=telemetry_ref)
+
+    @app.on_event("shutdown")
+    async def shutdown_event() -> None:
+        telemetry_ref.record_event("shutdown", {"system": cfg.system_name})
+        telemetry_ref.shutdown()
+
+    @app.get("/health", tags=["telemetry"])
+    async def health_check() -> Dict[str, Any]:
+        return {
+            "status": "ok",
+            "system": cfg.system_name,
+            "live_test_flag": cfg.live_test_flag,
+            "audit": cfg.audit_metadata,
+        }
+
+    @app.get("/synthetic-wallets", tags=["activation"])
+    async def synthetic_wallets(pipeline: LiveTestPipeline = Depends(get_pipeline)) -> list[Dict[str, Any]]:
+        return [wallet.__dict__ for wallet in pipeline.registry.list_wallets()]
+
+    @app.post("/activation-to-yield", tags=["activation"])
+    async def activation_endpoint(payload: ActivationRequest, pipeline: LiveTestPipeline = Depends(get_pipeline)) -> Dict[str, Any]:
+        try:
+            result = pipeline.process_activation(
+                pilot_signal_hash=payload.pilot_signal_hash,
+                wallet_id=payload.wallet_id,
+            )
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        telemetry_ref.record_event("activation_request", {"trace_id": result["trace_id"], "wallet_id": payload.wallet_id})
+        return result
+
+    @app.post("/attest", tags=["attestation"])
+    async def attest_endpoint(payload: AttestationRequest, pipeline: LiveTestPipeline = Depends(get_pipeline)) -> Dict[str, Any]:
+        attested = pipeline.attest_metrics(payload.metrics)
+        telemetry_ref.record_event("attestation_request", {"trace_id": attested["trace_id"]})
+        return attested
+
+    @app.get("/telemetry", response_model=LiveTelemetryState, tags=["telemetry"])
+    async def telemetry_snapshot() -> LiveTelemetryState:
+        summary = telemetry_ref.export_summary()
+        return LiveTelemetryState(**summary)
+
+    return app
+
+
+__all__ = ["create_app"]

--- a/live_test_pilot/config.py
+++ b/live_test_pilot/config.py
@@ -1,0 +1,76 @@
+"""Configuration helpers for the live test pilot deployment."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "vaultfire_config.json"
+DEFAULT_TELEMETRY_INTERVAL = 60 * 60 * 24  # 24 hours
+
+
+@dataclass(slots=True)
+class LiveTestConfig:
+    """Represents the configuration required for the live test pilot."""
+
+    system_name: str
+    live_test_flag: bool
+    telemetry_interval_seconds: int
+    audit_metadata: Dict[str, Any]
+    synthetic_wallets: list[dict]
+
+
+def _load_file(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing configuration file: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _resolve_interval(raw: Any) -> int:
+    if raw is None:
+        return DEFAULT_TELEMETRY_INTERVAL
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_TELEMETRY_INTERVAL
+    return max(value, 60)
+
+
+def load_config(*, config_path: Path | None = None) -> LiveTestConfig:
+    """Load the Vaultfire config and synthesize pilot-specific metadata."""
+
+    path = config_path or CONFIG_PATH
+    data = _load_file(path)
+    telemetry_interval_env = os.getenv("VAULTFIRE_METRICS_INTERVAL")
+    telemetry_interval = _resolve_interval(
+        telemetry_interval_env or data.get("telemetry_interval_seconds")
+    )
+    synthetic_wallets = data.get(
+        "synthetic_wallets",
+        [
+            {"wallet_id": "demo-wallet-001", "ens": "demo1.test", "label": "Community Uplift"},
+            {"wallet_id": "demo-wallet-002", "ens": "demo2.test", "label": "Ethics Anchor"},
+            {"wallet_id": "demo-wallet-003", "ens": "demo3.test", "label": "Guardian Loop"},
+        ],
+    )
+    audit_metadata = data.get(
+        "live_test_audit_metadata",
+        {
+            "hook": "third-party-audit",
+            "provider": "Vaultfire Compliance Sandbox",
+            "contact": "audit@vaultfire.local",
+        },
+    )
+    return LiveTestConfig(
+        system_name=data.get("system_name", "Vaultfire"),
+        live_test_flag=bool(data.get("live_test_flag")),
+        telemetry_interval_seconds=telemetry_interval,
+        audit_metadata=audit_metadata,
+        synthetic_wallets=list(synthetic_wallets),
+    )
+
+
+__all__ = ["LiveTestConfig", "load_config"]

--- a/live_test_pilot/pipeline.py
+++ b/live_test_pilot/pipeline.py
@@ -1,0 +1,98 @@
+"""Live test pipeline orchestration using Vaultfire primitives."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict
+
+from activation_to_yield import activationToYield
+from engine.attestation_engine import attestation_engine
+from engine.belief_multiplier import multiplier_capacity_plan
+
+from .config import LiveTestConfig
+from .telemetry import TelemetryManager
+
+
+@dataclass(slots=True)
+class SyntheticWallet:
+    wallet_id: str
+    ens: str
+    label: str
+
+
+class SyntheticWalletRegistry:
+    """In-memory registry for sandbox wallets."""
+
+    def __init__(self, wallets: list[dict[str, Any]]) -> None:
+        self._wallets = {
+            item["wallet_id"]: SyntheticWallet(
+                wallet_id=item["wallet_id"],
+                ens=item.get("ens", item["wallet_id"]),
+                label=item.get("label", "Synthetic Wallet"),
+            )
+            for item in wallets
+        }
+
+    def list_wallets(self) -> list[SyntheticWallet]:
+        return list(self._wallets.values())
+
+    def get(self, wallet_id: str) -> SyntheticWallet:
+        if wallet_id not in self._wallets:
+            raise KeyError(f"Wallet '{wallet_id}' is not part of the synthetic registry")
+        return self._wallets[wallet_id]
+
+
+class LiveTestPipeline:
+    """Bridge activation-to-yield flow into attestation metrics."""
+
+    def __init__(self, config: LiveTestConfig, telemetry: TelemetryManager) -> None:
+        self.config = config
+        self.telemetry = telemetry
+        self.registry = SyntheticWalletRegistry(config.synthetic_wallets)
+
+    def _trace(self, event_type: str, payload: Dict[str, Any]) -> str:
+        return self.telemetry.record_event(event_type, payload)
+
+    def process_activation(self, *, pilot_signal_hash: str, wallet_id: str) -> Dict[str, Any]:
+        wallet = self.registry.get(wallet_id)
+        timestamp = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+        result = activationToYield(pilot_signal_hash, timestamp, wallet.ens)
+        trace_id = self._trace(
+            "activation_to_yield",
+            {
+                "wallet_id": wallet.wallet_id,
+                "ens": wallet.ens,
+                "tier": result["tier"],
+                "ghostscore": result["ghostscore"],
+                "yield_value": result["yield_value"],
+                "pilot_signal_hash": pilot_signal_hash,
+            },
+        )
+        result["trace_id"] = trace_id
+        result["wallet_label"] = wallet.label
+        return result
+
+    def attest_metrics(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        attestation = attestation_engine(
+            metrics,
+            validator_id="vaultfire-live-pilot",
+        )
+        trace_id = self._trace(
+            "attestation",
+            {
+                "validator_id": attestation.validator_id,
+                "issued_at": attestation.issued_at,
+                "proof_hash": attestation.proof_hash,
+            },
+        )
+        payload = attestation.as_dict()
+        payload["trace_id"] = trace_id
+        return payload
+
+    def get_capacity_plan(self) -> Dict[str, Any]:
+        plan = multiplier_capacity_plan()
+        self._trace("capacity_plan_view", {"tiers": len(plan.get("tiers", []))})
+        return plan
+
+
+__all__ = ["LiveTestPipeline", "SyntheticWalletRegistry", "SyntheticWallet"]

--- a/live_test_pilot/telemetry.py
+++ b/live_test_pilot/telemetry.py
@@ -1,0 +1,120 @@
+"""Telemetry plumbing for the live pilot environment."""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from datetime import datetime
+from hashlib import sha256
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+LOG_DIR = Path(__file__).resolve().parents[1] / "logs"
+TRACE_LOG_PATH = LOG_DIR / "live_pilot_traces.log"
+SUMMARY_PATH = LOG_DIR / "pilot_live_metrics.json"
+CI_CD_AUDIT_LOG = LOG_DIR / "cicd_audit.log"
+
+
+class TelemetryManager:
+    """Collects request traces, audit hooks, and usage metrics."""
+
+    def __init__(self) -> None:
+        self._logger = logging.getLogger("vaultfire.live_pilot")
+        self._logger.setLevel(logging.INFO)
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        handler = RotatingFileHandler(TRACE_LOG_PATH, maxBytes=2_000_000, backupCount=5)
+        handler.setFormatter(
+            logging.Formatter("%(asctime)sZ %(levelname)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")
+        )
+        self._logger.addHandler(handler)
+        self._lock = threading.Lock()
+        self._event_totals: Dict[str, int] = {}
+        self._recent_traces: list[str] = []
+        self._export_interval = 60 * 60 * 24
+        self._export_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._write_cicd_boot_record()
+
+    def _write_cicd_boot_record(self) -> None:
+        payload = {
+            "event": "live_pilot_boot",
+            "timestamp": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+            "hash": self.generate_trace_id({"event": "live_pilot_boot"}),
+        }
+        with CI_CD_AUDIT_LOG.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload) + "\n")
+
+    def configure_interval(self, seconds: int) -> None:
+        self._export_interval = max(seconds, 60)
+
+    def generate_trace_id(self, payload: Dict[str, Any]) -> str:
+        serialized = json.dumps(payload, sort_keys=True)
+        return sha256(serialized.encode("utf-8")).hexdigest()
+
+    def record_event(self, event_type: str, data: Dict[str, Any]) -> str:
+        timestamp = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+        trace_payload = {"event_type": event_type, "timestamp": timestamp, **data}
+        trace_id = self.generate_trace_id(trace_payload)
+        trace_payload["trace_id"] = trace_id
+        with self._lock:
+            self._event_totals[event_type] = self._event_totals.get(event_type, 0) + 1
+            self._recent_traces.append(trace_id)
+            self._recent_traces = self._recent_traces[-100:]
+        self._logger.info(json.dumps(trace_payload, sort_keys=True))
+        return trace_id
+
+    def export_summary(self) -> Dict[str, Any]:
+        with self._lock:
+            payload = {
+                "last_exported_at": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+                "event_totals": dict(self._event_totals),
+                "recent_traces": list(self._recent_traces),
+                "ci_cd_audit_hook": "enabled",
+            }
+        SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with SUMMARY_PATH.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+        return payload
+
+    def _run_exporter(self) -> None:
+        while not self._stop_event.wait(self._export_interval):
+            self.export_summary()
+
+    def start_background_exporter(self, *, interval_seconds: int | None = None) -> None:
+        if interval_seconds:
+            self.configure_interval(interval_seconds)
+        if self._export_thread and self._export_thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._export_thread = threading.Thread(target=self._run_exporter, name="telemetry-exporter", daemon=True)
+        self._export_thread.start()
+
+    def shutdown(self) -> None:
+        self._stop_event.set()
+        if self._export_thread:
+            self._export_thread.join(timeout=5)
+        self.export_summary()
+
+    def flush_recent(self) -> Iterable[str]:
+        with self._lock:
+            return list(self._recent_traces)
+
+
+def _initialise_ci_cd_header() -> None:
+    header = {
+        "event": "ci_cd_audit_header",
+        "timestamp": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+        "hash": sha256(b"ci_cd_audit_header").hexdigest(),
+    }
+    CI_CD_AUDIT_LOG.parent.mkdir(parents=True, exist_ok=True)
+    if not CI_CD_AUDIT_LOG.exists():
+        with CI_CD_AUDIT_LOG.open("w", encoding="utf-8") as handle:
+            handle.write(json.dumps(header) + "\n")
+
+
+_initialise_ci_cd_header()
+telemetry_manager = TelemetryManager()
+
+__all__ = ["TelemetryManager", "telemetry_manager", "TRACE_LOG_PATH", "SUMMARY_PATH", "CI_CD_AUDIT_LOG"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ certifi==2025.7.14
 click==8.2.1
 cryptography==43.0.1
 distro==1.9.0
+fastapi==0.115.0
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
@@ -28,6 +29,8 @@ pytest==8.4.1
 ruff==0.12.4
 sniffio==1.3.1
 SQLAlchemy==2.0.36
+streamlit==1.38.0
 tqdm==4.67.1
 typing-inspection==0.4.1
 typing_extensions==4.14.1
+uvicorn==0.30.3

--- a/start_live_test_pilot.py
+++ b/start_live_test_pilot.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""CLI entrypoint to launch the Vaultfire live test pilot."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import uvicorn
+
+os.environ.setdefault("VAULTFIRE_SANDBOX_MODE", "1")
+
+from live_test_pilot.api import create_app
+from live_test_pilot.config import load_config
+from live_test_pilot.telemetry import telemetry_manager
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Start the Vaultfire live pilot sandbox")
+    parser.add_argument("--host", default="0.0.0.0", help="Host interface to bind (default: 0.0.0.0)")
+    parser.add_argument("--port", type=int, default=8080, help="Port to serve the API (default: 8080)")
+    parser.add_argument("--log-level", default="info", help="Uvicorn log level")
+    parser.add_argument(
+        "--force", action="store_true", help="Override live_test_flag guard (for CI synthetic validation)"
+    )
+    parser.add_argument(
+        "--metrics-interval", type=int, help="Override telemetry export interval in seconds"
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config()
+
+    if not config.live_test_flag and not args.force:
+        sys.stderr.write("Live test flag disabled. Enable live_test_flag in vaultfire_config.json or pass --force.\n")
+        return 2
+
+    if args.metrics_interval:
+        telemetry_manager.configure_interval(args.metrics_interval)
+
+    app = create_app(config=config, telemetry=telemetry_manager)
+    telemetry_manager.record_event(
+        "cli_boot",
+        {
+            "host": args.host,
+            "port": args.port,
+            "force": args.force,
+            "metrics_interval": args.metrics_interval or config.telemetry_interval_seconds,
+        },
+    )
+    uvicorn.run(app, host=args.host, port=args.port, log_level=args.log_level)
+    telemetry_manager.record_event("cli_shutdown", {"host": args.host, "port": args.port})
+    telemetry_manager.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vaultfire_config.json
+++ b/vaultfire_config.json
@@ -19,6 +19,8 @@
   "partner_hooks_enabled": true,
   "wallet_auth_hook": true,
   "live_training_mode": true,
+  "live_test_flag": false,
+  "telemetry_interval_seconds": 86400,
   "fail_safe": "Hard shutdown on ethics breach",
   "localforge_enabled": true,
   "use_database": true,


### PR DESCRIPTION
## Summary
- add a dedicated `live_test_pilot` package with config loader, synthetic wallet pipeline, and FastAPI surface for activation-to-yield and attestation flows
- implement telemetry manager, CLI launcher, and scheduled exports to provide hashed traces, CI/CD audit logs, and pilot metrics
- deliver a Streamlit dashboard plus configuration and dependency updates for the live test flag and monitoring stack

## Testing
- python -m compileall live_test_pilot dashboards/live_test_dashboard.py start_live_test_pilot.py

------
https://chatgpt.com/codex/tasks/task_e_68e05c4a929c832284bd52ec63ac095d