### PR TITLE
Add encrypted pilot pilot mode ledger and privacy toggles

### DIFF
--- a/tests/test_pilot_mode.py
+++ b/tests/test_pilot_mode.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import hmac
 import hashlib
+import hmac
 import json
-from pathlib import Path
+import os
 
 import pytest
 
+from utils.crypto import derive_key, decrypt_text
 from vaultfire.pilot_mode import PilotAccessLayer
 from vaultfire.pilot_mode import storage as pilot_storage
 
@@ -18,19 +19,36 @@ def isolated_pilot_storage(tmp_path, monkeypatch):
     """Isolate pilot mode storage to a temporary directory for tests."""
 
     monkeypatch.setattr(pilot_storage, "PILOT_MODE_ROOT", tmp_path)
+    monkeypatch.setattr(pilot_storage, "PRIVATE_LEDGER_ROOT", tmp_path / "private")
     monkeypatch.setattr(pilot_storage, "PARTNER_REGISTRY_PATH", tmp_path / "partners.json")
     monkeypatch.setattr(pilot_storage, "PROTOCOL_KEYS_PATH", tmp_path / "protocol_keys.json")
     monkeypatch.setattr(pilot_storage, "SESSION_LOG_PATH", tmp_path / "sessions.jsonl")
     monkeypatch.setattr(pilot_storage, "YIELD_LOG_PATH", tmp_path / "yield.jsonl")
     monkeypatch.setattr(pilot_storage, "BEHAVIOR_LOG_PATH", tmp_path / "behavior.jsonl")
     monkeypatch.setattr(pilot_storage, "FEEDBACK_LOG_PATH", tmp_path / "feedback.jsonl")
+    private_path = tmp_path / "private" / "pilot_refs.jsonl"
+    monkeypatch.setattr(pilot_storage, "PRIVATE_REFERENCE_LOG_PATH", private_path)
+    monkeypatch.setenv("VAULTFIRE_PILOT_SECRET", "test-secret")
     yield
 
 
-def _read_jsonl(path: Path) -> list[dict]:
+def _load_references() -> list[tuple[dict, dict]]:
+    path = pilot_storage.PRIVATE_REFERENCE_LOG_PATH
     if not path.exists():
         return []
-    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    key = derive_key(os.environ["VAULTFIRE_PILOT_SECRET"])
+    entries: list[tuple[dict, dict]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        entry = json.loads(line)
+        payload = json.loads(decrypt_text(key, entry["payload_token"]))
+        entries.append((entry, payload))
+    return entries
+
+
+def _entries_of_type(references: list[tuple[dict, dict]], ref_type: str) -> list[tuple[dict, dict]]:
+    return [item for item in references if item[0]["reference_type"] == ref_type]
 
 
 def test_pilot_session_activation_via_api_key(tmp_path):
@@ -41,31 +59,82 @@ def test_pilot_session_activation_via_api_key(tmp_path):
         wallet_addresses=["0xabc"],
         default_watermark=True,
     )
-    token = layer.issue_protocol_key(partner.partner_id, max_uses=2)
+    token = layer.issue_protocol_key(
+        partner.partner_id,
+        max_uses=2,
+        metadata={"protocols": ["ASM", "Base"]},
+    )
     session = layer.activate_session(
         partner.partner_id,
         protocol_key=token,
         api_key="asm-secret",
+        protocols=["ASM", "Base"],
+        simulate_real_user_load=True,
+        load_multiplier=1.5,
+        load_profile={"cohort": "beta"},
     )
+    session.toggle_real_user_load(True, load_multiplier=2.5, profile={"region": "global"})
     result = session.simulate_yield(wallet_id="0xabc", strategy_id="demo-strategy", sample_size=25)
     session.log_behavior(wallet_id="0xabc", event_type="test", payload={"result": "ok"})
+    session.register_stake(12.5, asset="VF-PILOT", metadata={"lock": "90d"})
+    session.trigger_loyalty("activation", score=0.95, metadata={"tier": "gold"})
+    session.mirror_consent("consent-123", target_protocol="ASM", metadata={"audited": True})
     session.submit_feedback(feedback_type="bug", message="Found edge case")
 
     assert session.pilot_mode is True
     assert session.get_watermark() == "Pilot Powered by Vaultfire"
     assert result.partner_tag == partner.anonymized_tag
     assert result.wallet_fingerprint != "0xabc"
