### PR TITLE
Add yield insights pipeline, API, and simulation tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Live pilot deployments targeted for Q4 roadmap; current examples demonstrate arc
 - **Unified scale health snapshot:** `./tools/scale_readiness_report.py --pretty` compiles recent Purposeful Scale decisions, thread coverage, belief-density stats, and attestation freshness into a single JSON payload so partners can gate launches on objective readiness signals.
 - **Staleness guards baked in:** The readiness report fails the `scale_ready` flag if approvals drop below 60% or if the last aligned expansion is older than six hours, keeping the protocol’s ethics-first mission central while scaling.
 
+## Yield Insights Pipeline
+- **Mission log conversion:** `python scripts/run_yield_pipeline.py` ingests `/missions/pilot_logs/*.json`, strips pilot identifiers, hashes mission IDs with SHA256, and publishes anonymized case studies to `/public/case_studies/` following `schemas/yield_case_study.schema.json`.
+- **Public API:** Launch the FastAPI service with `uvicorn yield_pipeline.api:app --reload` and query `/api/yield-insights?segment_id=belief-01`. Responses are rate limited to 30 requests/minute per IP, accept optional `date_range=start,end`, and require the `X-API-Key` header when `YIELD_API_KEY` is set.
+- **Repeatable activation modelling:** `python -c "from yield_pipeline.engine import simulate_activation_to_yield; import json; print(json.dumps(simulate_activation_to_yield('pilot-001'), indent=2))"` calculates retention, referral, and time projections, persisting audit-friendly reports in `/yield_reports/`.
+- **Attestations:** Every API call writes an anonymized audit record to `/attestations/yield-api-activity.json` so compliance teams can trace public insight access.
+- **Dashboard:** `streamlit run dashboard/yield_dashboard.py` renders belief-segment filters, ROI visualizations, and mission drilldowns sourced from the published case studies for transparent partner storytelling.
+
 ## Enterprise Bridge Enhancements (Resolved)
 - **Live adoption status:** `/deployment/status` and `/deployment/mode` expose a simulated/live toggle with a green-dot `LIVE` indicator, real-time telemetry ingestion (`POST /telemetry/realtime`), and onchain-ready signature logging (`POST /belief/actions/sign`). Partners can explore the view through the new `/trust-map` endpoint or the `cli/belief-mapper.js --map` CLI.
 - **Financial model clarity:** Rewards now surface hybrid-compliance posture, reputation-to-yield conversions, and partner revenue bridge previews directly from `/vaultfire/rewards/:walletId`. Config schemas accept `vaultfire.partnerReady`, deployment profiles, and partner revenue templates so governance votes can unlock real payouts on demand.

--- a/attestations/yield-api-activity.json
+++ b/attestations/yield-api-activity.json
@@ -1,0 +1,8 @@
+[
+  {
+    "timestamp": "2025-10-04T00:54:45.601623+00:00",
+    "client_hash": "846488f1dc5c07b4cebe5c14e0814b7b14f958f962c39ee7e5e5282c4b1e9474",
+    "segment": null,
+    "results": 3
+  }
+]

