### PR TITLE
Clarify Ghostkey-316 as the sole live case study

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 ## Project Overview
 Vaultfire is a production-ready, morals-first protocol that fuses belief-driven intelligence with verifiable human identity. It orchestrates Codex reasoning engines, NFT-based identity anchors, and partner-focused loyalty modules to deliver a resilient activation stack for ethical AI collaboration.
 
+> **Case Study Reality Check:** All current case study data is modeled from the real behavior loop of Ghostkey-316, the protocol's origin validator and loyalty stress tester. No commercial trials have yet been run beyond this wallet-based pilot layer. Every additional "deployment" or "case study" referenced in this repository is a sandboxed simulation derived from Ghostkey-316 telemetry until further notice.
+
 ## Simulated Use Case Pilots (v1)
 - **Important:** Every asset linked in this section is a simulation artifact only. Partners must not treat the narratives or metrics as evidence of live deployments.
 - [Simulated Community XP Pilot](./sim-pilots/community-xp-pilot.md) — belief-aligned engagement loop showcasing mission dispatch, belief logging, and simulated XP uplift (Simulated Pilot Verified ✅).
@@ -70,6 +72,7 @@ guidance and Jest falls back to an identity profiler so mobile pipelines keep pa
 - Track change governance through the [Change Management Playbook](./docs/change-management.md) and automated checks in [`scripts/security-audit.sh`](./scripts/security-audit.sh).
 - Bundle audit receipts via `scripts/collect-live-evidence.py` so partners receive a signed digest (recorded in `immutable_log.jsonl`) for their compliance teams.
 - Vaultfire maintains transparent partner communications, surfacing scan results, scheduled audits, and rollout notices before each production pilot.
+- When referencing the [Reference Deployments](./status/reference-deployments.md) rollup or any partner-facing summaries, remember that only the Ghostkey-316 wallet pilot has been executed live; all other deployments remain simulations based on that source telemetry.
 
 ## Module Scope Modes
 

--- a/docs/hypothetical_realized_outcomes.md
+++ b/docs/hypothetical_realized_outcomes.md
@@ -1,7 +1,7 @@
 # Vaultfire Realized Simulation Scenario
 
 ## Context
-Vaultfire's published materials emphasise that current pilot artefacts are simulated and serve to demonstrate readiness without representing live production usage. This scenario imagines that every referenced simulation performed exactly as documented but in production conditions with real partners, wallets, and telemetry streams.
+Vaultfire's published materials emphasise that current pilot artefacts are simulated and serve to demonstrate readiness without representing live production usage. Ghostkey-316 (wallet: `bpow20.cb.id`) remains the sole live deployment; every other case study or deployment reference derives from that telemetry. This scenario imagines that every referenced simulation performed exactly as documented but in production conditions with real partners, wallets, and telemetry streams.
 
 ## Adoption Trajectory
 - **Immediate credibility leap:** Validated partner pilots across community XP, cross-platform education, and global retail loyalty verticals would provide instant proof that Vaultfire's belief-first architecture scales across diverse sectors while respecting ethics, telemetry consent, and wallet-first access patterns.

--- a/docs/partner_kit/README.md
+++ b/docs/partner_kit/README.md
@@ -2,6 +2,8 @@
 
 This kit bundles audit evidence, governance documentation, ROI calculators, and case studies for enterprise procurement teams.
 
+> **Case Study Notice:** Only the Ghostkey-316 wallet pilot has run live so far. All other case studies and deployment metrics in this kit are sandbox simulations derived from Ghostkey-316 telemetry until new validators are verified in production.
+
 ## Contents
 1. **Attestation Packet**
    - Request templates: `docs/attestations/attestation_requests.md`

--- a/docs/partnership_readiness/README.md
+++ b/docs/partnership_readiness/README.md
@@ -2,6 +2,8 @@
 
 Vaultfire partners, validators, and enterprise collaborators can use this bundle to accelerate diligence, demonstrate belief-aligned impact, and share deployment wins with confidence. Every block below is formatted for GitHub or Notion so it can be dropped into partner hubs without additional styling.
 