+    assert session.real_load_enabled is True
+    assert session.protocols == ("ASM", "Base")
 
-    sessions = _read_jsonl(pilot_storage.SESSION_LOG_PATH)
-    assert len(sessions) == 1
-    yield_logs = _read_jsonl(pilot_storage.YIELD_LOG_PATH)
-    assert yield_logs[0]["partner_tag"] == partner.anonymized_tag
-    assert "wallet_fingerprint" in yield_logs[0] and "0xabc" not in yield_logs[0]["wallet_fingerprint"]
-    behavior_logs = _read_jsonl(pilot_storage.BEHAVIOR_LOG_PATH)
-    assert behavior_logs[0]["partner_tag"] == partner.anonymized_tag
-    assert behavior_logs[0]["wallet_fingerprint"] != "0xabc"
-    feedback_logs = _read_jsonl(pilot_storage.FEEDBACK_LOG_PATH)
-    assert "partner_id" not in feedback_logs[0]
+    references = _load_references()
+    reference_types = {entry["reference_type"] for entry, _ in references}
+    expected_types = {"session", "yield", "behavior", "feedback", "load-toggle", "stake", "loyalty", "consent"}
+    assert expected_types.issubset(reference_types)
+
+    for entry, payload in references:
+        assert entry["partner_tag"] == partner.anonymized_tag
+        assert "partner_id" not in entry["metadata"]
+
+    session_entry = _entries_of_type(references, "session")[0]
+    session_payload = session_entry[1]
+    assert session_payload["protocols"] == ["ASM", "Base"]
+
+    yield_entry = _entries_of_type(references, "yield")[0]
+    yield_payload = yield_entry[1]
+    assert yield_payload["sample_size"] == 62  # 25 * 2.5 load multiplier
+    assert "wallet_fingerprint" in yield_payload and "0xabc" not in yield_payload["wallet_fingerprint"]
+    assert yield_entry[0]["metadata"]["load_simulation_enabled"] is True
+
+    behavior_entry = _entries_of_type(references, "behavior")[0]
+    assert behavior_entry[0]["metadata"]["event_type"] == "test"
+
+    feedback_entry = _entries_of_type(references, "feedback")[0]
+    assert "partner_id" not in feedback_entry[1]
+    assert feedback_entry[0]["metadata"]["expose_identity"] is False
+
+    load_entries = _entries_of_type(references, "load-toggle")
+    assert len(load_entries) == 2
+    assert load_entries[-1][1]["load_multiplier"] == 2.5
+    assert load_entries[-1][1]["profile"]["region"] == "global"
+
+    stake_entry = _entries_of_type(references, "stake")[0]
+    assert stake_entry[1]["amount"] == 12.5
+    assert stake_entry[1]["asset"] == "VF-PILOT"
+
+    loyalty_entry = _entries_of_type(references, "loyalty")[0]
+    assert loyalty_entry[1]["trigger"] == "activation"
+    assert loyalty_entry[1]["score"] == 0.95
+
+    consent_entry = _entries_of_type(references, "consent")[0]
+    assert consent_entry[1]["consent_reference"] == "consent-123"
+    assert consent_entry[1]["target_protocol"] == "ASM"
+
+    assert not pilot_storage.SESSION_LOG_PATH.exists()
+    assert not pilot_storage.YIELD_LOG_PATH.exists()
+    assert not pilot_storage.BEHAVIOR_LOG_PATH.exists()
+    assert not pilot_storage.FEEDBACK_LOG_PATH.exists()
 
 
 def test_wallet_signature_activation_and_feedback_identity(tmp_path):
@@ -90,6 +159,7 @@ def test_wallet_signature_activation_and_feedback_identity(tmp_path):
         wallet_address="0x1234",
         wallet_signature=signature,
         signature_message=signature_message,
+        protocols=["Base"],
     )
     assert session.pilot_mode is True
     assert session.get_watermark() is None
@@ -101,9 +171,9 @@ def test_wallet_signature_activation_and_feedback_identity(tmp_path):
         metadata={"priority": "p0"},
         expose_identity=True,
     )
