### PR TITLE
Add purposeful scale readiness automation

### DIFF
--- a/FINAL_READINESS_REPORT.md
+++ b/FINAL_READINESS_REPORT.md
@@ -20,6 +20,7 @@ Vaultfire Final Commit: July 30, 2025 — 12:29 AM ET
 - **Reward streams**: loyalty multipliers trigger the reward stream planner, which updates the token stream contract (or mock interface in dev mode) whenever contribution events are recorded.
 - **Ethics guardrails**: `tools/lint_guardrails.js` blocks biometric/KYC imports; extend list when new surveillance vendors emerge.
 - **Residency enforcement**: Telemetry DSNs and partner hooks must satisfy `trustSync.telemetry.residency` allow-lists; preflight now fails without region coverage, closing the open question on remote sink compliance.
+- **Scale attestations**: `vaultfire_system_ready.py --attest <guardian>` now bakes a Purposeful Scale attestation (with mission bootstrap + alignment replay) into `attestations/`, and partners can score readiness using `tools/scale_readiness_report.py` before flipping live traffic.
 
 ### Safe Partner Testnet Entry Points
 - `https://partner-sandbox.vaultfire.xyz` — mirrored belief sync with wallet-only auth.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Live pilot deployments targeted for Q4 roadmap; current examples demonstrate arc
 - **Telemetry ethics:** Wallet-level consent toggles route opt-in signals to Sentry, logging dashboard renders, wallet logins, and belief vote casts only when explicitly approved.
 - **Trust badge:** The coverage-driven badge above is auto-generated from `coverage/coverage-summary.json` via `node tools/generateCoverageBadge.js` after each test run.
 
+## Scale Readiness Automation
+- **Guardian attestations on demand:** `./vaultfire_system_ready.py --attest guardian.eth` now provisions mission profiles, runs alignment simulations, and emits an attestation pack under `attestations/` with the digest logged for audit trails.
+- **Unified scale health snapshot:** `./tools/scale_readiness_report.py --pretty` compiles recent Purposeful Scale decisions, thread coverage, belief-density stats, and attestation freshness into a single JSON payload so partners can gate launches on objective readiness signals.
+- **Staleness guards baked in:** The readiness report fails the `scale_ready` flag if approvals drop below 60% or if the last aligned expansion is older than six hours, keeping the protocol’s ethics-first mission central while scaling.
+
 ## Enterprise Bridge Enhancements (Resolved)
 - **Live adoption status:** `/deployment/status` and `/deployment/mode` expose a simulated/live toggle with a green-dot `LIVE` indicator, real-time telemetry ingestion (`POST /telemetry/realtime`), and onchain-ready signature logging (`POST /belief/actions/sign`). Partners can explore the view through the new `/trust-map` endpoint or the `cli/belief-mapper.js --map` CLI.
 - **Financial model clarity:** Rewards now surface hybrid-compliance posture, reputation-to-yield conversions, and partner revenue bridge previews directly from `/vaultfire/rewards/:walletId`. Config schemas accept `vaultfire.partnerReady`, deployment profiles, and partner revenue templates so governance votes can unlock real payouts on demand.