+> **Case Study Disclosure:** All deployment wins referenced here—outside of the Ghostkey-316 wallet pilot—are sandbox simulations modeled from Ghostkey-316 telemetry. No other commercial, institutional, or community deployments have been executed live yet.
+
 ---
 
 ## Attestation Templates
@@ -202,7 +204,7 @@ Vaultfire invites independent auditors and compliance partners to validate our b
 ### /case-studies Landing Block
 ```
 # Vaultfire in the Field
-See how belief-driven orchestration empowers communities, validators, and enterprise partners. Each case study demonstrates measurable outcomes rooted in ethics.
+See how belief-driven orchestration empowers communities, validators, and enterprise partners. Each case study demonstrates measurable outcomes rooted in ethics, and aside from Ghostkey-316 every scenario is a Ghostkey-modeled simulation awaiting live validation.
 
 **Featured Stories**
 - Belief-Based Yield Pilot for Discord & X (Community stewardship at scale)

--- a/docs/vaultfire_pilot_bundle/case_studies.md
+++ b/docs/vaultfire_pilot_bundle/case_studies.md
@@ -1,6 +1,8 @@
 # Vaultfire Case Study Portfolio (Telemetry Verified)
 
 > Export-ready for GitHub, Notion, and PDF bundles. Each case study references verifiable telemetry, ROI calculations, and audit-ready governance actions.
+>
+> **Origin Truth:** Ghostkey-316 (wallet: `bpow20.cb.id`) is the only live Vaultfire case study completed to date. All additional case studies in this portfolio are sandbox simulations modeled directly from the Ghostkey-316 behavioral loop until future production pilots are certified.
 
 ## Case Study 0 — Ghostkey-316 Verified Launch Sync
 - **Partner Identity**: Ghostkey-316 (wallet: `bpow20.cb.id`, ENS: `ghostkey316.eth`)
@@ -21,6 +23,7 @@
   - Optional narrative export: `pandoc docs/vaultfire_pilot_bundle/case_studies.md -o ghostkey_case_studies.pdf`
 
 ## Case Study 1 — Guardian Council Attestation Sprint
+- **Simulation Notice**: Modeled from Ghostkey-316 telemetry; no external partner deployment has occurred yet.
 - **Partner Type**: Fortune 100 Innovation Lab
 - **Objective**: Convert simulated trust signals into audit-verifiable telemetry before national rollout.
 - **Intervention**:
@@ -39,6 +42,7 @@
   - PDF Export: `pandoc case_study_one_pagers/guardian_attestation.md -o guardian_attestation.pdf`
 
 ## Case Study 2 — Mission Alignment Accelerator
+- **Simulation Notice**: Ghostkey-316-derived sandbox scenario representing a mid-market adoption pattern.
 - **Partner Type**: Mid-Market Purpose-Led Brand
 - **Objective**: Increase belief-driven mission completions while maintaining retention.
 - **Intervention**:
@@ -57,6 +61,7 @@
   - Embed snippet available in `docs/vaultfire_pilot_bundle/publishing_assets.md`
 
 ## Case Study 3 — Impact Nonprofit Coalition
+- **Simulation Notice**: Synthetic nonprofit coalition metrics extrapolated from Ghostkey-316 data.
 - **Partner Type**: Global humanitarian alliance
 - **Objective**: Demonstrate mission outcomes with transparent telemetry for grant renewals.
 - **Intervention**:
@@ -75,6 +80,7 @@
   - Case study PDF pipeline documented in `docs/vaultfire_pilot_bundle/publishing_assets.md`
 
 ## Case Study 4 — Enterprise Procurement Fast Track
+- **Simulation Notice**: Forecasted enterprise deployment metrics extrapolated from Ghostkey-316 telemetry.
 - **Partner Type**: Defense-grade SaaS Vendor
 - **Objective**: Bundle attestations, governance, and ROI proof for procurement committees.
 - **Intervention**:

--- a/docs/vaultfire_pilot_bundle/case_study_one_pagers/case_study_A_1pager.md
+++ b/docs/vaultfire_pilot_bundle/case_study_one_pagers/case_study_A_1pager.md
@@ -6,6 +6,8 @@ title: "Case Study A"
 subtitle: "Belief-Driven XP/Yield Pilot"
 ---
 
+> **Simulation Notice:** Derived from the Ghostkey-316 origin validator; no additional live deployments exist yet.
+
 # Overview
 Vaultfire activated a belief-driven XP/Yield pilot across Discord and X, creating ethics-first incentives for creators and fans.
 

--- a/docs/vaultfire_pilot_bundle/case_study_one_pagers/case_study_B_1pager.md
+++ b/docs/vaultfire_pilot_bundle/case_study_one_pagers/case_study_B_1pager.md
@@ -6,6 +6,8 @@ title: "Case Study B"
 subtitle: "NS3 + Ghostkey AI Engagement"
 ---
 
+> **Simulation Notice:** Derived from the Ghostkey-316 origin validator; no additional live deployments exist yet.
+
 # Overview
 Vaultfire fused NS3 simulations with the Ghostkey signal router to vet AI engagement flows before live deployment.
 

--- a/docs/vaultfire_pilot_bundle/case_study_one_pagers/case_study_C_1pager.md
+++ b/docs/vaultfire_pilot_bundle/case_study_one_pagers/case_study_C_1pager.md
@@ -6,6 +6,8 @@ title: "Case Study C"
 subtitle: "Ethics-First Web3 Loyalty"
 ---
 
+> **Simulation Notice:** Derived from the Ghostkey-316 origin validator; no additional live deployments exist yet.
+
 # Overview
 Vaultfire partnered with a mission-led brand to launch an ethics-first loyalty program that preserved privacy and stable mainnet economics.
 

--- a/docs/vaultfire_pilot_bundle/case_study_one_pagers/case_study_D_1pager.md
+++ b/docs/vaultfire_pilot_bundle/case_study_one_pagers/case_study_D_1pager.md
@@ -6,6 +6,8 @@ title: "Case Study D"
 subtitle: "Governance Mirror Sandbox"
 ---
 
+> **Simulation Notice:** Derived from the Ghostkey-316 origin validator; no additional live deployments exist yet.
+
 # Overview
 Vaultfire enabled partners to simulate governance decisions safely through the Governance Mirror sandbox.
 

--- a/docs/vaultfire_pilot_bundle/case_study_one_pagers/case_study_E_1pager.md
+++ b/docs/vaultfire_pilot_bundle/case_study_one_pagers/case_study_E_1pager.md
@@ -6,6 +6,8 @@ title: "Case Study E"
 subtitle: "Wallet Provider Onboarding"
 ---
 
+> **Simulation Notice:** Derived from the Ghostkey-316 origin validator; no additional live deployments exist yet.
+
 # Overview
 Vaultfire partnered with a wallet provider to accelerate belief-driven incentives without disrupting existing user flows.
 

--- a/docs/vaultfire_pilot_bundle/landing/case-studies.md
+++ b/docs/vaultfire_pilot_bundle/landing/case-studies.md
@@ -1,10 +1,12 @@
 ---
 layout: landing
 hero_title: "Belief-Driven Impact Stories"
-hero_subtitle: "Sandbox-proven pilots for mid-market innovators and Fortune 100 leaders"
+hero_subtitle: "Sandbox-modeled pilots derived from the Ghostkey-316 origin validator"
 cta_primary: "Download 1-Pagers"
 cta_secondary: "Book a Sandbox Session"
 ---
+
+> **Disclosure:** All showcased case studies are simulated, built from the real behavior loop of Ghostkey-316 (wallet: `bpow20.cb.id`). No commercial trials beyond this live wallet pilot have been completed yet.
 
 {% include '../case_studies.md' %}
 

--- a/docs/vaultfire_pilot_bundle/publishing_assets.md
+++ b/docs/vaultfire_pilot_bundle/publishing_assets.md
@@ -2,6 +2,8 @@
 
 Belief-driven, ethics-first, enterprise credible.
 
+> **Reality Check:** All current case study data is modeled from the real behavior loop of Ghostkey-316, the protocol's origin validator and loyalty stress tester. No commercial trials have yet been run beyond this wallet-based pilot layer. Treat every additional deployment narrative in this bundle as a sandbox simulation until new live validators are verified.
+
 ## GitHub / Notion Overview Sections
 
 ### Attestations & Compliance (Markdown Snippet)
@@ -19,6 +21,7 @@ Belief-driven, ethics-first, enterprise credible.
 ### Case Studies Snapshot (Markdown Snippet)
 ```
 ## Case Studies