-    feedback_logs = _read_jsonl(pilot_storage.FEEDBACK_LOG_PATH)
-    assert feedback_logs[-1]["expose_identity"] is True
-    assert feedback_logs[-1]["partner_id"] == partner.partner_id
+    feedback_entries = _entries_of_type(_load_references(), "feedback")
+    assert feedback_entries[-1][0]["metadata"]["expose_identity"] is True
+    assert feedback_entries[-1][1]["partner_id"] == partner.partner_id
 
     with pytest.raises(PermissionError):
         layer.activate_session(

--- a/vaultfire/pilot_mode/__init__.py
+++ b/vaultfire/pilot_mode/__init__.py
@@ -3,6 +3,7 @@
 from .access_layer import PilotAccessLayer
 from .feedback import FeedbackCollector, FeedbackRecord
 from .keys import ProtocolKey, ProtocolKeyManager
+from .privacy import PilotPrivacyLedger, PilotReference
 from .registry import PilotAccessRegistry, PartnerRecord
 from .sandbox import SandboxResult, YieldSandbox
 from .session import PilotSession, SessionFactory
@@ -15,6 +16,8 @@ __all__ = [
     "ProtocolKeyManager",
     "PilotAccessRegistry",
     "PartnerRecord",
+    "PilotPrivacyLedger",
+    "PilotReference",
     "SandboxResult",
     "YieldSandbox",
     "PilotSession",

--- a/vaultfire/pilot_mode/access_layer.py
+++ b/vaultfire/pilot_mode/access_layer.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Iterable, MutableMapping, Optional
+from typing import Iterable, Mapping, MutableMapping, Optional
 
 from .feedback import FeedbackCollector
 from .keys import ProtocolKeyManager
+from .privacy import PilotPrivacyLedger
 from .registry import PilotAccessRegistry, PartnerRecord
 from .sandbox import YieldSandbox
 from .session import PilotSession, SessionFactory
@@ -23,10 +24,22 @@ class PilotAccessLayer:
         key_manager: Optional[ProtocolKeyManager] = None,
         sandbox: Optional[YieldSandbox] = None,
         feedback: Optional[FeedbackCollector] = None,
+        ledger: Optional[PilotPrivacyLedger] = None,
     ) -> None:
         self._registry = registry or PilotAccessRegistry()
         self._keys = key_manager or ProtocolKeyManager()
-        self._session_factory = SessionFactory(sandbox=sandbox, feedback=feedback)
+        self._ledger = ledger or PilotPrivacyLedger()
+        sandbox_instance = sandbox or YieldSandbox(ledger=self._ledger)
+        if sandbox and hasattr(sandbox, "attach_ledger"):
+            sandbox.attach_ledger(self._ledger)
+        feedback_instance = feedback or FeedbackCollector(ledger=self._ledger)
+        if feedback and hasattr(feedback, "attach_ledger"):
+            feedback.attach_ledger(self._ledger)
+        self._session_factory = SessionFactory(
+            sandbox=sandbox_instance,
+            feedback=feedback_instance,
+            ledger=self._ledger,
+        )
 
     @property
     def registry(self) -> PilotAccessRegistry:
@@ -35,6 +48,10 @@ class PilotAccessLayer:
     @property
     def key_manager(self) -> ProtocolKeyManager:
         return self._keys
+
+    @property
+    def ledger(self) -> PilotPrivacyLedger:
+        return self._ledger
 
     def register_partner(
         self,
@@ -85,6 +102,10 @@ class PilotAccessLayer:
         wallet_signature: Optional[str] = None,
         signature_message: str = "vaultfire-pilot-access",
         watermark_override: Optional[bool] = None,
+        protocols: Optional[Iterable[str]] = None,
+        simulate_real_user_load: bool = False,
+        load_multiplier: float = 1.0,
+        load_profile: Optional[Mapping[str, object]] = None,
     ) -> PilotSession:
         if not protocol_key or not protocol_key.strip():
             raise ValueError("protocol_key must be provided")
@@ -105,6 +126,10 @@ class PilotAccessLayer:
             partner=partner,
             protocol_key=key_record,
             watermark_override=watermark_override,
+            protocols=protocols,
+            simulate_real_user_load=simulate_real_user_load,
+            load_multiplier=load_multiplier,
+            load_profile=load_profile,
         )
         return session
 

--- a/vaultfire/pilot_mode/feedback.py
+++ b/vaultfire/pilot_mode/feedback.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Dict, Mapping, MutableMapping, Optional
 
 from . import storage