--- a/dashboard/yield_dashboard.py
+++ b/dashboard/yield_dashboard.py
@@ -1,0 +1,49 @@
+"""Streamlit dashboard for visualising yield case studies."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+from yield_pipeline.converter import load_case_studies
+
+st.set_page_config(page_title="Vaultfire Yield Dashboard", layout="wide")
+st.title("Vaultfire Yield Case Studies")
+st.caption("Ethical, scalable, transparent insights from mission activations.")
+
+case_study_dir = Path(st.sidebar.text_input("Case study directory", "public/case_studies"))
+
+try:
+    studies = load_case_studies(case_study_dir)
+except FileNotFoundError:
+    st.error("No case studies found. Run the pipeline first.")
+    st.stop()
+
+if not studies:
+    st.warning("Case study directory is empty. Generate insights to continue.")
+    st.stop()
+
+data = [study.model_dump(mode="json") for study in studies]
+frame = pd.DataFrame(data)
+frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+
+segments = sorted(frame["belief_segment"].unique())
+selected_segments = st.sidebar.multiselect("Belief segments", segments, default=segments)
+start_date = st.sidebar.date_input("Start date", value=frame["timestamp"].min().date())
+end_date = st.sidebar.date_input("End date", value=frame["timestamp"].max().date())
+
+mask = (
+    frame["belief_segment"].isin(selected_segments)
+    & (frame["timestamp"] >= datetime.combine(start_date, datetime.min.time()))
+    & (frame["timestamp"] <= datetime.combine(end_date, datetime.max.time()))
+)
+filtered = frame.loc[mask]
+
+st.metric("Total missions", len(filtered))
+st.metric("Average Ghostscore ROI", round(filtered["ghostscore_roi"].mean(), 2))
+
+st.bar_chart(filtered.groupby("yield_classification")["ghostscore_roi"].mean())
+st.dataframe(filtered.sort_values("timestamp", ascending=False), use_container_width=True)

--- a/missions/pilot_logs/mission_alpha.json
+++ b/missions/pilot_logs/mission_alpha.json
@@ -1,0 +1,12 @@
+{
+  "mission_id": "mission-alpha",
+  "pilot_id": "pilot-001",
+  "belief_id": "belief-engage-01",
+  "timestamp": "2024-12-01T10:15:00Z",
+  "trigger_event": "Completed onboarding flow",
+  "ghostscore_delta": 12.5,
+  "activation_signals": [
+    {"signal": "tutorial_complete", "weight": 0.6},
+    {"signal": "first_share", "weight": 0.4}
+  ]
+}

--- a/missions/pilot_logs/mission_beta.json
+++ b/missions/pilot_logs/mission_beta.json
@@ -1,0 +1,12 @@
+{
+  "mission_id": "mission-beta",
+  "pilot_id": "pilot-002",
+  "belief_id": "belief-retain-05",
+  "timestamp": "2024-12-02T14:45:00Z",
+  "trigger_event": "Unlocked community badge",
+  "ghostscore_delta": 20.1,
+  "activation_signals": [
+    {"signal": "community_post", "weight": 0.7},
+    {"signal": "event_attendance", "weight": 0.3}
+  ]
+}

--- a/missions/pilot_logs/mission_gamma.json
+++ b/missions/pilot_logs/mission_gamma.json
@@ -1,0 +1,12 @@
+{
+  "mission_id": "mission-gamma",
+  "pilot_id": "pilot-003",
+  "belief_id": "belief-convert-09",
+  "timestamp": "2024-12-03T08:30:00Z",
+  "trigger_event": "Converted free trial to paid tier",
+  "ghostscore_delta": 35.4,
+  "activation_signals": [
+    {"signal": "referral_generated", "weight": 0.5},
+    {"signal": "upgrade_click", "weight": 0.5}
+  ]
+}

--- a/public/case_studies/09acef66679dd891df5ef674fa49fa31c93285c9fe8906fb3d53412805b17be1.json
+++ b/public/case_studies/09acef66679dd891df5ef674fa49fa31c93285c9fe8906fb3d53412805b17be1.json
@@ -1,0 +1,8 @@
+{
+  "timestamp": "2024-12-01T10:15:00Z",
+  "belief_segment": "belief-01",
+  "yield_classification": "engagement",
+  "ghostscore_roi": 12.5,
+  "trigger_summary": "Completed onboarding flow",
+  "mission_hash": "09acef66679dd891df5ef674fa49fa31c93285c9fe8906fb3d53412805b17be1"
+}

--- a/public/case_studies/1dfbeebe583a95124d60f24bb1881c5c25e5059256899e552a9916e131d4932e.json
+++ b/public/case_studies/1dfbeebe583a95124d60f24bb1881c5c25e5059256899e552a9916e131d4932e.json
@@ -1,0 +1,8 @@
+{
+  "timestamp": "2024-12-02T14:45:00Z",
+  "belief_segment": "belief-05",
+  "yield_classification": "retention",
+  "ghostscore_roi": 20.1,
+  "trigger_summary": "Unlocked community badge",
+  "mission_hash": "1dfbeebe583a95124d60f24bb1881c5c25e5059256899e552a9916e131d4932e"
+}

--- a/public/case_studies/40b516e73cee4becbcd6627acf1a28201ca0bb58d553ef26a0e700b44628c380.json
+++ b/public/case_studies/40b516e73cee4becbcd6627acf1a28201ca0bb58d553ef26a0e700b44628c380.json
@@ -1,0 +1,8 @@
+{
+  "timestamp": "2024-12-03T08:30:00Z",
+  "belief_segment": "belief-09",
+  "yield_classification": "conversion",
+  "ghostscore_roi": 35.4,
+  "trigger_summary": "Converted free trial to paid tier",
+  "mission_hash": "40b516e73cee4becbcd6627acf1a28201ca0bb58d553ef26a0e700b44628c380"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ mypy_extensions==1.1.0
 nodeenv==1.9.1
 openai==1.98.0
 packaging==25.0
+pandas==2.2.3
 pathspec==0.12.1
 platformdirs==4.3.8
 pluggy==1.6.0

--- a/schemas/yield_case_study.schema.json
+++ b/schemas/yield_case_study.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "YieldCaseStudy",
+  "type": "object",
+  "required": [
+    "timestamp",
+    "belief_segment",
+    "yield_classification",
+    "ghostscore_roi",
+    "trigger_summary",
+    "mission_hash"
+  ],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "belief_segment": {
+      "type": "string",
+      "description": "An anonymized segment identifier"
+    },
+    "yield_classification": {
+      "type": "string",
+      "enum": ["engagement", "conversion", "retention", "risk"]
+    },
+    "ghostscore_roi": {
+      "type": "number"
+    },
+    "trigger_summary": {
+      "type": "string"
+    },
+    "mission_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/run_yield_pipeline.py
+++ b/scripts/run_yield_pipeline.py
@@ -1,0 +1,38 @@
+"""Command line entry point for the Vaultfire yield pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from yield_pipeline import convert_pilot_logs, settings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert pilot logs to public case studies")
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=settings.mission_logs_dir,
+        help="Directory containing pilot log JSON files",
+    )
+    parser.add_argument(
+        "--destination",
+        type=Path,
+        default=settings.case_study_dir,
+        help="Directory where case study JSON files will be written",
+    )
+    args = parser.parse_args()
+
+    case_studies = convert_pilot_logs(args.source, args.destination)
+    print(json.dumps([study.model_dump(mode="json") for study in case_studies], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_yield_pipeline.py
+++ b/tests/test_yield_pipeline.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from yield_pipeline import convert_pilot_logs, create_app, settings
+from yield_pipeline.engine import simulate_activation_to_yield
+
+
+def _write_pilot_log(path: Path, mission_id: str, belief_id: str, ghostscore: float) -> None:
+    payload = {
+        "mission_id": mission_id,
+        "pilot_id": "pilot-test",
+        "belief_id": belief_id,
+        "timestamp": "2024-01-01T00:00:00Z",
+        "trigger_event": "Test event",
+        "ghostscore_delta": ghostscore,
+        "activation_signals": [{"signal": "alpha", "weight": 0.5}],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_convert_pilot_logs(tmp_path, monkeypatch):
+    source = tmp_path / "missions"
+    dest = tmp_path / "cases"
+    source.mkdir()
+    _write_pilot_log(source / "mission_one.json", "mission-one", "belief-engage-01", 10.0)
+    _write_pilot_log(source / "mission_two.json", "mission-two", "belief-retain-04", 15.0)
+
+    monkeypatch.setattr(settings, "mission_logs_dir", source)
+    monkeypatch.setattr(settings, "case_study_dir", dest)
+
+    studies = convert_pilot_logs()
+    assert len(studies) == 2
+    for study in studies:
+        assert study.mission_hash
+        assert study.belief_segment.startswith("belief-")
+        assert study.trigger_summary == "Test event"
+
+
+def test_api_endpoint_filters(tmp_path, monkeypatch):
+    source = tmp_path / "missions"
+    dest = tmp_path / "cases"
+    attestations = tmp_path / "attestations.json"
+    source.mkdir()
+    _write_pilot_log(source / "mission_one.json", "mission-one", "belief-engage-01", 10.0)
+    _write_pilot_log(source / "mission_two.json", "mission-two", "belief-retain-04", 15.0)
+
+    monkeypatch.setattr(settings, "mission_logs_dir", source)
+    monkeypatch.setattr(settings, "case_study_dir", dest)
+    monkeypatch.setattr(settings, "attestations_path", attestations)
+    monkeypatch.setattr(settings, "api_key", None)
+
+    app = create_app()
+    client = TestClient(app)
+    response = client.get(
+        "/api/yield-insights",
+        params={"segment_id": "belief-04", "date_range": "2023-12-31T00:00:00,2024-12-31T23:59:59"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["belief_segment"] == "belief-04"
+
+    audit = json.loads(attestations.read_text(encoding="utf-8"))
+    assert audit[0]["results"] == 1
+
+
+def test_simulate_activation_to_yield(tmp_path, monkeypatch):
+    source = tmp_path / "missions"
+    source.mkdir()
+    _write_pilot_log(source / "mission_one.json", "mission-one", "belief-convert-01", 25.0)
+
+    monkeypatch.setattr(settings, "mission_logs_dir", source)
+    monkeypatch.setattr(settings, "yield_reports_dir", tmp_path / "reports")
+
+    result = simulate_activation_to_yield("pilot-test")
+    assert "user_hash" in result
+    assert result["mission_hashes"]
+    report_files = list((tmp_path / "reports").glob("*.json"))
+    assert report_files

--- a/yield_pipeline/__init__.py
+++ b/yield_pipeline/__init__.py
@@ -1,0 +1,13 @@
+"""Vaultfire Yield Pipeline package."""
+
+from .config import settings
+from .converter import convert_pilot_logs
+from .engine import simulate_activation_to_yield
+from .api import create_app
+
+__all__ = [
+    "settings",
+    "convert_pilot_logs",
+    "simulate_activation_to_yield",
+    "create_app",
+]

--- a/yield_pipeline/api.py
+++ b/yield_pipeline/api.py
@@ -1,0 +1,132 @@
+"""FastAPI application exposing yield insights."""
+
+from __future__ import annotations
+
+import json
+from collections import deque
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Deque, Dict, List, Optional, Tuple
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+from contextlib import asynccontextmanager
+
+from .config import settings
+from .converter import case_studies_to_yield_insights, convert_pilot_logs, load_case_studies
+
+RequestLog = Deque[datetime]
+_rate_log: Dict[str, RequestLog] = {}
+
+
+def _hash_ip(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def _log_audit(entry: dict) -> None:
+    path = settings.attestations_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        with path.open("r", encoding="utf-8") as handle:
+            try:
+                data = json.load(handle)
+            except json.JSONDecodeError:
+                data = []
+    else:
+        data = []
+    data.append(entry)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2)
+
+
+def rate_limiter(request: Request) -> None:
+    ip = request.client.host if request.client else "unknown"
+    now = datetime.now(timezone.utc)
+    log = _rate_log.setdefault(ip, deque())
+    while log and (now - log[0]).total_seconds() > 60:
+        log.popleft()
+    if len(log) >= settings.rate_limit_per_minute:
+        raise HTTPException(status_code=429, detail="Rate limit exceeded")
+    log.append(now)
+
+
+def authenticate(request: Request) -> None:
+    if settings.api_key:
+        provided = request.headers.get("X-API-Key")
+        if provided != settings.api_key:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+def _ensure_timezone(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def parse_date_range(date_range: Optional[str]) -> Tuple[Optional[datetime], Optional[datetime]]:
+    if not date_range:
+        return None, None
+    try:
+        start_raw, end_raw = [part.strip() for part in date_range.split(",", 1)]
+        start = _ensure_timezone(datetime.fromisoformat(start_raw))
+        end = _ensure_timezone(datetime.fromisoformat(end_raw))
+        return start, end
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid date_range format") from exc
+
+
+def filter_case_studies(
+    studies: List[dict],
+    segment_id: Optional[str],
+    date_range: Tuple[Optional[datetime], Optional[datetime]],
+) -> List[dict]:
+    start, end = date_range
+    filtered = []
+    for study in studies:
+        if segment_id and segment_id != study["belief_segment"]:
+            continue
+        timestamp = _ensure_timezone(datetime.fromisoformat(study["timestamp"]))
+        if start and timestamp < start:
+            continue
+        if end and timestamp > end:
+            continue
+        filtered.append(study)
+    return filtered
+
+
+@asynccontextmanager
+async def _lifespan(_: FastAPI):
+    convert_pilot_logs()
+    yield
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="Vaultfire Yield Insights",
+        version="1.0.0",
+        description="Ethical, scalable and transparent yield case studies pipeline.",
+        lifespan=_lifespan,
+    )
+
+    @app.get("/api/yield-insights", dependencies=[Depends(rate_limiter), Depends(authenticate)])
+    async def get_yield_insights(
+        request: Request,
+        segment_id: Optional[str] = None,
+        date_range: Optional[str] = None,
+    ) -> List[dict]:
+        convert_pilot_logs()
+        case_studies = load_case_studies()
+        insights = case_studies_to_yield_insights(case_studies)
+        filtered = filter_case_studies(insights, segment_id, parse_date_range(date_range))
+        audit_entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "client_hash": _hash_ip(request.client.host if request.client else "unknown"),
+            "segment": segment_id,
+            "results": len(filtered),
+        }
+        _log_audit(audit_entry)
+        return filtered
+
+    return app
+
+
+app = create_app()

--- a/yield_pipeline/config.py
+++ b/yield_pipeline/config.py
@@ -1,0 +1,25 @@
+"""Configuration for the Vaultfire yield pipeline."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Settings(BaseModel):
+    """Paths and runtime configuration for the pipeline."""
+
+    mission_logs_dir: Path = Path("missions/pilot_logs")
+    case_study_dir: Path = Path("public/case_studies")
+    yield_reports_dir: Path = Path("yield_reports")
+    attestations_path: Path = Path("attestations/yield-api-activity.json")
+    api_key: Optional[str] = None
+    rate_limit_per_minute: int = 30
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+settings = Settings(api_key=os.getenv("YIELD_API_KEY"))

--- a/yield_pipeline/converter.py
+++ b/yield_pipeline/converter.py
@@ -1,0 +1,76 @@
+"""Pilot log conversion into public case studies."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+from .config import settings
+from .models import CaseStudy, PilotLog, anonymize_belief_segment, classify_yield
+
+
+def _load_pilot_log(path: Path) -> PilotLog:
+    with path.open("r", encoding="utf-8") as handle:
+        raw = json.load(handle)
+    return PilotLog.model_validate(raw)
+
+
+def _to_case_study(pilot_log: PilotLog) -> CaseStudy:
+    belief_segment = anonymize_belief_segment(pilot_log.belief_id)
+    yield_classification = classify_yield(pilot_log.belief_id, pilot_log.ghostscore_delta)
+    return CaseStudy(
+        timestamp=pilot_log.timestamp,
+        belief_segment=belief_segment,
+        yield_classification=yield_classification,
+        ghostscore_roi=round(pilot_log.ghostscore_delta, 2),
+        trigger_summary=pilot_log.trigger_event,
+        mission_hash=pilot_log.hashed_mission_id,
+    )
+
+
+def convert_pilot_logs(source: Path | None = None, destination: Path | None = None) -> List[CaseStudy]:
+    """Convert pilot logs into anonymised case studies."""
+
+    source_dir = Path(source or settings.mission_logs_dir)
+    destination_dir = Path(destination or settings.case_study_dir)
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    case_studies: List[CaseStudy] = []
+    for path in sorted(source_dir.glob("*.json")):
+        pilot_log = _load_pilot_log(path)
+        case_study = _to_case_study(pilot_log)
+        case_studies.append(case_study)
+        output_path = destination_dir / f"{case_study.mission_hash}.json"
+        with output_path.open("w", encoding="utf-8") as handle:
+            json.dump(case_study.model_dump(mode="json"), handle, indent=2)
+    return case_studies
+
+
+def load_case_studies(directory: Path | None = None) -> List[CaseStudy]:
+    """Load previously generated case studies."""
+
+    case_dir = Path(directory or settings.case_study_dir)
+    studies: List[CaseStudy] = []
+    for path in sorted(case_dir.glob("*.json")):
+        with path.open("r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+        studies.append(CaseStudy.model_validate(raw))
+    return studies
+
+
+def case_studies_to_yield_insights(case_studies: Iterable[CaseStudy]) -> List[dict]:
+    """Translate case studies into a payload suitable for the public API."""
+
+    insights = []
+    for study in case_studies:
+        insights.append(
+            {
+                "mission_id": study.mission_hash,
+                "belief_segment": study.belief_segment,
+                "yield_type": study.yield_classification,
+                "ghostscore_delta": study.ghostscore_roi,
+                "timestamp": study.timestamp.isoformat(),
+            }
+        )
+    return insights

--- a/yield_pipeline/engine.py
+++ b/yield_pipeline/engine.py
@@ -1,0 +1,62 @@
+"""Activation-to-yield simulation utilities."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+from statistics import mean
+from typing import List
+
+from .config import settings
+from .models import PilotLog, YieldSimulationResult
+from .converter import _load_pilot_log
+
+
+def _hash_identifier(identifier: str) -> str:
+    return sha256(identifier.encode("utf-8")).hexdigest()
+
+
+def _load_user_missions(user_id: str, source: Path | None = None) -> List[PilotLog]:
+    source_dir = Path(source or settings.mission_logs_dir)
+    missions: List[PilotLog] = []
+    for path in source_dir.glob("*.json"):
+        log = _load_pilot_log(path)
+        if log.pilot_id == user_id:
+            missions.append(log)
+    return missions
+
+
+def simulate_activation_to_yield(user_id: str) -> dict:
+    """Calculate projected yield outcomes for a given user."""
+
+    missions = _load_user_missions(user_id)
+    if not missions:
+        raise ValueError(f"No mission history found for user: {user_id}")
+
+    total_delta = sum(m.ghostscore_delta for m in missions)
+    avg_signal_weight = mean(
+        signal.weight for mission in missions for signal in mission.activation_signals
+    ) if any(m.activation_signals for m in missions) else 0.0
+
+    estimated_retention_boost = min(0.35 + total_delta / 100, 0.95)
+    referral_probability = min(0.1 + avg_signal_weight * 0.5 + len(missions) * 0.05, 0.99)
+    projected_active_minutes = round(45 + total_delta * 1.8, 2)
+
+    result = YieldSimulationResult(
+        user_hash=_hash_identifier(user_id),
+        mission_hashes=[mission.hashed_mission_id for mission in missions],
+        estimated_retention_boost=round(estimated_retention_boost, 3),
+        referral_probability=round(referral_probability, 3),
+        projected_active_minutes=projected_active_minutes,
+        generated_at=datetime.now(timezone.utc),
+        notes="Derived from historical ghostscore trends.",
+    )
+
+    settings.yield_reports_dir.mkdir(parents=True, exist_ok=True)
+    report_path = settings.yield_reports_dir / f"{result.user_hash}.json"
+    with report_path.open("w", encoding="utf-8") as handle:
+        json.dump(result.model_dump(mode="json"), handle, indent=2)
+
+    return result.model_dump(mode="json")

--- a/yield_pipeline/models.py
+++ b/yield_pipeline/models.py
@@ -1,0 +1,80 @@
+"""Data models for the Vaultfire yield pipeline."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from hashlib import sha256
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ActivationSignal(BaseModel):
+    signal: str
+    weight: float
+
+
+class PilotLog(BaseModel):
+    mission_id: str
+    pilot_id: str
+    belief_id: str
+    timestamp: datetime
+    trigger_event: str
+    ghostscore_delta: float
+    activation_signals: List[ActivationSignal] = Field(default_factory=list)
+
+    @property
+    def hashed_mission_id(self) -> str:
+        """Return a deterministic SHA256 hash of the mission identifier."""
+
+        return sha256(self.mission_id.encode("utf-8")).hexdigest()
+
+
+class CaseStudy(BaseModel):
+    timestamp: datetime
+    belief_segment: str
+    yield_classification: str
+    ghostscore_roi: float
+    trigger_summary: str
+    mission_hash: str
+
+
+class YieldInsight(BaseModel):
+    mission_id: str
+    belief_segment: str
+    yield_type: str
+    ghostscore_delta: float
+    timestamp: datetime
+
+
+class YieldSimulationResult(BaseModel):
+    user_hash: str
+    mission_hashes: List[str]
+    estimated_retention_boost: float
+    referral_probability: float
+    projected_active_minutes: float
+    generated_at: datetime
+    notes: Optional[str] = None
+
+
+def anonymize_belief_segment(belief_id: str) -> str:
+    """Return a privacy-preserving belief segment label."""
+
+    prefix = belief_id.split("-")[0]
+    return f"{prefix}-{belief_id[-2:]}"
+
+
+YIELD_CLASSIFICATION_RULES = {
+    "engage": "engagement",
+    "convert": "conversion",
+    "retain": "retention",
+}
+
+
+def classify_yield(belief_id: str, ghostscore_delta: float) -> str:
+    """Derive a yield classification from the belief id and score delta."""
+
+    for key, label in YIELD_CLASSIFICATION_RULES.items():
+        if key in belief_id:
+            return label
+    return "engagement" if ghostscore_delta >= 0 else "risk"

--- a/yield_reports/24b8fc0dadce841e51822d4278ed09e74092b10f015fb9bdd7d9a3a56a8cb5d0.json
+++ b/yield_reports/24b8fc0dadce841e51822d4278ed09e74092b10f015fb9bdd7d9a3a56a8cb5d0.json
@@ -1,0 +1,11 @@
+{
+  "user_hash": "24b8fc0dadce841e51822d4278ed09e74092b10f015fb9bdd7d9a3a56a8cb5d0",
+  "mission_hashes": [
+    "09acef66679dd891df5ef674fa49fa31c93285c9fe8906fb3d53412805b17be1"
+  ],
+  "estimated_retention_boost": 0.475,
+  "referral_probability": 0.4,
+  "projected_active_minutes": 67.5,
+  "generated_at": "2025-10-04T00:54:30.086310Z",
+  "notes": "Derived from historical ghostscore trends."
+}


### PR DESCRIPTION
## Summary
- convert pilot mission logs into anonymized case studies and publish schema plus CLI entrypoint
- expose a secured `/api/yield-insights` FastAPI endpoint with rate limiting, audit logging, and hashed identifiers
- add activation-to-yield simulation engine, Streamlit dashboard, automated tests, and sample outputs for reports and attestations

## Testing
- pytest tests/test_yield_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e06f8d5b488322bfd1f4b0c8877f5a