### PR TITLE
Add secure collaboration and ethics alignment upgrades

### DIFF
--- a/tests/test_fhe_mpc_integrity.py
+++ b/tests/test_fhe_mpc_integrity.py
@@ -1,0 +1,33 @@
+from vaultfire.protocol.secure_collaboration import MPCFabric
+from vaultfire.security.fhe import FHECipherSuite, Ciphertext
+from vaultfire.protocol.telemetry import ZKFog
+
+
+def test_mpc_collaboration_generates_proof():
+    suite = FHECipherSuite()
+    fabric = MPCFabric(cipher_suite=suite)
+    fabric.submit_encrypted_payload("alpha.eth", {"stake": 10}, signal_context="shared-staking")
+    fabric.submit_encrypted_payload("beta.eth", {"stake": 12}, signal_context="shared-staking")
+
+    result = fabric.collaborative_sum()
+    assert isinstance(result["ciphertext"], Ciphertext)
+    assert result["participants"] == 2
+    assert result["proof"]["context"] == "vaultfire::mpc_collaboration"
+    assert result["architect_wallet"] == "bpow20.cb.id"
+    assert result["origin_node"] == "Ghostkey-316"
+
+    summary = fabric.decrypt_summary()
+    assert summary["participants"] == 2
+    assert summary["moral_tag"] == suite.moral_tag
+
+
+def test_zk_fog_emits_encrypted_summary():
+    entries = (
+        {"ethics": "aligned", "action": "stake"},
+        {"ethics": "aligned", "action": "vote"},
+    )
+    fog = ZKFog(behavior_input=entries, output_proof="ethics_compliant_weekly_summary")
+    proof = fog.synthesize_summary()
+    assert proof["events"] == 2
+    assert proof["proof"]["context"] == "telemetry::ethics_compliant_weekly_summary"
+    assert proof["architect_wallet"] == "bpow20.cb.id"

--- a/tests/test_ghostkey_ai_nodes.py
+++ b/tests/test_ghostkey_ai_nodes.py
@@ -1,0 +1,17 @@
+import pytest
+
+from vaultfire.protocol.ghostkey_ai import GhostkeyAINetwork
+
+
+def test_deploy_and_trigger_ghostkey_ai_node():
+    network = GhostkeyAINetwork()
+    node = network.deploy(wallet="ghostkey316.eth", function="Observe + Trigger Ethics Yield Boosts")
+    assert node.wallet == "ghostkey316.eth"
+    assert node.status == "passive"
+
+    event = network.trigger_ethics_boost("ghostkey316.eth", ethics_score=0.92)
+    assert event["status"] == "boosted"
+    assert event["architect_wallet"] == "bpow20.cb.id"
+
+    with pytest.raises(KeyError):
+        network.trigger_ethics_boost("unknown.eth", ethics_score=1.0)

--- a/tests/test_partner_consent_mirroring.py
+++ b/tests/test_partner_consent_mirroring.py
@@ -1,0 +1,22 @@
+import pytest
+
+from vaultfire.protocol.consent_mirror import ConsentMirror
+
+
+def test_partner_consent_mirroring_flow():
+    manifest = {"ethics_framework": "ghostkey"}
+    consent = ConsentMirror(
+        public_manifest=manifest,
+        usage_scope="Loyalty, Trust Scoring, Yield Distribution",
+    )
+
+    record = consent.register_partner("partner.one", consent_hash="consent123")
+    assert record.manifest["consent_hash"] == "consent123"
+    assert record.manifest["architect_wallet"] == "bpow20.cb.id"
+
+    mirrored = consent.mirror_beliefs("partner.one", signal={"score": 0.91})
+    assert mirrored["signal"]["score"] == 0.91
+    assert mirrored["origin_node"] == "Ghostkey-316"
+
+    with pytest.raises(PermissionError):
+        consent.mirror_beliefs("partner.two", signal={})

--- a/tests/test_reputation_tokens_encryption.py
+++ b/tests/test_reputation_tokens_encryption.py
@@ -1,0 +1,20 @@
+import pytest
+
+from vaultfire.protocol.reputation_tokens import ReputationLedger
+from vaultfire.security.fhe import FHECipherSuite
+
+
+def test_reputation_tokens_are_soulbound_and_encrypted():
+    ledger = ReputationLedger(cipher_suite=FHECipherSuite())
+    manifest = {"ethics_framework": "ghostkey", "architect": "bpow20.cb.id"}
+    token = ledger.mint(wallet="aligned.eth", score=0.97, manifest=manifest)
+
+    assert token.proof["context"] == "sbt::aligned.eth"
+    assert token.manifest["ethics_framework"] == "ghostkey"
+    assert ledger.get_token("aligned.eth") is token
+
+    with pytest.raises(ValueError):
+        ledger.mint(wallet="aligned.eth", score=0.5, manifest=manifest)
+
+    with pytest.raises(PermissionError):
+        ledger.transfer("aligned.eth", "other.eth")

