### PR TITLE
Add pilot mode access layer for secure partner testing

### DIFF
--- a/telemetry/pilot_mode/.gitignore
+++ b/telemetry/pilot_mode/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_pilot_mode.py
+++ b/tests/test_pilot_mode.py
@@ -1,0 +1,115 @@
+"""Tests for the Vaultfire pilot mode namespace."""
+
+from __future__ import annotations
+
+import hmac
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from vaultfire.pilot_mode import PilotAccessLayer
+from vaultfire.pilot_mode import storage as pilot_storage
+
+
+@pytest.fixture(autouse=True)
+def isolated_pilot_storage(tmp_path, monkeypatch):
+    """Isolate pilot mode storage to a temporary directory for tests."""
+
+    monkeypatch.setattr(pilot_storage, "PILOT_MODE_ROOT", tmp_path)
+    monkeypatch.setattr(pilot_storage, "PARTNER_REGISTRY_PATH", tmp_path / "partners.json")
+    monkeypatch.setattr(pilot_storage, "PROTOCOL_KEYS_PATH", tmp_path / "protocol_keys.json")
+    monkeypatch.setattr(pilot_storage, "SESSION_LOG_PATH", tmp_path / "sessions.jsonl")
+    monkeypatch.setattr(pilot_storage, "YIELD_LOG_PATH", tmp_path / "yield.jsonl")
+    monkeypatch.setattr(pilot_storage, "BEHAVIOR_LOG_PATH", tmp_path / "behavior.jsonl")
+    monkeypatch.setattr(pilot_storage, "FEEDBACK_LOG_PATH", tmp_path / "feedback.jsonl")
+    yield
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_pilot_session_activation_via_api_key(tmp_path):
+    layer = PilotAccessLayer()
+    partner = layer.register_partner(
+        "assemble-ai",
+        api_keys=["asm-secret"],
+        wallet_addresses=["0xabc"],
+        default_watermark=True,
+    )
+    token = layer.issue_protocol_key(partner.partner_id, max_uses=2)
+    session = layer.activate_session(
+        partner.partner_id,
+        protocol_key=token,
+        api_key="asm-secret",
+    )
+    result = session.simulate_yield(wallet_id="0xabc", strategy_id="demo-strategy", sample_size=25)
+    session.log_behavior(wallet_id="0xabc", event_type="test", payload={"result": "ok"})
+    session.submit_feedback(feedback_type="bug", message="Found edge case")
+
+    assert session.pilot_mode is True
+    assert session.get_watermark() == "Pilot Powered by Vaultfire"
+    assert result.partner_tag == partner.anonymized_tag
+    assert result.wallet_fingerprint != "0xabc"
+
+    sessions = _read_jsonl(pilot_storage.SESSION_LOG_PATH)
+    assert len(sessions) == 1
+    yield_logs = _read_jsonl(pilot_storage.YIELD_LOG_PATH)
+    assert yield_logs[0]["partner_tag"] == partner.anonymized_tag
+    assert "wallet_fingerprint" in yield_logs[0] and "0xabc" not in yield_logs[0]["wallet_fingerprint"]
+    behavior_logs = _read_jsonl(pilot_storage.BEHAVIOR_LOG_PATH)
+    assert behavior_logs[0]["partner_tag"] == partner.anonymized_tag
+    assert behavior_logs[0]["wallet_fingerprint"] != "0xabc"
+    feedback_logs = _read_jsonl(pilot_storage.FEEDBACK_LOG_PATH)
+    assert "partner_id" not in feedback_logs[0]
+
+
+def test_wallet_signature_activation_and_feedback_identity(tmp_path):
+    layer = PilotAccessLayer()
+    partner = layer.register_partner(
+        "protocol-x",
+        wallet_addresses=["0x1234"],
+        default_watermark=False,
+        allow_identity_disclosure=True,
+    )
+    secret = layer.registry.get_record(partner.partner_id).signature_secret
+    signature_message = "vaultfire-pilot-access"
+    signature = hmac.new(
+        key=secret.encode("utf-8"),
+        msg=f"{partner.wallet_addresses[0]}:{signature_message}".encode("utf-8"),
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+    token = layer.issue_protocol_key(partner.partner_id, expires_in_days=90, max_uses=1, watermark_enabled=False)
+    session = layer.activate_session(
+        partner.partner_id,
+        protocol_key=token,
+        wallet_address="0x1234",
+        wallet_signature=signature,
+        signature_message=signature_message,
+    )
+    assert session.pilot_mode is True
+    assert session.get_watermark() is None
+
+    session.submit_feedback(
+        feedback_type="feature",
+        message="Request new metric",
+        severity="high",
+        metadata={"priority": "p0"},
+        expose_identity=True,
+    )
+    feedback_logs = _read_jsonl(pilot_storage.FEEDBACK_LOG_PATH)
+    assert feedback_logs[-1]["expose_identity"] is True
+    assert feedback_logs[-1]["partner_id"] == partner.partner_id
+
+    with pytest.raises(PermissionError):
+        layer.activate_session(
+            partner.partner_id,
+            protocol_key=token,
+            wallet_address="0x1234",
+            wallet_signature=signature,
+            signature_message=signature_message,
+        )

--- a/vaultfire/__init__.py
+++ b/vaultfire/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "enterprise",
     "rewards",
     "refund",
+    "pilot_mode",
     "auto_refund",
     "should_refund",
     "freeze_refunds",
@@ -31,6 +32,7 @@ _LAZY_MODULES: Dict[str, str] = {
     "enterprise": ".enterprise",
     "rewards": ".rewards",
     "refund": ".refund",
+    "pilot_mode": ".pilot_mode",
 }
 
 _REFUND_EXPORTS: Iterable[str] = (

--- a/vaultfire/pilot_mode/__init__.py
+++ b/vaultfire/pilot_mode/__init__.py
@@ -1,0 +1,22 @@
+"""Pilot mode namespace for secure partner testing."""
+
+from .access_layer import PilotAccessLayer
+from .feedback import FeedbackCollector, FeedbackRecord
+from .keys import ProtocolKey, ProtocolKeyManager
+from .registry import PilotAccessRegistry, PartnerRecord
+from .sandbox import SandboxResult, YieldSandbox
+from .session import PilotSession, SessionFactory
+
+__all__ = [
+    "PilotAccessLayer",
+    "FeedbackCollector",
+    "FeedbackRecord",
+    "ProtocolKey",
+    "ProtocolKeyManager",
+    "PilotAccessRegistry",
+    "PartnerRecord",
+    "SandboxResult",
+    "YieldSandbox",
+    "PilotSession",
+    "SessionFactory",
+]

--- a/vaultfire/pilot_mode/access_layer.py
+++ b/vaultfire/pilot_mode/access_layer.py
@@ -1,0 +1,115 @@
+"""Pilot access layer orchestrating registry, keys, and sessions."""
+
+from __future__ import annotations
+
+from typing import Iterable, MutableMapping, Optional
+
+from .feedback import FeedbackCollector
+from .keys import ProtocolKeyManager
+from .registry import PilotAccessRegistry, PartnerRecord
+from .sandbox import YieldSandbox
+from .session import PilotSession, SessionFactory
+
+__all__ = ["PilotAccessLayer"]
+
+
+class PilotAccessLayer:
+    """High-level API for secure pilot mode activation."""
+
+    def __init__(
+        self,
+        *,
+        registry: Optional[PilotAccessRegistry] = None,
+        key_manager: Optional[ProtocolKeyManager] = None,
+        sandbox: Optional[YieldSandbox] = None,
+        feedback: Optional[FeedbackCollector] = None,
+    ) -> None:
+        self._registry = registry or PilotAccessRegistry()
+        self._keys = key_manager or ProtocolKeyManager()
+        self._session_factory = SessionFactory(sandbox=sandbox, feedback=feedback)
+
+    @property
+    def registry(self) -> PilotAccessRegistry:
+        return self._registry
+
+    @property
+    def key_manager(self) -> ProtocolKeyManager:
+        return self._keys
+
+    def register_partner(
+        self,
+        partner_id: str,
+        *,
+        api_keys: Optional[Iterable[str]] = None,
+        wallet_addresses: Optional[Iterable[str]] = None,
+        default_watermark: bool = False,
+        allow_identity_disclosure: bool = False,
+        metadata: Optional[MutableMapping[str, object]] = None,
+    ) -> PartnerRecord:
+        return self._registry.register_partner(
+            partner_id,
+            api_keys=api_keys,
+            wallet_addresses=wallet_addresses,
+            default_watermark=default_watermark,
+            allow_identity_disclosure=allow_identity_disclosure,
+            metadata=metadata,
+        )
+
+    def issue_protocol_key(
+        self,
+        partner_id: str,
+        *,
+        expires_in_days: int = 30,
+        max_uses: Optional[int] = 1,
+        watermark_enabled: Optional[bool] = None,
+        metadata: Optional[MutableMapping[str, object]] = None,
+    ) -> str:
+        partner = self._registry.get_record(partner_id)
+        watermark = watermark_enabled if watermark_enabled is not None else partner.default_watermark
+        return self._keys.issue_key(
+            partner_id=partner.partner_id,
+            partner_tag=partner.anonymized_tag,
+            expires_in_days=expires_in_days,
+            max_uses=max_uses,
+            watermark_enabled=watermark,
+            metadata=metadata,
+        )
+
+    def activate_session(
+        self,
+        partner_id: str,
+        *,
+        protocol_key: str,
+        api_key: Optional[str] = None,
+        wallet_address: Optional[str] = None,
+        wallet_signature: Optional[str] = None,
+        signature_message: str = "vaultfire-pilot-access",
+        watermark_override: Optional[bool] = None,
+    ) -> PilotSession:
+        if not protocol_key or not protocol_key.strip():
+            raise ValueError("protocol_key must be provided")
+        partner: Optional[PartnerRecord] = None
+        key_record = self._keys.consume(protocol_key, partner_id=partner_id)
+        if api_key:
+            partner = self._registry.validate_api_key(partner_id, api_key)
+        elif wallet_address and wallet_signature:
+            partner = self._registry.validate_wallet_signature(
+                partner_id,
+                wallet_address=wallet_address,
+                signature=wallet_signature,
+                message=signature_message,
+            )
+        else:
+            raise PermissionError("pilot access requires api key or wallet signature")
+        session = self._session_factory.create(
+            partner=partner,
+            protocol_key=key_record,
+            watermark_override=watermark_override,
+        )
+        return session
+
+    def refresh_signature_secret(self, partner_id: str) -> str:
+        return self._registry.issue_signature_secret(partner_id)
+
+    def prune_expired_keys(self) -> None:
+        self._keys.prune_expired()

--- a/vaultfire/pilot_mode/feedback.py
+++ b/vaultfire/pilot_mode/feedback.py
@@ -1,0 +1,93 @@
+"""Feedback collection for pilot users."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Mapping, MutableMapping, Optional
+
+from . import storage
+
+__all__ = ["FeedbackRecord", "FeedbackCollector"]
+
+
+@dataclass
+class FeedbackRecord:
+    """Structured pilot feedback payload."""
+
+    partner_tag: str
+    session_id: str
+    feedback_type: str
+    message: str
+    severity: str
+    created_at: datetime
+    metadata: MutableMapping[str, object]
+    expose_identity: bool
+    partner_id: Optional[str] = None
+
+    def export(self) -> Dict[str, object]:
+        payload = {
+            "partner_tag": self.partner_tag,
+            "session_id": self.session_id,
+            "feedback_type": self.feedback_type,
+            "message": self.message,
+            "severity": self.severity,
+            "created_at": self.created_at.isoformat(),
+            "metadata": dict(self.metadata),
+            "expose_identity": self.expose_identity,
+        }
+        if self.partner_id and self.expose_identity:
+            payload["partner_id"] = self.partner_id
+        return payload
+
+
+class FeedbackCollector:
+    """Capture and persist structured pilot feedback."""
+
+    def __init__(self, *, log_path=None) -> None:
+        self._log_path = log_path or storage.FEEDBACK_LOG_PATH
+
+    def submit_feedback(
+        self,
+        *,
+        partner_tag: str,
+        session_id: str,
+        feedback_type: str,
+        message: str,
+        severity: str = "info",
+        metadata: Optional[Mapping[str, object]] = None,
+        expose_identity: bool = False,
+        partner_id: Optional[str] = None,
+    ) -> FeedbackRecord:
+        if not feedback_type or not feedback_type.strip():
+            raise ValueError("feedback_type must be provided")
+        if not message or not message.strip():
+            raise ValueError("message must be provided")
+        record = FeedbackRecord(
+            partner_tag=partner_tag,
+            session_id=session_id,
+            feedback_type=feedback_type.strip(),
+            message=message.strip(),
+            severity=severity,
+            created_at=datetime.now(timezone.utc),
+            metadata=dict(metadata or {}),
+            expose_identity=expose_identity,
+            partner_id=partner_id,
+        )
+        storage.append_jsonl(self._log_path, record.export())
+        return record
+
+    def format_cli_payload(
+        self,
+        *,
+        feedback_type: str,
+        message: str,
+        severity: str = "info",
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> Dict[str, object]:
+        return {
+            "feedback_type": feedback_type,
+            "message": message,
+            "severity": severity,
+            "metadata": dict(metadata or {}),
+        }

--- a/vaultfire/pilot_mode/keys.py
+++ b/vaultfire/pilot_mode/keys.py
@@ -1,0 +1,169 @@
+"""Protocol key management for pilot mode sessions."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List, MutableMapping, Optional
+
+from . import storage
+
+__all__ = ["ProtocolKey", "ProtocolKeyManager"]
+
+
+@dataclass
+class ProtocolKey:
+    """Represents a limited-access protocol key."""
+
+    token_hash: str
+    partner_id: str
+    partner_tag: str
+    expires_at: datetime
+    max_uses: Optional[int]
+    usage_count: int = 0
+    watermark_enabled: bool = False
+    metadata: MutableMapping[str, object] = field(default_factory=dict)
+
+    def is_expired(self, *, reference_time: Optional[datetime] = None) -> bool:
+        reference_time = reference_time or datetime.now(timezone.utc)
+        return reference_time >= self.expires_at
+
+    def has_remaining_uses(self) -> bool:
+        if self.max_uses is None:
+            return True
+        return self.usage_count < self.max_uses
+
+    def record_use(self) -> None:
+        self.usage_count += 1
+
+
+class ProtocolKeyManager:
+    """Persistent manager for issuing and validating protocol keys."""
+
+    def __init__(self, *, path=None) -> None:
+        self._path = path or storage.PROTOCOL_KEYS_PATH
+        self._records: List[Dict[str, object]] = storage.read_json(self._path, [])
+
+    @staticmethod
+    def _hash_token(token: str) -> str:
+        if not token or not token.strip():
+            raise ValueError("token must be provided")
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _serialize(key: ProtocolKey) -> Dict[str, object]:
+        payload = {
+            "token_hash": key.token_hash,
+            "partner_id": key.partner_id,
+            "partner_tag": key.partner_tag,
+            "expires_at": key.expires_at.isoformat(),
+            "usage_count": key.usage_count,
+            "watermark_enabled": key.watermark_enabled,
+        }
+        if key.max_uses is not None:
+            payload["max_uses"] = key.max_uses
+        if key.metadata:
+            payload["metadata"] = dict(key.metadata)
+        return payload
+
+    @staticmethod
+    def _deserialize(payload: Dict[str, object]) -> ProtocolKey:
+        expires_at = datetime.fromisoformat(str(payload["expires_at"])).astimezone(timezone.utc)
+        return ProtocolKey(
+            token_hash=str(payload["token_hash"]),
+            partner_id=str(payload["partner_id"]),
+            partner_tag=str(payload["partner_tag"]),
+            expires_at=expires_at,
+            max_uses=payload.get("max_uses"),
+            usage_count=int(payload.get("usage_count", 0)),
+            watermark_enabled=bool(payload.get("watermark_enabled", False)),
+            metadata=dict(payload.get("metadata", {})),
+        )
+
+    def _flush(self) -> None:
+        storage.write_json(self._path, self._records)
+
+    def _iter_keys(self) -> Iterable[ProtocolKey]:
+        for record in list(self._records):
+            try:
+                yield self._deserialize(record)
+            except (KeyError, ValueError):
+                continue
+
+    def _replace_record(self, key: ProtocolKey) -> None:
+        for index, record in enumerate(self._records):
+            if record.get("token_hash") == key.token_hash:
+                self._records[index] = self._serialize(key)
+                break
+        else:
+            self._records.append(self._serialize(key))
+        self._flush()
+
+    def issue_key(
+        self,
+        *,
+        partner_id: str,
+        partner_tag: str,
+        expires_in_days: int = 30,
+        max_uses: Optional[int] = 1,
+        watermark_enabled: bool = False,
+        metadata: Optional[MutableMapping[str, object]] = None,
+    ) -> str:
+        if expires_in_days <= 0:
+            raise ValueError("expires_in_days must be positive")
+        token = secrets.token_urlsafe(32)
+        token_hash = self._hash_token(token)
+        expiry = datetime.now(timezone.utc) + timedelta(days=expires_in_days)
+        record = ProtocolKey(
+            token_hash=token_hash,
+            partner_id=partner_id,
+            partner_tag=partner_tag,
+            expires_at=expiry,
+            max_uses=max_uses,
+            usage_count=0,
+            watermark_enabled=watermark_enabled,
+            metadata=dict(metadata or {}),
+        )
+        self._records.append(self._serialize(record))
+        self._flush()
+        return token
+
+    def prune_expired(self) -> None:
+        now = datetime.now(timezone.utc)
+        filtered: List[Dict[str, object]] = []
+        for record in self._records:
+            try:
+                expires_at = datetime.fromisoformat(str(record["expires_at"])).astimezone(timezone.utc)
+            except (KeyError, ValueError):
+                continue
+            if now < expires_at:
+                filtered.append(record)
+        if len(filtered) != len(self._records):
+            self._records = filtered
+            self._flush()
+
+    def consume(self, token: str, *, partner_id: str) -> ProtocolKey:
+        token_hash = self._hash_token(token)
+        refreshed: List[Dict[str, object]] = []
+        selected: Optional[ProtocolKey] = None
+        for record in self._records:
+            if record.get("token_hash") != token_hash:
+                refreshed.append(record)
+                continue
+            key = self._deserialize(record)
+            if key.partner_id != partner_id:
+                raise PermissionError("protocol key does not belong to partner")
+            if key.is_expired():
+                raise PermissionError("protocol key has expired")
+            if not key.has_remaining_uses():
+                raise PermissionError("protocol key has no remaining uses")
+            key.record_use()
+            selected = key
+            refreshed.append(self._serialize(key))
+        if selected is None:
+            raise PermissionError("protocol key is invalid")
+        self._records = refreshed
+        self._flush()
+        return selected

--- a/vaultfire/pilot_mode/registry.py
+++ b/vaultfire/pilot_mode/registry.py
@@ -1,0 +1,197 @@
+"""Partner registry for the Vaultfire pilot access layer."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, MutableMapping, Optional
+
+from . import storage
+
+__all__ = ["PartnerRecord", "PilotAccessRegistry"]
+
+
+def _hash_value(value: str) -> str:
+    if not value or not value.strip():
+        raise ValueError("value must be provided")
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _normalize_wallet(wallet: str) -> str:
+    if not wallet or not wallet.strip():
+        raise ValueError("wallet must be provided")
+    return wallet.strip().lower()
+
+
+def _generate_anonymized_tag(index: int) -> str:
+    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    prefix = index % len(alphabet)
+    suffix = index // len(alphabet)
+    if suffix:
+        return f"Partner-{alphabet[prefix]}{suffix}"
+    return f"Partner-{alphabet[prefix]}"
+
+
+@dataclass
+class PartnerRecord:
+    """Partner registration details."""
+
+    partner_id: str
+    anonymized_tag: str
+    hashed_api_keys: List[str] = field(default_factory=list)
+    wallet_addresses: List[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    default_watermark: bool = False
+    signature_secret: str = field(default_factory=lambda: secrets.token_hex(16))
+    allow_identity_disclosure: bool = False
+    metadata: MutableMapping[str, object] = field(default_factory=dict)
+
+    def to_payload(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "partner_id": self.partner_id,
+            "anonymized_tag": self.anonymized_tag,
+            "hashed_api_keys": list(self.hashed_api_keys),
+            "wallet_addresses": list(self.wallet_addresses),
+            "created_at": self.created_at.isoformat(),
+            "default_watermark": self.default_watermark,
+            "signature_secret": self.signature_secret,
+            "allow_identity_disclosure": self.allow_identity_disclosure,
+        }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, object]) -> "PartnerRecord":
+        created_at = datetime.fromisoformat(str(payload["created_at"])).astimezone(timezone.utc)
+        return cls(
+            partner_id=str(payload["partner_id"]),
+            anonymized_tag=str(payload["anonymized_tag"]),
+            hashed_api_keys=list(payload.get("hashed_api_keys", [])),
+            wallet_addresses=list(payload.get("wallet_addresses", [])),
+            created_at=created_at,
+            default_watermark=bool(payload.get("default_watermark", False)),
+            signature_secret=str(payload.get("signature_secret", secrets.token_hex(16))),
+            allow_identity_disclosure=bool(payload.get("allow_identity_disclosure", False)),
+            metadata=dict(payload.get("metadata", {})),
+        )
+
+
+class PilotAccessRegistry:
+    """Registry that manages verified partner credentials."""
+
+    def __init__(self, *, path=None) -> None:
+        self._path = path or storage.PARTNER_REGISTRY_PATH
+        raw_records = storage.read_json(self._path, [])
+        self._records: Dict[str, PartnerRecord] = {}
+        for raw in raw_records:
+            try:
+                record = PartnerRecord.from_payload(raw)
+            except (KeyError, ValueError):
+                continue
+            self._records[record.partner_id] = record
+
+    def _next_anonymized_tag(self) -> str:
+        existing = sorted(record.anonymized_tag for record in self._records.values())
+        index = 0
+        while True:
+            tag = _generate_anonymized_tag(index)
+            if tag not in existing:
+                return tag
+            index += 1
+
+    def _persist(self) -> None:
+        payload = [record.to_payload() for record in self._records.values()]
+        storage.write_json(self._path, payload)
+
+    def register_partner(
+        self,
+        partner_id: str,
+        *,
+        api_keys: Optional[Iterable[str]] = None,
+        wallet_addresses: Optional[Iterable[str]] = None,
+        default_watermark: bool = False,
+        allow_identity_disclosure: bool = False,
+        metadata: Optional[MutableMapping[str, object]] = None,
+    ) -> PartnerRecord:
+        if not partner_id or not partner_id.strip():
+            raise ValueError("partner_id must be provided")
+        partner_id = partner_id.strip()
+        record = self._records.get(partner_id)
+        if record is None:
+            record = PartnerRecord(
+                partner_id=partner_id,
+                anonymized_tag=self._next_anonymized_tag(),
+                default_watermark=default_watermark,
+                allow_identity_disclosure=allow_identity_disclosure,
+                metadata=dict(metadata or {}),
+            )
+        if api_keys:
+            record.hashed_api_keys = sorted({_hash_value(key) for key in api_keys})
+        if wallet_addresses:
+            record.wallet_addresses = sorted({_normalize_wallet(wallet) for wallet in wallet_addresses})
+        if metadata:
+            record.metadata.update(metadata)
+        record.default_watermark = default_watermark
+        record.allow_identity_disclosure = allow_identity_disclosure
+        self._records[partner_id] = record
+        self._persist()
+        return record
+
+    def get_record(self, partner_id: str) -> PartnerRecord:
+        if partner_id not in self._records:
+            raise PermissionError("partner is not registered")
+        return self._records[partner_id]
+
+    def validate_api_key(self, partner_id: str, api_key: str) -> PartnerRecord:
+        record = self.get_record(partner_id)
+        hashed = _hash_value(api_key)
+        if hashed not in record.hashed_api_keys:
+            raise PermissionError("invalid api key")
+        return record
+
+    def validate_wallet_signature(
+        self,
+        partner_id: str,
+        *,
+        wallet_address: str,
+        signature: str,
+        message: str = "vaultfire-pilot-access",
+    ) -> PartnerRecord:
+        record = self.get_record(partner_id)
+        normalized_wallet = _normalize_wallet(wallet_address)
+        if normalized_wallet not in record.wallet_addresses:
+            raise PermissionError("wallet is not authorized for pilot access")
+        expected = hmac.new(
+            key=record.signature_secret.encode("utf-8"),
+            msg=f"{normalized_wallet}:{message}".encode("utf-8"),
+            digestmod=hashlib.sha256,
+        ).hexdigest()
+        if not secrets.compare_digest(expected, signature):
+            raise PermissionError("wallet signature is invalid")
+        return record
+
+    def get_anonymized_tag(self, partner_id: str) -> str:
+        return self.get_record(partner_id).anonymized_tag
+
+    def list_records(self) -> List[PartnerRecord]:
+        return list(self._records.values())
+
+    def revoke_api_keys(self, partner_id: str) -> None:
+        record = self.get_record(partner_id)
+        record.hashed_api_keys = []
+        self._persist()
+
+    def revoke_wallets(self, partner_id: str) -> None:
+        record = self.get_record(partner_id)
+        record.wallet_addresses = []
+        self._persist()
+
+    def issue_signature_secret(self, partner_id: str) -> str:
+        record = self.get_record(partner_id)
+        record.signature_secret = secrets.token_hex(16)
+        self._persist()
+        return record.signature_secret

--- a/vaultfire/pilot_mode/sandbox.py
+++ b/vaultfire/pilot_mode/sandbox.py
@@ -1,0 +1,139 @@
+"""Pilot mode sandbox utilities for isolated simulations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+from . import storage
+
+__all__ = ["SandboxResult", "YieldSandbox"]
+
+
+@dataclass
+class SandboxResult:
+    """Result of an isolated yield simulation."""
+
+    session_id: str
+    partner_tag: str
+    wallet_fingerprint: str
+    strategy_id: str
+    sample_size: int
+    projected_apr: float
+    confidence_interval: float
+    engagement_score: float
+    generated_at: datetime
+    metadata: MutableMapping[str, object]
+
+    def export(self) -> Dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "partner_tag": self.partner_tag,
+            "wallet_fingerprint": self.wallet_fingerprint,
+            "strategy_id": self.strategy_id,
+            "sample_size": self.sample_size,
+            "projected_apr": round(self.projected_apr, 5),
+            "confidence_interval": round(self.confidence_interval, 5),
+            "engagement_score": round(self.engagement_score, 5),
+            "generated_at": self.generated_at.isoformat(),
+            "metadata": dict(self.metadata),
+        }
+
+
+class YieldSandbox:
+    """Creates isolated simulations and logs pilot activity."""
+
+    def __init__(
+        self,
+        *,
+        yield_log_path=None,
+        behavior_log_path=None,
+        secret_salt: str | None = None,
+    ) -> None:
+        self._yield_log_path = yield_log_path or storage.YIELD_LOG_PATH
+        self._behavior_log_path = behavior_log_path or storage.BEHAVIOR_LOG_PATH
+        self._secret_salt = secret_salt or uuid.uuid4().hex
+
+    def _fingerprint_wallet(self, wallet_id: str) -> str:
+        if not wallet_id or not wallet_id.strip():
+            raise ValueError("wallet_id must be provided")
+        digest = hashlib.sha256(f"{wallet_id.lower()}::{self._secret_salt}".encode("utf-8")).hexdigest()
+        return digest[:16]
+
+    def _record(self, path, payload: Mapping[str, object]) -> None:
+        storage.append_jsonl(path, payload)
+
+    def simulate_yield(
+        self,
+        *,
+        partner_tag: str,
+        session_id: str,
+        wallet_id: str,
+        strategy_id: str,
+        sample_size: int = 100,
+        telemetry_flags: Optional[Mapping[str, object]] = None,
+    ) -> SandboxResult:
+        if sample_size <= 0:
+            raise ValueError("sample_size must be positive")
+        wallet_fingerprint = self._fingerprint_wallet(wallet_id)
+        seed_material = f"{partner_tag}:{session_id}:{strategy_id}:{wallet_fingerprint}:{sample_size}"
+        digest = hashlib.sha256(seed_material.encode("utf-8")).digest()
+        apr = (int.from_bytes(digest[:2], "big") % 5000) / 100  # up to 50% APR in sandbox
+        deviation = (int.from_bytes(digest[2:4], "big") % 250) / 100  # +/- 2.5 spread
+        engagement_baseline = statistics.fmean([(value % 100) / 100 for value in digest[:8]])
+        engagement_score = min(1.0, max(0.0, engagement_baseline))
+        result = SandboxResult(
+            session_id=session_id,
+            partner_tag=partner_tag,
+            wallet_fingerprint=wallet_fingerprint,
+            strategy_id=strategy_id,
+            sample_size=sample_size,
+            projected_apr=apr,
+            confidence_interval=deviation,
+            engagement_score=engagement_score,
+            generated_at=datetime.now(timezone.utc),
+            metadata=dict(telemetry_flags or {}),
+        )
+        self._record(self._yield_log_path, result.export())
+        return result
+
+    def log_behavior(
+        self,
+        *,
+        partner_tag: str,
+        session_id: str,
+        wallet_id: str,
+        event_type: str,
+        payload: Mapping[str, object],
+    ) -> None:
+        if not event_type or not event_type.strip():
+            raise ValueError("event_type must be provided")
+        record = {
+            "event_type": event_type.strip(),
+            "partner_tag": partner_tag,
+            "session_id": session_id,
+            "wallet_fingerprint": self._fingerprint_wallet(wallet_id),
+            "payload": dict(payload),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        self._record(self._behavior_log_path, record)
+
+    def summarize_behavior(self, *, limit: int = 10) -> Iterable[Dict[str, object]]:
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        path = self._behavior_log_path
+        if not path.exists():
+            return []
+        lines = path.read_text(encoding="utf-8").splitlines()[-limit:]
+        summary: List[Dict[str, object]] = []
+        for line in lines:
+            try:
+                summary.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return summary

--- a/vaultfire/pilot_mode/session.py
+++ b/vaultfire/pilot_mode/session.py
@@ -1,0 +1,150 @@
+"""Pilot session management for Vaultfire."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Mapping, Optional
+
+from .feedback import FeedbackCollector
+from .keys import ProtocolKey
+from .registry import PartnerRecord
+from .sandbox import YieldSandbox
+from . import storage
+
+__all__ = ["PilotSession", "SessionFactory"]
+
+
+@dataclass
+class PilotSession:
+    """Represents an active pilot mode session."""
+
+    session_id: str
+    partner_id: str
+    partner_tag: str
+    pilot_mode: bool
+    watermark_enabled: bool
+    sandbox: YieldSandbox
+    feedback: FeedbackCollector
+    protocol_key: ProtocolKey
+
+    def get_watermark(self) -> Optional[str]:
+        if not self.watermark_enabled:
+            return None
+        return "Pilot Powered by Vaultfire"
+
+    def simulate_yield(
+        self,
+        *,
+        wallet_id: str,
+        strategy_id: str,
+        sample_size: int = 100,
+        telemetry_flags: Optional[Mapping[str, object]] = None,
+    ):
+        return self.sandbox.simulate_yield(
+            partner_tag=self.partner_tag,
+            session_id=self.session_id,
+            wallet_id=wallet_id,
+            strategy_id=strategy_id,
+            sample_size=sample_size,
+            telemetry_flags=telemetry_flags,
+        )
+
+    def log_behavior(
+        self,
+        *,
+        wallet_id: str,
+        event_type: str,
+        payload: Mapping[str, object],
+    ) -> None:
+        self.sandbox.log_behavior(
+            partner_tag=self.partner_tag,
+            session_id=self.session_id,
+            wallet_id=wallet_id,
+            event_type=event_type,
+            payload=payload,
+        )
+
+    def submit_feedback(
+        self,
+        *,
+        feedback_type: str,
+        message: str,
+        severity: str = "info",
+        metadata: Optional[Mapping[str, object]] = None,
+        expose_identity: bool | None = None,
+    ) -> None:
+        self.feedback.submit_feedback(
+            partner_tag=self.partner_tag,
+            session_id=self.session_id,
+            feedback_type=feedback_type,
+            message=message,
+            severity=severity,
+            metadata=metadata,
+            expose_identity=bool(expose_identity) if expose_identity is not None else False,
+            partner_id=self.partner_id,
+        )
+
+    def export_context(self) -> Dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "partner_tag": self.partner_tag,
+            "pilot_mode": self.pilot_mode,
+            "watermark_enabled": self.watermark_enabled,
+            "protocol_key_metadata": dict(self.protocol_key.metadata),
+        }
+
+
+class SessionFactory:
+    """Factory for initializing pilot sessions with logging."""
+
+    def __init__(
+        self,
+        *,
+        sandbox: Optional[YieldSandbox] = None,
+        feedback: Optional[FeedbackCollector] = None,
+        session_log_path=None,
+    ) -> None:
+        self._sandbox = sandbox or YieldSandbox()
+        self._feedback = feedback or FeedbackCollector()
+        self._session_log_path = session_log_path or storage.SESSION_LOG_PATH
+
+    def _log_session(self, record: Dict[str, object]) -> None:
+        storage.append_jsonl(self._session_log_path, record)
+
+    def create(
+        self,
+        *,
+        partner: PartnerRecord,
+        protocol_key: ProtocolKey,
+        watermark_override: Optional[bool] = None,
+    ) -> PilotSession:
+        session_id = uuid.uuid4().hex
+        watermark_enabled = (
+            watermark_override if watermark_override is not None else protocol_key.watermark_enabled
+        )
+        session = PilotSession(
+            session_id=session_id,
+            partner_id=partner.partner_id,
+            partner_tag=partner.anonymized_tag,
+            pilot_mode=True,
+            watermark_enabled=watermark_enabled,
+            sandbox=self._sandbox,
+            feedback=self._feedback,
+            protocol_key=protocol_key,
+        )
+        log_record: Dict[str, object] = {
+            "session_id": session_id,
+            "partner_tag": partner.anonymized_tag,
+            "pilot_mode": True,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "watermark_enabled": watermark_enabled,
+            "protocol_key": {
+                "expires_at": protocol_key.expires_at.isoformat(),
+                "usage_count": protocol_key.usage_count,
+                "max_uses": protocol_key.max_uses,
+            },
+        }
+        self._log_session(log_record)
+        return session

--- a/vaultfire/pilot_mode/storage.py
+++ b/vaultfire/pilot_mode/storage.py
@@ -1,0 +1,66 @@
+"""Storage helpers for the Vaultfire pilot mode namespace."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+__all__ = [
+    "PILOT_MODE_ROOT",
+    "PARTNER_REGISTRY_PATH",
+    "PROTOCOL_KEYS_PATH",
+    "SESSION_LOG_PATH",
+    "YIELD_LOG_PATH",
+    "BEHAVIOR_LOG_PATH",
+    "FEEDBACK_LOG_PATH",
+    "read_json",
+    "write_json",
+    "append_jsonl",
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+PILOT_MODE_ROOT = _REPO_ROOT / "telemetry" / "pilot_mode"
+PARTNER_REGISTRY_PATH = PILOT_MODE_ROOT / "partners.json"
+PROTOCOL_KEYS_PATH = PILOT_MODE_ROOT / "protocol_keys.json"
+SESSION_LOG_PATH = PILOT_MODE_ROOT / "sessions.jsonl"
+YIELD_LOG_PATH = PILOT_MODE_ROOT / "yield_log.jsonl"
+BEHAVIOR_LOG_PATH = PILOT_MODE_ROOT / "behavior_log.jsonl"
+FEEDBACK_LOG_PATH = PILOT_MODE_ROOT / "feedback.jsonl"
+
+_LOCK = Lock()
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def read_json(path: Path, default: Any) -> Any:
+    """Read JSON data from ``path`` returning ``default`` on failure."""
+
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return default
+
+
+def write_json(path: Path, payload: Any) -> None:
+    """Atomically write ``payload`` as JSON to ``path``."""
+
+    _ensure_parent(path)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with _LOCK:
+        tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        tmp_path.replace(path)
+
+
+def append_jsonl(path: Path, payload: Any) -> None:
+    """Append ``payload`` as a JSON line to ``path``."""
+
+    _ensure_parent(path)
+    with _LOCK:
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")


### PR DESCRIPTION
## Summary
- add a new `vaultfire.pilot_mode` namespace providing partner registry, protocol keys, feedback collection, sandboxed yield simulations, and session orchestration for stealth pilot runs
- wire the package entry point to expose the pilot mode module and ensure telemetry artifacts are segregated under `telemetry/pilot_mode`
- cover pilot activation flows and anonymized logging with dedicated pytest coverage

## Testing
- `pytest tests/test_pilot_mode.py`


------
https://chatgpt.com/codex/tasks/task_e_68e13709c4cc8322bbece8f3e0ae63ca