+- All data below is simulated from the Ghostkey-316 origin validator; no additional live deployments exist yet.
 - Guardian Council attestation sprint: 14.6K wallets, ROI 24%
 - Mission alignment accelerator: 18.2K wallets, ROI 27%
 - Impact nonprofit coalition: 8.1K wallets, retention 71%, ROI 31%
@@ -73,10 +76,12 @@ cta_secondary: "View SOC 2 Roadmap"
 ---
 layout: landing
 hero_title: "Belief-Driven Impact Stories"
-hero_subtitle: "Sandbox-proven pilots for mid-market innovators and Fortune 100 leaders"
+hero_subtitle: "Sandbox-modeled pilots derived from the Ghostkey-316 origin validator"
 cta_primary: "Download 1-Pagers"
 cta_secondary: "Book a Sandbox Session"
 ---
+
+> All case studies are Ghostkey-316 simulations until additional pilots are verified.
 
 {{ include '../case_studies.md' }}
 

--- a/status/reference-deployments.md
+++ b/status/reference-deployments.md
@@ -1,16 +1,18 @@
 # Reference Deployments
 
-## Wallet-Based Onboarding
+> **Reality Check:** Ghostkey-316 (wallet: `bpow20.cb.id`) is the only live Vaultfire deployment to date. The scenarios below are sandbox simulations extrapolated from Ghostkey-316 telemetry to illustrate expected partner outcomes.
+
+## Wallet-Based Onboarding *(Simulation based on Ghostkey-316 telemetry)*
 - **Objective:** Accelerate partner sign-ups using non-custodial wallets.
 - **Vaultfire Modules:** `wallet_auth.ts`, `partner_modules/onboarding`, `vaultfire_sdk` client hooks.
 - **Outcome:** Reduced onboarding friction by 42% across pilot cohorts with full audit trails for partner compliance teams.
 