--- a/tests/test_zkid_biometric_gates.py
+++ b/tests/test_zkid_biometric_gates.py
@@ -1,0 +1,18 @@
+import pytest
+
+from vaultfire.protocol.identity_gate import BiometricYieldRouter, ZKIdentityVerifier
+
+
+def test_biometric_yield_requires_verified_identity():
+    registry = {
+        "ghostkey316.eth": {"status": "verified", "provider": "worldcoin", "proof_hash": "abc123"},
+    }
+    verifier = ZKIdentityVerifier(registry=registry)
+    router = BiometricYieldRouter(verifier=verifier)
+
+    event = router.yield_drop("ghostkey316.eth", drop_id="yield-001")
+    assert event["architect_wallet"] == "bpow20.cb.id"
+    assert event["origin_node"] == "Ghostkey-316"
+
+    with pytest.raises(PermissionError):
+        router.yield_drop("unknown.eth", drop_id="yield-002")

--- a/vaultfire/protocol/__init__.py
+++ b/vaultfire/protocol/__init__.py
@@ -10,13 +10,23 @@ from .fhe_bridge import (
     seal_belief_yield_event,
     verify_cross_chain_payload,
 )
+from .ghostkey_ai import GhostkeyAINetwork, GhostkeyAINode
+from .identity_gate import BiometricYieldRouter, ZKIdentityVerifier
 from .logs import log_private_behavioral_signal, log_telemetry_event
 from .private_staking import ConfidentialVaultScoring, PrivateStake, PrivateStakingLedger
+from .reputation_tokens import EncryptedTrustToken, ReputationLedger
+from .secure_collaboration import MPCContribution, MPCFabric
 from .telemetry import activate_trace_stream