+from .privacy import PilotPrivacyLedger
 
 __all__ = ["FeedbackRecord", "FeedbackCollector"]
 
@@ -44,8 +45,12 @@ class FeedbackRecord:
 class FeedbackCollector:
     """Capture and persist structured pilot feedback."""
 
-    def __init__(self, *, log_path=None) -> None:
+    def __init__(self, *, log_path=None, ledger: Optional[PilotPrivacyLedger] = None) -> None:
         self._log_path = log_path or storage.FEEDBACK_LOG_PATH
+        self._ledger = ledger
+
+    def attach_ledger(self, ledger: PilotPrivacyLedger) -> None:
+        self._ledger = ledger
 
     def submit_feedback(
         self,
@@ -74,7 +79,18 @@ class FeedbackCollector:
             expose_identity=expose_identity,
             partner_id=partner_id,
         )
-        storage.append_jsonl(self._log_path, record.export())
+        if self._ledger:
+            self._ledger.record_reference(
+                partner_tag=partner_tag,
+                reference_type="feedback",
+                payload=record.export(),
+                metadata={
+                    "severity": severity,
+                    "expose_identity": expose_identity,
+                },
+            )
+        else:
+            storage.append_jsonl(self._log_path, record.export())
         return record
 
     def format_cli_payload(

--- a/vaultfire/pilot_mode/privacy.py
+++ b/vaultfire/pilot_mode/privacy.py
@@ -1,0 +1,90 @@
+"""Privacy and encryption utilities for Vaultfire pilot mode."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Mapping, MutableMapping, Optional
+
+from utils.crypto import derive_key, encrypt_text
+
+from . import storage
+
+__all__ = ["PilotReference", "PilotPrivacyLedger"]
+
+
+_DEFAULT_SECRET = "vaultfire-pilot-secret"
+
+
+def _serialize_json(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"Unsupported type for serialization: {type(value)!r}")
+
+
+@dataclass
+class PilotReference:
+    """An anonymized, encrypted pilot record."""
+
+    reference_id: str
+    reference_type: str
+    partner_tag: str
+    generated_at: datetime
+    payload_token: str
+    metadata: MutableMapping[str, object] = field(default_factory=dict)
+
+    def export(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "reference_id": self.reference_id,
+            "reference_type": self.reference_type,
+            "partner_tag": self.partner_tag,
+            "generated_at": self.generated_at.isoformat(),
+            "payload_token": self.payload_token,
+            "metadata": dict(self.metadata),
+        }
+        return payload
+
+
+class PilotPrivacyLedger:
+    """Encrypts and persists anonymized pilot references."""
+
+    def __init__(
+        self,
+        *,
+        secret: Optional[str] = None,
+        reference_log_path=None,
+    ) -> None:
+        self._secret = secret or os.environ.get("VAULTFIRE_PILOT_SECRET") or _DEFAULT_SECRET
+        self._key = derive_key(self._secret)
+        self._reference_log_path = reference_log_path or storage.PRIVATE_REFERENCE_LOG_PATH
+
+    def attach_path(self, path) -> None:
+        self._reference_log_path = path
+
+    def record_reference(
+        self,
+        *,
+        partner_tag: str,
+        reference_type: str,
+        payload: Mapping[str, object],
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> PilotReference:
+        if not partner_tag or not partner_tag.strip():
+            raise ValueError("partner_tag must be provided")
+        if not reference_type or not reference_type.strip():
+            raise ValueError("reference_type must be provided")
+        serialized = json.dumps(payload, sort_keys=True, default=_serialize_json)
+        token = encrypt_text(self._key, serialized)
+        reference = PilotReference(
+            reference_id=uuid.uuid4().hex,
+            reference_type=reference_type.strip(),
+            partner_tag=partner_tag,
+            generated_at=datetime.now(timezone.utc),
+            payload_token=token,
+            metadata=dict(metadata or {}),
+        )
+        storage.append_jsonl(self._reference_log_path, reference.export())
+        return reference

--- a/vaultfire/pilot_mode/sandbox.py
+++ b/vaultfire/pilot_mode/sandbox.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
 
 from . import storage
+from .privacy import PilotPrivacyLedger
 
 __all__ = ["SandboxResult", "YieldSandbox"]
 
@@ -54,10 +55,29 @@ class YieldSandbox:
         yield_log_path=None,
         behavior_log_path=None,
         secret_salt: str | None = None,
+        ledger: Optional[PilotPrivacyLedger] = None,
     ) -> None:
         self._yield_log_path = yield_log_path or storage.YIELD_LOG_PATH
         self._behavior_log_path = behavior_log_path or storage.BEHAVIOR_LOG_PATH
         self._secret_salt = secret_salt or uuid.uuid4().hex
+        self._ledger = ledger
+        self._simulate_real_load = False
+        self._load_multiplier = 1.0
+        self._load_profile: MutableMapping[str, object] = {}
+
+    def attach_ledger(self, ledger: PilotPrivacyLedger) -> None:
+        self._ledger = ledger
+
+    def set_real_load_simulation(
+        self,
+        enabled: bool,
+        *,
+        load_multiplier: float = 1.0,
+        profile: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        self._simulate_real_load = bool(enabled)
+        self._load_multiplier = max(load_multiplier, 0.1)
+        self._load_profile = dict(profile or {})
 
     def _fingerprint_wallet(self, wallet_id: str) -> str:
         if not wallet_id or not wallet_id.strip():
@@ -81,7 +101,12 @@ class YieldSandbox:
         if sample_size <= 0:
             raise ValueError("sample_size must be positive")
         wallet_fingerprint = self._fingerprint_wallet(wallet_id)
-        seed_material = f"{partner_tag}:{session_id}:{strategy_id}:{wallet_fingerprint}:{sample_size}"
+        applied_sample_size = sample_size
+        if self._simulate_real_load:
+            applied_sample_size = max(1, int(sample_size * self._load_multiplier))
+        seed_material = (
+            f"{partner_tag}:{session_id}:{strategy_id}:{wallet_fingerprint}:{applied_sample_size}"
+        )
         digest = hashlib.sha256(seed_material.encode("utf-8")).digest()
         apr = (int.from_bytes(digest[:2], "big") % 5000) / 100  # up to 50% APR in sandbox
         deviation = (int.from_bytes(digest[2:4], "big") % 250) / 100  # +/- 2.5 spread
@@ -92,14 +117,32 @@ class YieldSandbox:
             partner_tag=partner_tag,
             wallet_fingerprint=wallet_fingerprint,
             strategy_id=strategy_id,
-            sample_size=sample_size,
+            sample_size=applied_sample_size,
             projected_apr=apr,
             confidence_interval=deviation,
             engagement_score=engagement_score,
             generated_at=datetime.now(timezone.utc),
             metadata=dict(telemetry_flags or {}),
         )
-        self._record(self._yield_log_path, result.export())
+        payload = result.export()
+        if self._ledger is None:
+            self._record(self._yield_log_path, payload)
+        else:
+            metadata = dict(payload.get("metadata", {}))
+            metadata.update(
+                {
+                    "load_simulation_enabled": self._simulate_real_load,
+                    "load_multiplier": self._load_multiplier,
+                }
+            )
+            if self._load_profile:
+                metadata["load_profile"] = dict(self._load_profile)
+            self._ledger.record_reference(
+                partner_tag=partner_tag,
+                reference_type="yield",
+                payload=payload,
+                metadata=metadata,
+            )
         return result
 
     def log_behavior(
@@ -121,7 +164,18 @@ class YieldSandbox:
             "payload": dict(payload),
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
-        self._record(self._behavior_log_path, record)
+        if self._ledger is None:
+            self._record(self._behavior_log_path, record)
+        else:
+            metadata = {"event_type": record["event_type"]}
+            if self._simulate_real_load:
+                metadata["load_simulation_enabled"] = True
+            self._ledger.record_reference(
+                partner_tag=partner_tag,
+                reference_type="behavior",
+                payload=record,
+                metadata=metadata,
+            )
 
     def summarize_behavior(self, *, limit: int = 10) -> Iterable[Dict[str, object]]:
         if limit <= 0:

--- a/vaultfire/pilot_mode/session.py
+++ b/vaultfire/pilot_mode/session.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Dict, Mapping, Optional
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional
 
 from .feedback import FeedbackCollector
 from .keys import ProtocolKey
 from .registry import PartnerRecord
 from .sandbox import YieldSandbox
+from .privacy import PilotPrivacyLedger
 from . import storage
 
 __all__ = ["PilotSession", "SessionFactory"]
@@ -28,6 +29,11 @@ class PilotSession:
     sandbox: YieldSandbox
     feedback: FeedbackCollector
     protocol_key: ProtocolKey
+    ledger: PilotPrivacyLedger
+    protocols: tuple[str, ...] = ()
+    real_load_enabled: bool = False
+    load_multiplier: float = 1.0
+    load_profile: MutableMapping[str, object] = field(default_factory=dict)
 
     def get_watermark(self) -> Optional[str]:
         if not self.watermark_enabled:
@@ -86,6 +92,108 @@ class PilotSession:
             partner_id=self.partner_id,
         )
 
+    def toggle_real_user_load(
+        self,
+        enabled: bool,
+        *,
+        load_multiplier: float = 1.0,
+        profile: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        self.real_load_enabled = bool(enabled)
+        self.load_multiplier = max(load_multiplier, 0.1)
+        self.load_profile = dict(profile or {})
+        if hasattr(self.sandbox, "set_real_load_simulation"):
+            self.sandbox.set_real_load_simulation(
+                self.real_load_enabled,
+                load_multiplier=self.load_multiplier,
+                profile=self.load_profile,
+            )
+        self.ledger.record_reference(
+            partner_tag=self.partner_tag,
+            reference_type="load-toggle",
+            payload={
+                "session_id": self.session_id,
+                "enabled": self.real_load_enabled,
+                "load_multiplier": self.load_multiplier,
+                "profile": dict(self.load_profile),
+            },
+            metadata={"protocols": list(self.protocols)},
+        )
+
+    def register_stake(
+        self,
+        amount: float,
+        *,
+        asset: str = "VF",
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        if amount <= 0:
+            raise ValueError("amount must be positive")
+        payload = {
+            "session_id": self.session_id,
+            "amount": amount,
+            "asset": asset,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        if metadata:
+            payload["metadata"] = dict(metadata)
+        self.ledger.record_reference(
+            partner_tag=self.partner_tag,
+            reference_type="stake",
+            payload=payload,
+            metadata={"protocols": list(self.protocols)},
+        )
+
+    def trigger_loyalty(
+        self,
+        trigger: str,
+        *,
+        score: float,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        if not trigger or not trigger.strip():
+            raise ValueError("trigger must be provided")
+        payload = {
+            "session_id": self.session_id,
+            "trigger": trigger.strip(),
+            "score": score,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        if metadata:
+            payload["metadata"] = dict(metadata)
+        self.ledger.record_reference(
+            partner_tag=self.partner_tag,
+            reference_type="loyalty",
+            payload=payload,
+            metadata={"protocols": list(self.protocols)},
+        )
+
+    def mirror_consent(
+        self,
+        consent_reference: str,
+        *,
+        target_protocol: str,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        if not consent_reference or not consent_reference.strip():
+            raise ValueError("consent_reference must be provided")
+        if not target_protocol or not target_protocol.strip():
+            raise ValueError("target_protocol must be provided")
+        payload = {
+            "session_id": self.session_id,
+            "consent_reference": consent_reference.strip(),
+            "target_protocol": target_protocol.strip(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        if metadata:
+            payload["metadata"] = dict(metadata)
+        self.ledger.record_reference(
+            partner_tag=self.partner_tag,
+            reference_type="consent",
+            payload=payload,
+            metadata={"protocols": list(self.protocols)},
+        )
+
     def export_context(self) -> Dict[str, object]:
         return {
             "session_id": self.session_id,
@@ -93,6 +201,10 @@ class PilotSession:
             "pilot_mode": self.pilot_mode,
             "watermark_enabled": self.watermark_enabled,
             "protocol_key_metadata": dict(self.protocol_key.metadata),
+            "protocols": list(self.protocols),
+            "real_load_enabled": self.real_load_enabled,
+            "load_multiplier": self.load_multiplier,
+            "load_profile": dict(self.load_profile),
         }
 
 
@@ -105,13 +217,36 @@ class SessionFactory:
         sandbox: Optional[YieldSandbox] = None,
         feedback: Optional[FeedbackCollector] = None,
         session_log_path=None,
+        ledger: Optional[PilotPrivacyLedger] = None,
     ) -> None:
-        self._sandbox = sandbox or YieldSandbox()
-        self._feedback = feedback or FeedbackCollector()
+        self._ledger = ledger or PilotPrivacyLedger()
+        if sandbox is None:
+            self._sandbox = YieldSandbox(ledger=self._ledger)
+        else:
+            self._sandbox = sandbox
+            if hasattr(self._sandbox, "attach_ledger"):
+                self._sandbox.attach_ledger(self._ledger)
+        if feedback is None:
+            self._feedback = FeedbackCollector(ledger=self._ledger)
+        else:
+            self._feedback = feedback
+            if hasattr(self._feedback, "attach_ledger"):
+                self._feedback.attach_ledger(self._ledger)
         self._session_log_path = session_log_path or storage.SESSION_LOG_PATH
 
     def _log_session(self, record: Dict[str, object]) -> None:
-        storage.append_jsonl(self._session_log_path, record)
+        if self._ledger:
+            self._ledger.record_reference(
+                partner_tag=record["partner_tag"],
+                reference_type="session",
+                payload=record,
+                metadata={
+                    "watermark_enabled": record.get("watermark_enabled", False),
+                    "protocols": record.get("protocols", []),
+                },
+            )
+        else:
+            storage.append_jsonl(self._session_log_path, record)
 
     def create(
         self,
@@ -119,11 +254,16 @@ class SessionFactory:
         partner: PartnerRecord,
         protocol_key: ProtocolKey,
         watermark_override: Optional[bool] = None,
+        protocols: Optional[Iterable[str]] = None,
+        simulate_real_user_load: bool = False,
+        load_multiplier: float = 1.0,
+        load_profile: Optional[Mapping[str, object]] = None,
     ) -> PilotSession:
         session_id = uuid.uuid4().hex
         watermark_enabled = (
             watermark_override if watermark_override is not None else protocol_key.watermark_enabled
         )
+        protocol_list = tuple(protocols or protocol_key.metadata.get("protocols", []))
         session = PilotSession(
             session_id=session_id,
             partner_id=partner.partner_id,
@@ -133,6 +273,8 @@ class SessionFactory:
             sandbox=self._sandbox,
             feedback=self._feedback,
             protocol_key=protocol_key,
+            ledger=self._ledger,
+            protocols=protocol_list,
         )
         log_record: Dict[str, object] = {
             "session_id": session_id,
@@ -145,6 +287,13 @@ class SessionFactory:
                 "usage_count": protocol_key.usage_count,
                 "max_uses": protocol_key.max_uses,
             },
+            "protocols": list(protocol_list),
         }
         self._log_session(log_record)
+        if simulate_real_user_load or load_profile:
+            session.toggle_real_user_load(
+                simulate_real_user_load,
+                load_multiplier=load_multiplier,
+                profile=load_profile,
+            )
         return session

--- a/vaultfire/pilot_mode/storage.py
+++ b/vaultfire/pilot_mode/storage.py
@@ -22,12 +22,14 @@ __all__ = [
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 PILOT_MODE_ROOT = _REPO_ROOT / "telemetry" / "pilot_mode"
+PRIVATE_LEDGER_ROOT = PILOT_MODE_ROOT / "private"
 PARTNER_REGISTRY_PATH = PILOT_MODE_ROOT / "partners.json"
 PROTOCOL_KEYS_PATH = PILOT_MODE_ROOT / "protocol_keys.json"
 SESSION_LOG_PATH = PILOT_MODE_ROOT / "sessions.jsonl"
 YIELD_LOG_PATH = PILOT_MODE_ROOT / "yield_log.jsonl"
 BEHAVIOR_LOG_PATH = PILOT_MODE_ROOT / "behavior_log.jsonl"
 FEEDBACK_LOG_PATH = PILOT_MODE_ROOT / "feedback.jsonl"
+PRIVATE_REFERENCE_LOG_PATH = PRIVATE_LEDGER_ROOT / "pilot_references.jsonl"
 
 _LOCK = Lock()
 


### PR DESCRIPTION
## Summary
- add a dedicated privacy ledger for pilot mode that stores encrypted anonymized references
- update pilot session workflow with load simulation toggles, staking, loyalty, and consent mirroring hooks
- ensure sandbox, feedback, and access layer use the private ledger and adjust tests for encrypted logging

## Testing
- pytest tests/test_pilot_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68e15ed7e2088322875729db573b25c2