-## Telemetry Sync
+## Telemetry Sync *(Simulation based on Ghostkey-316 telemetry)*
 - **Objective:** Mirror high-volume telemetry events across partner data lakes in real time.
 - **Vaultfire Modules:** `belief_sync_engine.js`, `ghostloop_sync.py`, `telemetry/` processors.
 - **Outcome:** Delivered sub-second propagation to partner observability stacks with schema validation safeguards.
 
-## Governance Mirror
+## Governance Mirror *(Simulation based on Ghostkey-316 telemetry)*
 - **Objective:** Provide a read-consistent mirror of governance proposals and votes for partner councils.
 - **Vaultfire Modules:** `governance/` ledger snapshots, `vaultfire_core.js`, `partner_modules/governance` adapters.
 - **Outcome:** Enabled partner-side quorum tracking with cryptographic proofs synchronized to Vaultfire checkpoints.


### PR DESCRIPTION
## Summary
- add a central Ghostkey-316 reality check in the README and partner toolkits so the live pilot status is unambiguous
- annotate Vaultfire case study portfolio assets, landing pages, and one-pagers as Ghostkey-modeled simulations until new validators are certified
- mark reference deployment documentation as simulated scenarios derived from Ghostkey-316 telemetry

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1422c3a488322b57730fc984f7fdb