### PR TITLE
Add GhostAudit logger for partner simulations

### DIFF
--- a/simulate_partner_activation.py
+++ b/simulate_partner_activation.py
@@ -5,46 +5,123 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import logging
+import time
 from datetime import datetime
 from pathlib import Path
+from typing import Iterable
 
 from engine import storage
 from engine.loyalty_engine import update_loyalty_ranks
 from engine.identity_resolver import resolve_identity
 from system_integrity_check import run_integrity_check
+from vaultfire.ghost_audit import GhostAuditLogger
 
 BASE_DIR = Path(__file__).resolve().parent
 CONFIG_PATH = BASE_DIR / "vaultfire-core" / "vaultfire_config.json"
 PARTNERS_PATH = BASE_DIR / "partners.json"
 ALIGNMENT_PHRASE = "Morals Before Metrics."
 
+logger = logging.getLogger("vaultfire.partner_activation")
+_AUDIT_LOGGER = GhostAuditLogger()
 
-def simulate_activation(partner_id: str, wallets: list[str],
-                        phrase: str = ALIGNMENT_PHRASE,
-                        test_mode: bool = False) -> dict:
-    """Run activation checks and return a result object."""
+
+def simulate_activation(
+    partner_id: str,
+    wallets: list[str],
+    phrase: str = ALIGNMENT_PHRASE,
+    test_mode: bool = False,
+    *,
+    audit_logger: GhostAuditLogger | None = None,
+    redact_sensitive: bool | None = None,
+    validators: Iterable[str] | None = None,
+) -> dict:
+    """Run activation checks and return a result object with audit logging."""
+
+    started = time.monotonic()
+    audit_logger = audit_logger or _AUDIT_LOGGER
+
     failures: list[str] = []
+    decision_tree: list[dict[str, object]] = []
 
-    if not partner_id:
+    partner_present = bool(partner_id)
+    decision_tree.append(
+        {
+            "id": "inputs.partner_id",
+            "description": "Partner identifier supplied",
+            "observed": "present" if partner_present else "missing",
+            "outcome": "pass" if partner_present else "fail",
+        }
+    )
+    if not partner_present:
         failures.append("partner_id missing")
-    if not wallets:
+
+    wallets_present = bool(wallets)
+    decision_tree.append(
+        {
+            "id": "inputs.wallet_roster",
+            "description": "Wallet roster provided",
+            "observed": len(wallets),
+            "outcome": "pass" if wallets_present else "fail",
+        }
+    )
+    if not wallets_present:
         failures.append("wallets missing")
 
-    if not check_alignment_phrase(phrase):
+    phrase_ok = check_alignment_phrase(phrase)
+    decision_tree.append(
+        {
+            "id": "controls.alignment_phrase",
+            "description": "Alignment phrase matches canonical charter",
+            "observed": "match" if phrase_ok else "mismatch",
+            "outcome": "pass" if phrase_ok else "fail",
+        }
+    )
+    if not phrase_ok:
         failures.append("alignment phrase mismatch")
 
-    if not check_ethics_anchor():
+    ethics_ok = check_ethics_anchor()
+    decision_tree.append(
+        {
+            "id": "controls.ethics_anchor",
+            "description": "Ethics anchor enabled in configuration",
+            "observed": ethics_ok,
+            "outcome": "pass" if ethics_ok else "fail",
+        }
+    )
+    if not ethics_ok:
         failures.append("ethics_anchor disabled")
 
-    if not init_loyalty_engine():
+    loyalty_ok = init_loyalty_engine()
+    decision_tree.append(
+        {
+            "id": "systems.loyalty_engine",
+            "description": "Loyalty engine initialised",
+            "observed": loyalty_ok,
+            "outcome": "pass" if loyalty_ok else "fail",
+        }
+    )
+    if not loyalty_ok:
         failures.append("loyalty_engine initialization failed")
 
     success = not failures
     resolved_wallets = resolve_wallets(wallets) if success else wallets
+    activation_recorded = False
     if success and not test_mode:
         activate_partner(partner_id, wallets, resolved_wallets)
+        activation_recorded = True
 