+from .telemetry import ZKFog
+from .consent_mirror import ConsentMirror, ConsentRecord
 
 __all__ = [
     "activate_trace_stream",
     "get_case_by_id",
+    "GhostkeyAINetwork",
+    "GhostkeyAINode",
+    "BiometricYieldRouter",
+    "ZKIdentityVerifier",
     "PrivateSignal",
     "PrivateStake",
     "PrivateStakingLedger",
@@ -28,4 +38,11 @@ __all__ = [
     "log_telemetry_event",
     "log_private_behavioral_signal",
     "mark_case_as_ready",
+    "EncryptedTrustToken",
+    "ReputationLedger",
+    "MPCContribution",
+    "MPCFabric",
+    "ZKFog",
+    "ConsentMirror",
+    "ConsentRecord",
 ]

--- a/vaultfire/protocol/consent_mirror.py
+++ b/vaultfire/protocol/consent_mirror.py
@@ -1,0 +1,57 @@
+"""Consent mirroring API for partner integrations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping
+
+from vaultfire.protocol.constants import ARCHITECT_WALLET, ORIGIN_NODE_ID
+
+
+@dataclass(slots=True)
+class ConsentRecord:
+    partner_id: str
+    scope: str
+    manifest: Mapping[str, object]
+
+
+class ConsentMirror:
+    """Allows partners to mirror the Vaultfire belief structure under consent."""
+
+    def __init__(self, *, public_manifest: Mapping[str, object], usage_scope: str) -> None:
+        self.public_manifest = dict(public_manifest)
+        self.usage_scope = usage_scope
+        self.architect_wallet = ARCHITECT_WALLET
+        self.origin_node = ORIGIN_NODE_ID
+        self._partners: MutableMapping[str, ConsentRecord] = {}
+
+    def register_partner(self, partner_id: str, *, consent_hash: str) -> ConsentRecord:
+        if not partner_id:
+            raise ValueError("partner_id required")
+        record = ConsentRecord(
+            partner_id=partner_id,
+            scope=self.usage_scope,
+            manifest={
+                **self.public_manifest,
+                "consent_hash": consent_hash,
+                "architect_wallet": self.architect_wallet,
+                "origin_node": self.origin_node,
+            },
+        )
+        self._partners[partner_id] = record
+        return record
+
+    def mirror_beliefs(self, partner_id: str, *, signal: Mapping[str, object]) -> Dict[str, object]:
+        record = self._partners.get(partner_id)
+        if not record:
+            raise PermissionError("partner not registered for consent mirroring")
+        return {
+            "partner_id": partner_id,
+            "scope": record.scope,
+            "signal": dict(signal),
+            "architect_wallet": self.architect_wallet,
+            "origin_node": self.origin_node,
+        }
+
+
+__all__ = ["ConsentMirror", "ConsentRecord"]

--- a/vaultfire/protocol/constants.py
+++ b/vaultfire/protocol/constants.py
@@ -1,0 +1,4 @@
+"""Shared constants for Vaultfire protocol upgrades."""
+
+ARCHITECT_WALLET = "bpow20.cb.id"
+ORIGIN_NODE_ID = "Ghostkey-316"

--- a/vaultfire/protocol/ghostkey_ai.py
+++ b/vaultfire/protocol/ghostkey_ai.py
@@ -1,0 +1,56 @@
+"""Ghostkey AI companion node helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping
+
+from vaultfire.protocol.constants import ARCHITECT_WALLET, ORIGIN_NODE_ID
+
+
+@dataclass(slots=True)
+class GhostkeyAINode:
+    wallet: str
+    function: str
+    status: str
+    telemetry: Mapping[str, object]
+
+
+class GhostkeyAINetwork:
+    """Passive AI ethics agent registry."""
+
+    def __init__(self) -> None:
+        self._nodes: MutableMapping[str, GhostkeyAINode] = {}
+        self.architect_wallet = ARCHITECT_WALLET
+        self.origin_node = ORIGIN_NODE_ID
+
+    def deploy(self, *, wallet: str, function: str, telemetry: Mapping[str, object] | None = None) -> GhostkeyAINode:
+        node = GhostkeyAINode(
+            wallet=wallet,
+            function=function,
+            status="passive",
+            telemetry=dict(telemetry or {}),
+        )
+        self._nodes[wallet] = node
+        return node
+
+    def trigger_ethics_boost(self, wallet: str, *, ethics_score: float) -> Dict[str, object]:
+        node = self._nodes.get(wallet)
+        if not node:
+            raise KeyError("ghostkey ai node not deployed")
+        event = {
+            "wallet": wallet,
+            "ethics_score": ethics_score,
+            "status": "boosted" if ethics_score >= 0.8 else "observing",
+            "architect_wallet": self.architect_wallet,
+            "origin_node": self.origin_node,
+        }
+        node.telemetry = {**dict(node.telemetry), **event}
+        node.status = event["status"]
+        return event
+
+    def get_node(self, wallet: str) -> GhostkeyAINode | None:
+        return self._nodes.get(wallet)
+
+
+__all__ = ["GhostkeyAINode", "GhostkeyAINetwork"]

--- a/vaultfire/protocol/identity_gate.py
+++ b/vaultfire/protocol/identity_gate.py
@@ -1,0 +1,68 @@
+"""Biometric and ZK identity integrations for yield gating.""" 
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, MutableMapping
+
+from vaultfire.protocol.constants import ARCHITECT_WALLET, ORIGIN_NODE_ID
+
+
+@dataclass(slots=True)
+class ZKIdentityRecord:
+    wallet: str
+    verified: bool
+    provider: str
+    proof_hash: str
+
+
+class ZKIdentityVerifier:
+    """Simple registry backed verifier compatible with Worldcoin/ZK-ID."""
+
+    def __init__(self, *, registry: Mapping[str, Mapping[str, str]]) -> None:
+        self._registry = {key.lower(): dict(value) for key, value in registry.items()}
+
+    def verified(self, wallet: str) -> bool:
+        if not wallet:
+            return False
+        record = self._registry.get(wallet.lower())
+        return bool(record and record.get("status") == "verified")
+
+    def get_record(self, wallet: str) -> ZKIdentityRecord | None:
+        record = self._registry.get(wallet.lower())
+        if not record:
+            return None
+        return ZKIdentityRecord(
+            wallet=wallet,
+            verified=record.get("status") == "verified",
+            provider=record.get("provider", "unknown"),
+            proof_hash=record.get("proof_hash", ""),
+        )
+
+
+class BiometricYieldRouter:
+    """Routes yield events only when biometric/zk identity requirements pass."""
+
+    def __init__(self, *, verifier: ZKIdentityVerifier) -> None:
+        self._verifier = verifier
+        self._yield_events: MutableMapping[str, Dict[str, str]] = {}
+        self.architect_wallet = ARCHITECT_WALLET
+        self.origin_node = ORIGIN_NODE_ID
+
+    def yield_drop(self, wallet: str, *, drop_id: str) -> Dict[str, str]:
+        if not self._verifier.verified(wallet):
+            raise PermissionError("identity verification required for biometric gated yield")
+        event = {
+            "wallet": wallet,
+            "drop_id": drop_id,
+            "architect_wallet": self.architect_wallet,
+            "origin_node": self.origin_node,
+        }
+        self._yield_events[wallet] = event
+        return event
+
+    def last_event(self, wallet: str) -> Dict[str, str] | None:
+        return self._yield_events.get(wallet)
+
+
+__all__ = ["ZKIdentityVerifier", "BiometricYieldRouter", "ZKIdentityRecord"]

--- a/vaultfire/protocol/reputation_tokens.py
+++ b/vaultfire/protocol/reputation_tokens.py
@@ -1,0 +1,64 @@
+"""Encrypted reputation token helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, MutableMapping
+
+from vaultfire.protocol.constants import ARCHITECT_WALLET, ORIGIN_NODE_ID
+from vaultfire.security.fhe import Ciphertext, FHECipherSuite
+
+
+@dataclass(slots=True)
+class EncryptedTrustToken:
+    wallet: str
+    ciphertext: Ciphertext
+    proof: Dict[str, object]
+    score: float
+    manifest: Mapping[str, object]
+
+
+class ReputationLedger:
+    """Soulbound encrypted trust token ledger."""
+
+    def __init__(self, *, cipher_suite: FHECipherSuite) -> None:
+        self._cipher_suite = cipher_suite
+        self._tokens: MutableMapping[str, EncryptedTrustToken] = {}
+        self.architect_wallet = ARCHITECT_WALLET
+        self.origin_node = ORIGIN_NODE_ID
+
+    def mint(
+        self,
+        *,
+        wallet: str,
+        score: float,
+        manifest: Mapping[str, object],
+    ) -> EncryptedTrustToken:
+        if wallet in self._tokens:
+            raise ValueError("soulbound token already minted for wallet")
+        ciphertext = self._cipher_suite.encrypt_value(
+            score,
+            metadata={"type": "EncryptedTrustSBT", "wallet": wallet},
+        )
+        proof = self._cipher_suite.generate_zero_knowledge_commitment(
+            ciphertext,
+            context=f"sbt::{wallet}",
+        )
+        token = EncryptedTrustToken(
+            wallet=wallet,
+            ciphertext=ciphertext,
+            proof=proof,
+            score=score,
+            manifest=dict(manifest),
+        )
+        self._tokens[wallet] = token
+        return token
+
+    def get_token(self, wallet: str) -> EncryptedTrustToken | None:
+        return self._tokens.get(wallet)
+
+    def transfer(self, from_wallet: str, to_wallet: str) -> None:
+        raise PermissionError("EncryptedTrustSBT tokens are soulbound and non-transferable")
+
+
+__all__ = ["EncryptedTrustToken", "ReputationLedger"]

--- a/vaultfire/protocol/secure_collaboration.py
+++ b/vaultfire/protocol/secure_collaboration.py
@@ -1,0 +1,87 @@
+"""MPC + FHE orchestration utilities for Vaultfire."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, MutableMapping
+
+from vaultfire.protocol.constants import ARCHITECT_WALLET, ORIGIN_NODE_ID
+from vaultfire.security.fhe import Ciphertext, FHECipherSuite
+
+
+@dataclass(slots=True)
+class MPCContribution:
+    """Container describing an encrypted MPC contribution."""
+
+    wallet: str
+    ciphertext: Ciphertext
+    context: str
+
+
+class MPCFabric:
+    """Prototype multi-party coordination fabric using FHE."""
+
+    def __init__(self, *, cipher_suite: FHECipherSuite) -> None:
+        self._cipher_suite = cipher_suite
+        self._contributions: MutableMapping[str, MPCContribution] = {}
+        self.architect_wallet = ARCHITECT_WALLET
+        self.origin_node = ORIGIN_NODE_ID
+
+    @property
+    def participants(self) -> Iterable[str]:
+        return tuple(self._contributions.keys())
+
+    def submit_encrypted_payload(
+        self,
+        wallet: str,
+        payload: Mapping[str, object],
+        *,
+        signal_context: str,
+    ) -> MPCContribution:
+        """Encrypt a participant payload and register it for MPC aggregation."""
+
+        if not wallet or not wallet.strip():
+            raise ValueError("wallet must be provided")
+        if not signal_context:
+            raise ValueError("signal_context is required")
+
+        ciphertext = self._cipher_suite.encrypt_record(
+            dict(payload),
+            sensitive_fields=tuple(payload.keys()),
+        )
+        contribution = MPCContribution(wallet=wallet, ciphertext=ciphertext, context=signal_context)
+        self._contributions[wallet] = contribution
+        return contribution
+
+    def collaborative_sum(self) -> Dict[str, object]:
+        """Combine contributions into a single ciphertext and generate a proof."""
+
+        if not self._contributions:
+            raise ValueError("no contributions registered")
+        ciphertexts = [item.ciphertext for item in self._contributions.values()]
+        aggregate = self._cipher_suite.homomorphic_add(*ciphertexts)
+        proof = self._cipher_suite.generate_zero_knowledge_commitment(
+            aggregate,
+            context="vaultfire::mpc_collaboration",
+        )
+        return {
+            "ciphertext": aggregate,
+            "proof": proof,
+            "participants": len(ciphertexts),
+            "architect_wallet": self.architect_wallet,
+            "origin_node": self.origin_node,
+        }
+
+    def decrypt_summary(self) -> Dict[str, object]:
+        """Produce a decrypted summary for compliance scoped review."""
+
+        aggregate = self.collaborative_sum()["ciphertext"]
+        value = self._cipher_suite.decrypt_record(aggregate)
+        return {
+            "approximate_value": value["approximate_value"],
+            "moral_tag": value["moral_tag"],
+            "participants": len(self._contributions),
+        }
+
+
+__all__ = ["MPCContribution", "MPCFabric"]

--- a/vaultfire/protocol/telemetry.py
+++ b/vaultfire/protocol/telemetry.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, Mapping
 from uuid import uuid4
+
+from vaultfire.protocol.constants import ARCHITECT_WALLET, ORIGIN_NODE_ID
+from vaultfire.security.fhe import FHECipherSuite
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _TRACE_STREAM_PATH = _REPO_ROOT / "telemetry" / "trace_stream.log"
@@ -37,4 +40,46 @@ def activate_trace_stream(wallet_id: str, *, simulation_mode: bool = False) -> D
     return event
 
 
-__all__ = ["activate_trace_stream"]
+class ZKFog:
+    """AI secure telemetry summarizer that emits ZK friendly proofs."""
+
+    def __init__(
+        self,
+        *,
+        behavior_input: Iterable[Mapping[str, Any]],
+        output_proof: str,
+        cipher_suite: FHECipherSuite | None = None,
+    ) -> None:
+        self._entries = tuple(dict(item) for item in behavior_input)
+        self._output_proof = output_proof
+        self._cipher_suite = cipher_suite or FHECipherSuite()
+        self.architect_wallet = ARCHITECT_WALLET
+        self.origin_node = ORIGIN_NODE_ID
+
+    def synthesize_summary(self) -> Dict[str, Any]:
+        """Create an encrypted telemetry digest and zk commitment."""
+
+        if not self._entries:
+            raise ValueError("behavior_input is required")
+        aggregate = self._cipher_suite.encrypt_record(
+            {
+                "events": len(self._entries),
+                "ethical_flags": [entry.get("ethics") for entry in self._entries],
+                "proof_target": self._output_proof,
+            },
+            sensitive_fields=("ethical_flags",),
+        )
+        proof = self._cipher_suite.generate_zero_knowledge_commitment(
+            aggregate,
+            context=f"telemetry::{self._output_proof}",
+        )
+        return {
+            "ciphertext": aggregate,
+            "proof": proof,
+            "events": len(self._entries),
+            "architect_wallet": self.architect_wallet,
+            "origin_node": self.origin_node,
+        }
+
+
+__all__ = ["activate_trace_stream", "ZKFog"]


### PR DESCRIPTION
## Summary
- add MPC fabric, zk identity gating, zk-fog telemetry, and ethics constants powering the Vaultfire V2 integrations
- introduce encrypted reputation ledger, Ghostkey AI companion nodes, and consent mirror partner API utilities
- cover the new protocol features with targeted pytest suites for MPC, identity gates, AI nodes, reputation tokens, and consent mirroring

## Testing
- `pytest tests/test_fhe_mpc_integrity.py`
- `pytest tests/test_ghostkey_ai_nodes.py`
- `pytest tests/test_zkid_biometric_gates.py`
- `pytest tests/test_reputation_tokens_encryption.py`
- `pytest tests/test_partner_consent_mirroring.py`


------
https://chatgpt.com/codex/tasks/task_e_68e130f35a508322afe54fe52d6e1e4e