--- a/tests/test_scale_readiness_report.py
+++ b/tests/test_scale_readiness_report.py
@@ -1,0 +1,95 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tools.scale_readiness_report import compile_scale_snapshot
+
+
+@pytest.fixture()
+def scale_paths(tmp_path, monkeypatch):
+    from tools import scale_readiness_report as report_module
+    from types import SimpleNamespace
+
+    log_path = tmp_path / "scale_log.json"
+    index_path = tmp_path / "scale_index.json"
+    profiles_path = tmp_path / "profiles.json"
+    attest_dir = tmp_path / "attestations"
+    attest_dir.mkdir()
+
+    stub = SimpleNamespace(
+        SCALE_LOG_PATH=log_path,
+        PURPOSE_INDEX_PATH=index_path,
+        PURPOSE_PROFILES_PATH=profiles_path,
+        BASE_DIR=tmp_path,
+        RECOGNIZED_MISSION_THREADS={"vaultfire", "ghostkey-316", "ns3"},
+    )
+    monkeypatch.setattr(report_module, "_purposeful_scale", lambda: stub)
+
+    profiles_path.write_text(json.dumps({"guardian.eth": {"mission": "Safeguard"}}, indent=2))
+
+    return log_path, index_path, profiles_path, attest_dir
+
+
+def test_compile_scale_snapshot_identifies_readiness(scale_paths, monkeypatch):
+    log_path, index_path, profiles_path, attest_dir = scale_paths
+
+    now = datetime.now(timezone.utc)
+    recent = now.isoformat().replace("+00:00", "Z")
+
+    log_entries = [
+        {
+            "timestamp": recent,
+            "user_id": "guardian.eth",
+            "operation": "scale.ok",
+            "mission_tags": ["Vaultfire", "NS3", "Ghostkey-316"],
+            "approved": True,
+            "belief_density": 0.82,
+            "alignment": 0.91,
+            "reason": "approved",
+        }
+    ]
+    log_path.write_text(json.dumps(log_entries, indent=2))
+
+    attestation_path = attest_dir / "guardian_attestation.json"
+    attestation_payload = {
+        "user_id": "guardian.eth",
+        "generated_at": recent,
+        "attestation_hash": "abc123",
+    }
+    attestation_path.write_text(json.dumps(attestation_payload, indent=2))
+
+    report = compile_scale_snapshot(history_limit=10)
+
+    assert report["entries"] == 1
+    assert report["scale_ready"] is True
+    assert report["approval_rate"] == 1.0
+    assert report["profile_count"] == 1
+    assert report["attestations"]["count"] == 1
+    assert report["attestations"]["latest_attestation_hash"] == "abc123"
+
+
+def test_compile_scale_snapshot_flags_stale(scale_paths, monkeypatch):
+    log_path, index_path, profiles_path, attest_dir = scale_paths
+
+    stale_time = datetime.now(timezone.utc) - timedelta(hours=12)
+    timestamp = stale_time.isoformat().replace("+00:00", "Z")
+
+    log_entries = [
+        {
+            "timestamp": timestamp,
+            "user_id": "guardian.eth",
+            "operation": "scale.ok",
+            "mission_tags": ["Vaultfire", "Ghostkey-316"],
+            "approved": True,
+            "belief_density": 0.7,
+            "alignment": 0.9,
+            "reason": "approved",
+        }
+    ]
+    log_path.write_text(json.dumps(log_entries, indent=2))
+
+    report = compile_scale_snapshot(history_limit=5)
+
+    assert report["scale_ready"] is False
+    assert any("stale" in note for note in report["readiness_notes"])