-    return {
+    decision_tree.append(
+        {
+            "id": "outcome.activation",
+            "description": "Overall activation status",
+            "observed": "activated" if success else "blocked",
+            "outcome": "pass" if success else "fail",
+            "notes": failures if not success else ["All readiness checks satisfied."],
+        }
+    )
+
+    result = {
         "partner_id": partner_id,
         "wallets": resolved_wallets,
         "input_wallets": wallets,
@@ -54,6 +131,41 @@ def simulate_activation(partner_id: str, wallets: list[str],
         "status": "PASS" if success else "FAIL",
         "integration_readiness": "10/10" if success else "0/10",
     }
+
+    duration_ms = round((time.monotonic() - started) * 1000, 3)
+    performance_metrics = {
+        "duration_ms": duration_ms,
+        "checks_total": len(decision_tree),
+        "checks_failed": len(failures),
+        "wallets_submitted": len(wallets),
+        "activation_recorded": activation_recorded,
+        "success": success,
+    }
+
+    run_context = {
+        "partner_id": partner_id,
+        "wallets": wallets,
+        "resolved_wallets": resolved_wallets,
+        "test_mode": test_mode,
+        "phrase": phrase,
+    }
+
+    try:
+        audit_logger.log_simulation(
+            protocol_name="partner_activation",
+            scenario=partner_id or "unassigned-partner",
+            decision_tree={"nodes": decision_tree},
+            performance=performance_metrics,
+            run_context=run_context,
+            outcome=result,
+            protocol_version="activation.v1",
+            validators=validators,
+            redact_sensitive=redact_sensitive,
+        )
+    except Exception as exc:  # pragma: no cover - audit logging must not break flow
+        logger.warning("Failed to persist GhostAudit record: %s", exc)
+
+    return result
 
 
 def _load_json(path: Path, default):

--- a/tests/test_ghost_audit_logger.py
+++ b/tests/test_ghost_audit_logger.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vaultfire.ghost_audit import GhostAuditLogger
+
+
+def read_latest_record(path: Path) -> dict:
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    return json.loads(lines[-1])
+
+
+def test_log_simulation_writes_publishable_record(tmp_path):
+    log_path = tmp_path / "ghost_audit.jsonl"
+    logger = GhostAuditLogger(log_path=log_path, default_validators=("validator.one",))
+
+    record = logger.log_simulation(
+        protocol_name="partner_activation",
+        scenario="pilot-001",
+        decision_tree={"nodes": [{"id": "step-1", "outcome": "pass"}]},
+        performance={"duration_ms": 12.5, "success": True},
+        run_context={"partner_id": "pilot-001", "wallets": ["0xabc"]},
+        outcome={"status": "PASS", "failures": []},
+        protocol_version="activation.v1",
+    )
+
+    assert log_path.exists(), "ghost audit log should be persisted"
+    persisted = read_latest_record(log_path)
+    assert persisted["run"]["protocol"]["name"] == "partner_activation"
+    assert persisted["run"]["scenario"] == "pilot-001"
+    assert persisted["performance"]["duration_ms"] == 12.5
+    assert persisted["validators"][0]["validator"] == "validator.one"
+    assert "signature" in persisted["validators"][0]
+    assert persisted["attestation"]["digest"]
+    # The return value mirrors persisted structure for callers who need it.
+    assert record["run"]["id"] == persisted["run"]["id"]
+
+
+def test_log_simulation_redacts_sensitive_fields(tmp_path):
+    log_path = tmp_path / "ghost_audit.jsonl"
+    logger = GhostAuditLogger(log_path=log_path)
+
+    record = logger.log_simulation(
+        protocol_name="consent_protocol",
+        scenario="pilot-002",
+        decision_tree={"nodes": [{"wallets": ["0xaaa", "0xbbb"]}]},
+        performance={"duration_ms": 4.2, "success": False},
+        run_context={"wallets": ["0xaaa", "0xbbb"], "partner_contact": "ops@pilot.io"},
+        outcome={"wallets": ["0xaaa"], "status": "FAIL"},
+        redact_sensitive=True,
+    )
+
+    persisted = read_latest_record(log_path)
+    assert persisted["redacted"] is True
+    assert record["context"]["wallets"] == ["***redacted***", "***redacted***"]
+    assert persisted["context"]["partner_contact"] == "***redacted***"
+    node_wallets = persisted["decision_tree"]["nodes"][0]["wallets"]
+    assert node_wallets == ["***redacted***", "***redacted***"]

--- a/vaultfire/__init__.py
+++ b/vaultfire/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "satellite",
     "enterprise",
     "rewards",
+    "ghost_audit",
     "refund",
     "pilot_mode",
     "auto_refund",
@@ -31,6 +32,7 @@ _LAZY_MODULES: Dict[str, str] = {
     "satellite": ".satellite",
     "enterprise": ".enterprise",
     "rewards": ".rewards",
+    "ghost_audit": ".ghost_audit",
     "refund": ".refund",
     "pilot_mode": ".pilot_mode",
 }

--- a/vaultfire/ghost_audit.py
+++ b/vaultfire/ghost_audit.py
@@ -1,0 +1,228 @@
+"""GhostAudit module for Vaultfire pilot partner readiness.
+
+This module captures protocol simulation runs, decision trees, and
+performance metrics and emits audit metadata suitable for distribution to
+pilot partners. Records can be redacted for sensitive payloads while still
+providing validator attestations with deterministic signatures.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, MutableMapping
+from uuid import uuid4
+
+_DEFAULT_LOG_PATH = Path("logs") / "audit" / "ghost_audit_metadata.jsonl"
+_DEFAULT_VALIDATORS = (
+    "validator.ethics.alpha",
+    "validator.mission.control",
+)
+_DEFAULT_SENSITIVE_FIELDS = frozenset(
+    {
+        "wallet",
+        "wallets",
+        "resolved_wallets",
+        "input_wallets",
+        "wallet_alias",
+        "wallet_aliases",
+        "contact",
+        "contact_email",
+        "partner_contact",
+        "private_notes",
+    }
+)
+
+
+@dataclass
+class GhostAuditLogger:
+    """Persist publishable audit metadata for protocol simulations."""
+
+    log_path: Path = field(default_factory=lambda: _DEFAULT_LOG_PATH)
+    schema_version: str = "1.0"
+    redact_sensitive: bool = field(
+        default_factory=lambda: os.getenv("VAULTFIRE_GHOSTAUDIT_REDACT", "false")
+        .strip()
+        .lower()
+        in {"1", "true", "yes", "on"}
+    )
+    sensitive_fields: Iterable[str] = field(default_factory=lambda: _DEFAULT_SENSITIVE_FIELDS)
+    default_validators: Iterable[str] = field(
+        default_factory=lambda: os.getenv("VAULTFIRE_GHOSTAUDIT_VALIDATORS", "").split(",")
+        if os.getenv("VAULTFIRE_GHOSTAUDIT_VALIDATORS")
+        else _DEFAULT_VALIDATORS
+    )
+
+    def __post_init__(self) -> None:
+        self.log_path = Path(self.log_path)
+        self._sensitive_fields = {field.strip() for field in self.sensitive_fields}
+        self._sensitive_fields.update({field.strip() for field in _DEFAULT_SENSITIVE_FIELDS})
+        self._validators = [validator.strip() for validator in self.default_validators if validator.strip()]
+        if not self._validators:
+            self._validators = list(_DEFAULT_VALIDATORS)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def log_simulation(
+        self,
+        *,
+        protocol_name: str,
+        scenario: str,
+        decision_tree: Mapping[str, Any] | Iterable[Any],
+        performance: Mapping[str, Any],
+        run_context: Mapping[str, Any] | None = None,
+        outcome: Mapping[str, Any] | None = None,
+        protocol_version: str | None = None,
+        validators: Iterable[str] | None = None,
+        redact_sensitive: bool | None = None,
+        run_id: str | None = None,
+    ) -> MutableMapping[str, Any]:
+        """Capture a protocol simulation run and return the audit record."""
+
+        if not protocol_name:
+            raise ValueError("protocol_name must be provided")
+        if not scenario:
+            raise ValueError("scenario must be provided")
+
+        timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        run_identifier = run_id or str(uuid4())
+        version = protocol_version or "pilot-ready"
+        redaction_enabled = self.redact_sensitive if redact_sensitive is None else bool(redact_sensitive)
+
+        normalised_decision_tree = self._normalise(decision_tree)
+        normalised_performance = self._normalise(performance)
+        normalised_context = self._normalise(run_context or {})
+        normalised_outcome = self._normalise(outcome or {})
+
+        audit_record: MutableMapping[str, Any] = {
+            "schema": {
+                "name": "vaultfire.ghost_audit",
+                "version": self.schema_version,
+            },
+            "run": {
+                "id": run_identifier,
+                "protocol": {
+                    "name": protocol_name,
+                    "version": version,
+                },
+                "scenario": scenario,
+                "timestamp": timestamp,
+            },
+            "decision_tree": normalised_decision_tree,
+            "performance": normalised_performance,
+            "context": normalised_context,
+            "outcome": normalised_outcome,
+            "distribution": {
+                "prepared_for": "vaultfire.pilot.partners",
+                "classification": "partner-internal" if redaction_enabled else "public",
+                "status": "ready",
+            },
+            "disclaimers": [
+                "Partners remain responsible for their own compliance reviews.",
+                "Ambient telemetry follows declared opt-in policies.",
+                "Nothing in this log constitutes legal, medical, or financial advice.",
+            ],
+        }
+
+        if redaction_enabled:
+            audit_record["context"] = self._redact_payload(audit_record["context"])
+            audit_record["outcome"] = self._redact_payload(audit_record["outcome"])
+            audit_record["decision_tree"] = self._redact_payload(audit_record["decision_tree"])
+
+        audit_record["validators"] = self._validator_signatures(validators, run_identifier)
+        audit_record["attestation"] = self._build_attestation(audit_record)
+        audit_record["redacted"] = redaction_enabled
+
+        self._append_record(audit_record)
+        return audit_record
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _normalise(self, payload: Any) -> Any:
+        if isinstance(payload, Mapping):
+            return {str(key): self._normalise(value) for key, value in payload.items()}
+        if isinstance(payload, (list, tuple, set)):
+            return [self._normalise(item) for item in payload]
+        if isinstance(payload, Path):
+            return str(payload)
+        if isinstance(payload, datetime):  # pragma: no cover - defensive path
+            return payload.replace(microsecond=0, tzinfo=timezone.utc).isoformat()
+        return payload
+
+    def _mask_value(self, value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {str(key): self._mask_value(sub_value) for key, sub_value in value.items()}
+        if isinstance(value, (list, tuple, set)):
+            return [self._mask_value(item) for item in value]
+        if value is None:
+            return None
+        return "***redacted***"
+
+    def _redact_payload(self, payload: Any) -> Any:
+        if isinstance(payload, Mapping):
+            redacted: MutableMapping[str, Any] = {}
+            for key, value in payload.items():
+                if key in self._sensitive_fields:
+                    redacted[key] = self._mask_value(value)
+                else:
+                    redacted[key] = self._redact_payload(value)
+            return redacted
+        if isinstance(payload, list):
+            return [self._redact_payload(item) for item in payload]
+        if isinstance(payload, tuple):  # pragma: no cover - defensive
+            return [self._redact_payload(item) for item in payload]
+        return payload
+
+    def _validator_signatures(
+        self,
+        validators: Iterable[str] | None,
+        run_id: str,
+    ) -> list[dict[str, Any]]:
+        resolved_validators = [v.strip() for v in (validators or self._validators) if v and v.strip()]
+        if not resolved_validators:
+            resolved_validators = list(self._validators)
+
+        signatures = []
+        for idx, validator in enumerate(resolved_validators):
+            signed_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+            signature_input = f"{validator}:{run_id}:{idx}:{signed_at}".encode("utf-8")
+            signatures.append(
+                {
+                    "validator": validator,
+                    "signed_at": signed_at,
+                    "signature": hashlib.sha256(signature_input).hexdigest(),
+                }
+            )
+        return signatures
+
+    def _build_attestation(self, record: Mapping[str, Any]) -> Mapping[str, Any]:
+        digest_payload = {
+            "run": record["run"],
+            "decision_tree": record["decision_tree"],
+            "performance": record["performance"],
+            "context": record["context"],
+            "outcome": record["outcome"],
+        }
+        digest = hashlib.sha256(
+            json.dumps(digest_payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
+        return {
+            "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            "digest": digest,
+            "visibility": "redacted" if record.get("redacted") else "public",
+            "intended_audience": ["pilot_partners", "compliance_team"],
+        }
+
+    def _append_record(self, record: Mapping[str, Any]) -> None:
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record) + "\n")
+
+
+__all__ = ["GhostAuditLogger"]


### PR DESCRIPTION
## Summary
- add a GhostAuditLogger module that emits publishable audit metadata with optional redaction and validator signatures
- hook the partner activation simulator into GhostAudit logging and expose the module via the vaultfire package
- cover the new behaviour with unit tests

## Testing
- pytest tests/test_ghost_audit_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68e15b95974c8322b74cf83530cee1ff