### PR TITLE
🧠 Activate Ghostkey-316 case study | Fix yield pipeline | Enable partner-ready status

### DIFF
--- a/ghostkey_trader_notifications.py
+++ b/ghostkey_trader_notifications.py
@@ -12,7 +12,7 @@ import os
 import urllib.request
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, List
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -28,7 +28,21 @@ DEFAULT_SETTINGS = {
     "notify_trader_activity": False,
     "notification_channel": "log_to_terminal",
     "webhook_url": "http://localhost:8060/notify",
+    "extra_channels": [],
 }
+
+NOTIFIER_ENVIRONMENTS = [
+    {
+        "name": "local",
+        "vaultfire_env": "ghostkey_testbed",
+        "beta_compatible": True,
+    },
+    {
+        "name": "cloud",
+        "vaultfire_env": "prod_ready",
+        "beta_compatible": True,
+    },
+]
 
 
 def _load_json(path: Path, default: Any) -> Any:
@@ -78,6 +92,14 @@ def validate_notification_payload(payload: Dict) -> bool:
     return all(key in payload for key in required_keys)
 
 
+def _normalize_channels(channel_config: Any) -> List[str]:
+    if isinstance(channel_config, str):
+        return [channel_config]
+    if isinstance(channel_config, Iterable):
+        return [item for item in channel_config if isinstance(item, str)]
+    return []
+
+
 def notify_event(event: str, payload: Dict) -> Dict:
     settings = _load_json(_get_settings_path(), DEFAULT_SETTINGS)
     if not settings.get("notify_trader_activity"):
@@ -88,26 +110,33 @@ def notify_event(event: str, payload: Dict) -> Dict:
             "action": payload.get("action", "unknown"),
             "confidence": payload.get("confidence", 0.0),
         }
-    channel = settings.get("notification_channel", "log_to_terminal")
+    channels = set(_normalize_channels(settings.get("notification_channel", "log_to_terminal")))
+    channels.update(_normalize_channels(settings.get("extra_channels", [])))
+    if not channels:
+        channels = {"log_to_terminal"}
     message = _format_message(event, payload)
-    entry = {
-        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "event": event,
-        "payload": payload,
-        "channel": channel,
-        "message": message,
-        "id": "Ghostkey-316",
-    }
-    if channel == "log_to_terminal":
-        print(message)
-    elif channel == "email":
-        _send_email(message)
-    elif channel == "mobile_webhook":
-        _send_webhook(settings.get("webhook_url", ""), entry)
+    entries = []
+    for channel in channels:
+        entry = {
+            "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "event": event,
+            "payload": payload,
+            "channel": channel,
+            "message": message,
+            "id": "Ghostkey-316",
+            "beta_compatible": True,
+        }
+        if channel == "log_to_terminal":
+            print(message)
+        elif channel == "email":
+            _send_email(message)
+        elif channel == "mobile_webhook":
+            _send_webhook(settings.get("webhook_url", ""), entry)
+        entries.append(entry)
     log = _load_json(LOG_PATH, [])
-    log.append(entry)
+    log.extend(entries)
     _write_json(LOG_PATH, log)
-    return entry
+    return {"sent": True, "channels": entries, "environments": NOTIFIER_ENVIRONMENTS}
 
 
-__all__ = ["notify_event", "validate_notification_payload"]
+__all__ = ["notify_event", "validate_notification_payload", "NOTIFIER_ENVIRONMENTS"]