--- a/tools/scale_readiness_report.py
+++ b/tools/scale_readiness_report.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Compile a production-readiness snapshot for the Purposeful Scale stack."""
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from functools import lru_cache
+from pathlib import Path
+from statistics import mean
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+from utils.json_io import load_json
+
+
+@lru_cache()
+def _purposeful_scale():
+    return importlib.import_module("engine.purposeful_scale")
+
+
+def _attestation_dir() -> Path:
+    return _purposeful_scale().BASE_DIR / "attestations"
+
+
+MAX_STALENESS = timedelta(hours=6)
+
+
+def _normalize_tags(values: Iterable[Any]) -> List[str]:
+    tags: List[str] = []
+    seen = set()
+    for value in values or []:
+        if isinstance(value, str):
+            text = value.strip().lower()
+        else:
+            text = str(value).strip().lower()
+        if not text:
+            continue
+        if text.startswith("#"):
+            text = text[1:]
+        if text and text not in seen:
+            tags.append(text)
+            seen.add(text)
+    return tags
+
+
+def _safe_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _parse_timestamp(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc)
+    if isinstance(value, str):
+        candidate = value.strip()
+        if not candidate:
+            return None
+        candidate = candidate.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return None
+
+
+def _format_timestamp(value: Optional[datetime]) -> Optional[str]:
+    if value is None:
+        return None
+    return value.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _belief_summary(values: Sequence[float]) -> Dict[str, float]:
+    if not values:
+        return {"avg": 0.0, "min": 0.0, "max": 0.0}
+    return {
+        "avg": round(mean(values), 4),
+        "min": round(min(values), 4),
+        "max": round(max(values), 4),
+    }
+
+
+def _attestation_snapshot() -> Dict[str, Any]:
+    info: Dict[str, Any] = {"count": 0}
+    attestation_dir = _attestation_dir()
+    if not attestation_dir.exists():
+        return info
+
+    files = sorted(attestation_dir.glob("*_attestation.json"))
+    info["count"] = len(files)
+    if not files:
+        return info
+
+    latest = max(files, key=lambda path: path.stat().st_mtime)
+    info["latest_file"] = latest.name
+    try:
+        data = json.loads(latest.read_text())
+    except (OSError, json.JSONDecodeError):
+        info["latest_status"] = "unreadable"
+        return info
+
+    info["latest_status"] = "ok"
+    info["latest_attestation_hash"] = data.get("attestation_hash")
+    info["latest_generated_at"] = data.get("generated_at")
+    info["latest_user_id"] = data.get("user_id")
+    return info
+
+
+def _thread_metrics(entries: Sequence[Mapping[str, Any]], thread: str) -> Dict[str, Any]:
+    normalized = thread.lower()
+    relevant: List[Mapping[str, Any]] = []
+    for entry in entries:
+        tags = entry.get("mission_tags", [])
+        if normalized in tags:
+            relevant.append(entry)
+
+    approvals = [entry for entry in relevant if entry.get("approved")]
+    denials = [entry for entry in relevant if not entry.get("approved")]
+    belief_values = [_safe_float(entry.get("belief_density")) for entry in relevant if entry.get("belief_density") is not None]
+
+    last_approved: Optional[datetime] = None
+    if approvals:
+        last_approved = max((_parse_timestamp(entry.get("timestamp")) for entry in approvals), default=None)
+
+    return {
+        "thread": normalized,
+        "total": len(relevant),
+        "approved": len(approvals),
+        "denied": len(denials),
+        "belief_density": _belief_summary(belief_values),
+        "last_approved": _format_timestamp(last_approved),
+    }
+
+
+def _sanitize_entry(entry: Mapping[str, Any]) -> Dict[str, Any]:
+    timestamp = _format_timestamp(_parse_timestamp(entry.get("timestamp")))
+    tags = _normalize_tags(entry.get("mission_tags", []))
+    return {
+        "timestamp": timestamp,
+        "user_id": entry.get("user_id"),
+        "operation": entry.get("operation"),
+        "mission": entry.get("mission"),
+        "mission_tags": tags,
+        "approved": bool(entry.get("approved")),
+        "belief_density": _safe_float(entry.get("belief_density")),
+        "alignment": _safe_float(entry.get("alignment")),
+        "reason": entry.get("reason"),
+    }
+
+
+def compile_scale_snapshot(
+    history_limit: int = 50,
+    mission_threads: Sequence[str] | None = None,
+) -> Dict[str, Any]:
+    """Return aggregated readiness information for scale operations."""
+
+    module = _purposeful_scale()
+
+    log: Sequence[Mapping[str, Any]] = load_json(module.SCALE_LOG_PATH, [])
+    sorted_log = sorted(
+        log,
+        key=lambda entry: _parse_timestamp(entry.get("timestamp")) or datetime.min.replace(tzinfo=timezone.utc),
+    )
+    if history_limit and history_limit > 0:
+        sorted_log = sorted_log[-history_limit:]
+
+    sanitized = [_sanitize_entry(entry) for entry in sorted_log]
+
+    total = len(sanitized)
+    approvals = [entry for entry in sanitized if entry["approved"]]
+    approval_rate = round(len(approvals) / total, 3) if total else 0.0
+    belief_values = [entry["belief_density"] for entry in sanitized if entry["belief_density"]]
+
+    reasons = Counter(
+        entry["reason"] for entry in sanitized if entry["reason"] and not entry["approved"]
+    )
+
+    threads: set[str] = set()
+    for entry in sanitized:
+        for tag in entry.get("mission_tags", []):
+            threads.add(tag)
+
+    focus = set(tag.lower() for tag in mission_threads) if mission_threads else set()
+    if not focus:
+        focus = set(tag.lower() for tag in module.RECOGNIZED_MISSION_THREADS)
+        focus.update(threads)
+
+    thread_summaries = [_thread_metrics(sanitized, thread) for thread in sorted(focus)]
+
+    last_activity: Optional[datetime] = None
+    if sanitized:
+        last_activity = max((_parse_timestamp(entry["timestamp"]) for entry in sanitized), default=None)
+
+    readiness_notes: List[str] = []
+    scale_ready = bool(approvals)
+
+    if not total:
+        readiness_notes.append("no scale history available")
+        scale_ready = False
+
+    if approval_rate < 0.6:
+        readiness_notes.append("approval rate below 60% threshold")
+        scale_ready = False
+
+    for summary in thread_summaries:
+        if summary["approved"] == 0:
+            readiness_notes.append(f"missing approved coverage for thread '{summary['thread']}'")
+            scale_ready = False
+
+    if last_activity is not None:
+        now = datetime.now(timezone.utc)
+        if now - last_activity > MAX_STALENESS:
+            readiness_notes.append("last approved scale event is stale (>6h)")
+            scale_ready = False
+
+    profiles = load_json(module.PURPOSE_PROFILES_PATH, {})
+    profile_count = len(profiles) if isinstance(profiles, MutableMapping) else 0
+
+    attestation = _attestation_snapshot()
+
+    report = {
+        "generated_at": _format_timestamp(datetime.now(timezone.utc)),
+        "history_window": history_limit,
+        "entries": total,
+        "approval_rate": approval_rate,
+        "belief_density": _belief_summary(belief_values),
+        "denial_reasons": dict(reasons.most_common()),
+        "mission_threads": thread_summaries,
+        "scale_ready": scale_ready,
+        "readiness_notes": readiness_notes,
+        "profile_count": profile_count,
+        "last_activity": _format_timestamp(last_activity),
+        "attestations": attestation,
+        "recent_decisions": sanitized[-5:],
+    }
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Vaultfire scale readiness report")
+    parser.add_argument(
+        "--history",
+        type=int,
+        default=50,
+        help="number of recent scale decisions to include (default: 50)",
+    )
+    parser.add_argument(
+        "--mission-thread",
+        action="append",
+        dest="mission_threads",
+        help="limit readiness coverage checks to specific mission threads",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="pretty-print JSON output",
+    )
+    args = parser.parse_args(argv)
+
+    report = compile_scale_snapshot(args.history, args.mission_threads)
+    dump_kwargs = {"indent": 2, "sort_keys": True} if args.pretty else {}
+    print(json.dumps(report, **dump_kwargs))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/vaultfire_system_ready.py
+++ b/vaultfire_system_ready.py
@@ -12,12 +12,14 @@ import hashlib
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 BASE_DIR = Path(__file__).resolve().parent
 AUDIT_PATH = BASE_DIR / "vaultfire_audit_report.txt"
 READY_FLAG_PATH = BASE_DIR / "vaultfire_ready.flag"
 PARTNER_FORK_PATH = BASE_DIR / "vaultbundle_partner_fork.json"
+ATTESTATION_DIR = BASE_DIR / "attestations"
+LOGS_DIR = BASE_DIR / "logs"
 
 CORE_FILES = {
     "vaultfire_core.py": """from pathlib import Path
@@ -108,6 +110,9 @@ def _ensure_files() -> None:
                 path.write_text(json.dumps(content, indent=2))
             _log(f"created {name}")
 
+    LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    ATTESTATION_DIR.mkdir(parents=True, exist_ok=True)
+
 
 def _validate_scripts() -> List[str]:
     errors: List[str] = []
@@ -156,7 +161,66 @@ def _simulate_actions() -> List[str]:
         fanforge_vr.vr_check_in("demo", "team")
     except Exception as e:
         errors.append(f"action simulation failed: {e}")
+
+    try:
+        from engine import purposeful_scale
+
+        guardian_identity = {
+            "ens": "guardian.eth",
+            "wallet": "guardian.wallet",
+            "missionTags": ["Vaultfire", "NS3", "Ghostkey-316"],
+            "beliefDensity": purposeful_scale.DEFAULT_BELIEF_THRESHOLD + 0.2,
+            "declaredPurpose": (
+                "Safeguard Vaultfire, NS3, and Ghostkey-316 mission threads with moral coherence"
+            ),
+        }
+
+        mission = purposeful_scale.ensure_mission_profile("guardian.eth", guardian_identity)
+
+        scale_request = {
+            "operation": "system.readiness",
+            "mission_tags": guardian_identity["missionTags"],
+            "declared_purpose": mission,
+            "belief_density": guardian_identity["beliefDensity"],
+        }
+
+        purposeful_scale.belief_trace(
+            "guardian.eth",
+            scale_request,
+            identity=guardian_identity,
+        )
+
+        purposeful_scale.behavioral_resonance_filter("guardian.eth", scale_request)
+
+        purposeful_scale.generate_attestation_pack("guardian.eth", history_limit=5)
+    except Exception as e:
+        errors.append(f"purposeful scale simulation failed: {e}")
     return errors