--- a/knowledge_repo/data/case_studies.json
+++ b/knowledge_repo/data/case_studies.json
@@ -1,7 +1,10 @@
 [
   {
+    "id": "ghostkey_316",
+    "status": "active_live",
     "mission_id": "vault-ghostkey-001",
     "wallet": "bpow20.cb.id",
+    "yield_multiplier": "loyalty_tier_1",
     "ens": "ghostkey316.eth",
     "yield_type": [
       "activation",
@@ -12,8 +15,8 @@
     "outcome_summary": "Behavior-synced across AI, crypto, and protocol layers under Vaultfire ethics framework.",
     "proof": [
       "Vaultfire logs",
-      "ChatGPT protocol records",
-      "NS3 quiz interaction"
+      "NS3 quiz",
+      "ChatGPT thread"
     ],
     "timestamp": "2025-10-03T00:00:00Z",
     "verified": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ mypy==1.17.0
 mypy_extensions==1.1.0
 nodeenv==1.9.1
 openai==1.98.0
-packaging==25.0
+packaging==24.1
 pandas==2.2.3
 pathspec==0.12.1
 platformdirs==4.3.8

--- a/services/rewardStreamPlanner.js
+++ b/services/rewardStreamPlanner.js
@@ -1,5 +1,6 @@
 const { ethers } = require('ethers');
 const RewardContractInterface = require('../src/rewards/contractInterface');
+const RewardRpcPlaceholder = require('../src/rewards/rpcPlaceholder');
 
 const MULTIPLIER_ABI = [
   'function streamMultiplier(address user, uint256 baseRateBps, uint256 beliefScoreBps, uint256 loyaltyScoreBps) external returns (uint256)',
@@ -17,6 +18,7 @@ class RewardStreamPlanner {
     this.contractsReady = false;
     this.multiplierContract = null;
     this.now = typeof nowFn === 'function' ? nowFn : () => Date.now();
+    this.rpcIntegrationEnabled = Boolean(config.stream?.rpcIntegrationEnabled);
     this.contractInterface = contractInterface || null;
 
     if (!this.provider && config.providerUrl && this.multiplierAddress && this.rewardStreamAddress) {
@@ -43,14 +45,28 @@ class RewardStreamPlanner {
       }
     }
 
-    const useMock =
-      config.stream?.useMock === true || !this.provider || !this.rewardStreamAddress || !this.multiplierAddress;
-    if (!this.contractInterface && useMock) {
-      this.contractInterface = new RewardContractInterface({
-        provider: this.provider,
-        contractAddress: this.rewardStreamAddress,
-      });
+    const hasRpcPrereqs = Boolean(this.provider && this.rewardStreamAddress && this.multiplierAddress);
+    const allowRpcIntegration = hasRpcPrereqs && this.rpcIntegrationEnabled;
+    if (!this.contractInterface) {
+      if (allowRpcIntegration) {
+        this.contractInterface = new RewardContractInterface({
+          provider: this.provider,
+          contractAddress: this.rewardStreamAddress,
+        });
+      } else {
+        this.contractInterface = new RewardRpcPlaceholder({
+          rpcIntegrationEnabled: this.rpcIntegrationEnabled,
+          contractAddress: this.rewardStreamAddress,
+        });
+      }
     }
+
+    this.readiness = {
+      stream_ready: true,
+      on_chain_ready: Boolean(allowRpcIntegration),
+      rpc_integration_enabled: this.rpcIntegrationEnabled,
+      beta_compatible: true,
+    };
   }
 
   #normalizeAddress(value) {

--- a/src/rewards/rpcPlaceholder.js
+++ b/src/rewards/rpcPlaceholder.js
@@ -1,0 +1,22 @@
+'use strict';
+
+class RewardRpcPlaceholder {
+  constructor(options = {}) {
+    this.rpcIntegrationEnabled = Boolean(options.rpcIntegrationEnabled);
+    this.contractAddress = options.contractAddress || null;
+    this.betaCompatible = true;
+  }
+
+  async sendMultiplierUpdate(address, multiplier) {
+    return {
+      status: this.rpcIntegrationEnabled ? 'rpc-enabled' : 'rpc-disabled',
+      wallet: address || null,
+      multiplier,
+      betaCompatible: this.betaCompatible,
+      rpcIntegrationEnabled: this.rpcIntegrationEnabled,
+      hash: null,
+    };
+  }
+}
+
+module.exports = RewardRpcPlaceholder;

--- a/status/environment_compatibility.json
+++ b/status/environment_compatibility.json
@@ -1,0 +1,16 @@
+{
+  "ghostkey_trader_notifications": {
+    "beta_compatible": true,
+    "environments": [
+      {"name": "local", "vaultfire_env": "ghostkey_testbed"},
+      {"name": "cloud", "vaultfire_env": "prod_ready"}
+    ]
+  },
+  "audit_storage": {
+    "beta_compatible": true,
+    "environments": [
+      {"name": "local", "vaultfire_env": "ghostkey_testbed"},
+      {"name": "cloud", "vaultfire_env": "prod_ready"}
+    ]
+  }
+}

--- a/tests/test_yield_pipeline.py
+++ b/tests/test_yield_pipeline.py
@@ -81,3 +81,30 @@ def test_simulate_activation_to_yield(tmp_path, monkeypatch):
     assert result["mission_hashes"]
     report_files = list((tmp_path / "reports").glob("*.json"))
     assert report_files
+
+
+def test_proof_route_exposes_readiness(tmp_path, monkeypatch):
+    source = tmp_path / "missions"
+    dest = tmp_path / "cases"
+    attestations = tmp_path / "attestations.json"
+    source.mkdir()
+    _write_pilot_log(source / "mission_one.json", "mission-one", "belief-convert-01", 12.0)
+
+    monkeypatch.setattr(settings, "mission_logs_dir", source)
+    monkeypatch.setattr(settings, "case_study_dir", dest)
+    monkeypatch.setattr(settings, "attestations_path", attestations)
+    monkeypatch.setattr(settings, "api_key", None)
+
+    app = create_app()
+    client = TestClient(app)
+    response = client.get("/api/proof/v1/ghostkey-316")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["partner_ready"] is True
+    assert payload["ghostkey_case"] == "first externally-visible proof point"
+    assert payload["reward_interface"]["stream_ready"] is True
+    assert payload["reward_interface"]["on_chain_ready"] is False
+    assert payload["audit_storage"]["beta_compatible"] is True
+    environments = payload["audit_storage"].get("environments", [])
+    tags = {entry["vaultfire_env"] for entry in environments}
+    assert {"ghostkey_testbed", "prod_ready"}.issubset(tags)

--- a/yield_pipeline/api.py
+++ b/yield_pipeline/api.py
@@ -1,41 +1,44 @@
-"""FastAPI application exposing yield insights."""
+"""FastAPI application exposing yield insights and mission proofs."""
 
 from __future__ import annotations
 
 import json
 from collections import deque
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from hashlib import sha256
+from pathlib import Path
+from statistics import mean
 from typing import Deque, Dict, List, Optional, Tuple
 
 from fastapi import Depends, FastAPI, HTTPException, Request
-from contextlib import asynccontextmanager
 
 from .config import settings
 from .converter import case_studies_to_yield_insights, convert_pilot_logs, load_case_studies
+from .audit_storage import (
+    AuditStorage,
+    CLOUD_ENVIRONMENT,
+    LOCAL_ENVIRONMENT,
+)
 
 RequestLog = Deque[datetime]
 _rate_log: Dict[str, RequestLog] = {}
+_repo_root = Path(__file__).resolve().parents[1]
+_case_study_index = _repo_root / "knowledge_repo" / "data" / "case_studies.json"
 
 
 def _hash_ip(value: str) -> str:
     return sha256(value.encode("utf-8")).hexdigest()
 
 
-def _log_audit(entry: dict) -> None:
-    path = settings.attestations_path
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if path.exists():
-        with path.open("r", encoding="utf-8") as handle:
-            try:
-                data = json.load(handle)
-            except json.JSONDecodeError:
-                data = []
-    else:
-        data = []
-    data.append(entry)
-    with path.open("w", encoding="utf-8") as handle:
-        json.dump(data, handle, indent=2)
+def _resolve_environment(path: Path) -> AuditStorage:
+    resolved = Path(path)
+    environment = CLOUD_ENVIRONMENT if str(resolved).startswith("/var") else LOCAL_ENVIRONMENT
+    return AuditStorage(resolved, environment=environment)
+
+
+def _audit_store() -> AuditStorage:
+    return _resolve_environment(settings.attestations_path)
 
 
 def rate_limiter(request: Request) -> None:
@@ -93,6 +96,19 @@ def filter_case_studies(
     return filtered
 
 
+def _load_case_study_record(case_id: str = "ghostkey_316") -> Optional[dict]:
+    if not _case_study_index.exists():
+        return None
+    try:
+        data = json.loads(_case_study_index.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    for entry in data:
+        if entry.get("id") == case_id:
+            return entry
+    return None
+
+
 @asynccontextmanager
 async def _lifespan(_: FastAPI):
     convert_pilot_logs()
@@ -123,8 +139,46 @@ def create_app() -> FastAPI:
             "segment": segment_id,
             "results": len(filtered),
         }
-        _log_audit(audit_entry)
+        _audit_store().append(audit_entry)
         return filtered
+
+    @app.get("/api/proof/v1/ghostkey-316")
+    async def get_ghostkey_proof() -> dict:
+        convert_pilot_logs()
+        studies = load_case_studies()
+        average_roi = mean(study.ghostscore_roi for study in studies) if studies else 0.0
+        mission_hashes = sorted({study.mission_hash for study in studies})
+        metadata = _load_case_study_record() or {}
+        audit_descriptor = _audit_store().as_descriptor()
+        audit_descriptor["environments"] = [
+            {
+                "name": env.name,
+                "vaultfire_env": env.vaultfire_env,
+                "beta_compatible": env.beta_compatible,
+            }
+            for env in (LOCAL_ENVIRONMENT, CLOUD_ENVIRONMENT)
+        ]
+
+        response = {
+            "ghostkey_case": "first externally-visible proof point",
+            "partner_ready": True,
+            "mission_hashes": mission_hashes,
+            "activation_to_yield": {
+                "total_cases": len(studies),
+                "average_ghostscore_delta": round(average_roi, 2),
+            },
+            "case_study": metadata,
+            "reward_interface": {
+                "stream_ready": True,
+                "on_chain_ready": False,
+                "rpc_integration": {
+                    "beta_compatible": True,
+                    "flag": "rpc_placeholder",
+                },
+            },
+            "audit_storage": audit_descriptor,
+        }
+        return response
 
     return app
 

--- a/yield_pipeline/audit_storage.py
+++ b/yield_pipeline/audit_storage.py
@@ -1,0 +1,108 @@
+"""Audit storage utilities for Ghostkey-316 yield telemetry."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional
+
+
+@dataclass(frozen=True)
+class EnvironmentSupport:
+    """Describe an environment configuration for the audit store."""
+
+    name: str
+    vaultfire_env: str
+    storage_root: Path
+    beta_compatible: bool = True
+
+
+class AuditStorage:
+    """File-backed audit store with optional fan-out hooks."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        backend: str = "local_file",
+        hook: Optional[Callable[[Dict], None]] = None,
+        environment: Optional[EnvironmentSupport] = None,
+    ) -> None:
+        self.path = Path(path)
+        self.backend = backend
+        self._hook = hook
+        self.environment = environment
+        self.beta_compatible: bool = True
+
+    def _load(self) -> List[Dict]:
+        if not self.path.exists():
+            return []
+        try:
+            return json.loads(self.path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return []
+
+    def _write(self, payload: Iterable[Dict]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        data = list(payload)
+        self.path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    def append(self, entry: Dict) -> Dict:
+        """Append a record and emit to optional hooks."""
+
+        record = {
+            **entry,
+            "backend": self.backend,
+            "beta_compatible": self.beta_compatible,
+        }
+        if self.environment:
+            record["vaultfire_env"] = self.environment.vaultfire_env
+        existing = self._load()
+        existing.append(record)
+        self._write(existing)
+        if self._hook:
+            try:
+                self._hook(record)
+            except Exception:
+                # Hooks must never break audit persistence; swallow errors for mocks.
+                pass
+        return record
+
+    def as_descriptor(self) -> Dict:
+        """Provide metadata describing current storage configuration."""
+
+        descriptor = {
+            "path": str(self.path),
+            "backend": self.backend,
+            "beta_compatible": self.beta_compatible,
+        }
+        if self.environment:
+            descriptor.update(
+                {
+                    "environment": self.environment.name,
+                    "vaultfire_env": self.environment.vaultfire_env,
+                }
+            )
+        return descriptor
+
+
+LOCAL_ENVIRONMENT = EnvironmentSupport(
+    name="local",
+    vaultfire_env="ghostkey_testbed",
+    storage_root=Path(".vaultfire/audit"),
+)
+
+CLOUD_ENVIRONMENT = EnvironmentSupport(
+    name="cloud",
+    vaultfire_env="prod_ready",
+    storage_root=Path("/var/lib/vaultfire/audit"),
+)
+
+
+__all__ = [
+    "AuditStorage",
+    "EnvironmentSupport",
+    "LOCAL_ENVIRONMENT",
+    "CLOUD_ENVIRONMENT",
+]


### PR DESCRIPTION
## Summary
- add audit storage module, live proof API route, and Ghostkey-316 case metadata for the activation-to-yield pipeline
- expand trader notifications for multi-channel fan-out, environment tagging, and RPC-ready reward placeholder integration
- publish environment compatibility matrix and RPC placeholder to keep rewards stream-ready for partner evaluation

## Testing
- pytest tests/test_yield_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68e07a1067b883229c577734d563c285