+
+
+def _generate_attestation(user_id: str, history_limit: int | None) -> Tuple[Path, Dict[str, Any]]:
+    from engine import purposeful_scale
+
+    guardian_identity = {
+        "ens": user_id,
+        "wallet": f"{user_id}.vaultfire",
+        "missionTags": ["Vaultfire", "NS3", "Ghostkey-316"],
+        "beliefDensity": purposeful_scale.DEFAULT_BELIEF_THRESHOLD + 0.15,
+        "declaredPurpose": (
+            "Safeguard Vaultfire, NS3, and Ghostkey-316 mission threads with moral coherence"
+        ),
+    }
+
+    purposeful_scale.ensure_mission_profile(user_id, guardian_identity)
+    attestation = purposeful_scale.generate_attestation_pack(
+        user_id,
+        history_limit=history_limit,
+        include_index=True,
+    )
+    destination = ATTESTATION_DIR / f"{user_id.replace('/', '_')}_attestation.json"
+    destination.write_text(json.dumps(attestation, indent=2))
+    _log(f"generated attestation for {user_id}")
+    return destination, attestation
 
 
 def _generate_partner_fork(wallet: str) -> None:
@@ -186,6 +250,18 @@ def _system_hash() -> str:
 def main(argv: List[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Vaultfire system readiness")
     parser.add_argument("--partner-mode", metavar="WALLET", help="generate partner fork")
+    parser.add_argument(
+        "--attest",
+        metavar="USER",
+        help="generate a purposeful scale attestation for USER",
+    )
+    parser.add_argument(
+        "--attest-history",
+        metavar="N",
+        type=int,
+        default=10,
+        help="limit the attestation decision history (default: 10)",
+    )
     args = parser.parse_args(argv)
 
     _ensure_files()
@@ -197,6 +273,14 @@ def main(argv: List[str] | None = None) -> int:
 
     if args.partner_mode:
         _generate_partner_fork(args.partner_mode)
+
+    if args.attest:
+        try:
+            path, attestation = _generate_attestation(args.attest, args.attest_history)
+            _log(f"attestation stored at {path}")
+            _log(f"attestation hash {attestation.get('attestation_hash')}")
+        except Exception as exc:
+            issues.append(f"failed to generate attestation: {exc}")
 
     moral_violations = []
     banned = {"gamble", "casino", "surveillance", "coercion"}


### PR DESCRIPTION
## Summary
- extend `vaultfire_system_ready.py` with Purposeful Scale simulations, attestation generation, and partner attestation CLI options
- add `tools/scale_readiness_report.py` plus regression tests to quantify scale readiness metrics and attestation freshness
- document the new automation in the README and final readiness report for partners

## Testing
- pytest tests/test_scale_readiness_report.py purposeful_scale_test.py

------
https://chatgpt.com/codex/tasks/task_e_68e065e7e08083229a372e5ef52234a4