### PR TITLE
Add partner assessment summary document

### DIFF
--- a/partner_assessment.md
+++ b/partner_assessment.md
@@ -1,0 +1,16 @@
+# Vaultfire Protocol Partner Assessment
+
+## Overall Impression
+Vaultfire positions itself as a belief-secured activation stack with a strong ethical governance wrapper. The repository demonstrates production-minded structure, automated testing culture, and extensive simulation artifacts, even while noting that only the Ghostkey-316 wallet pilot has executed live to date. The documentation is candid about the simulated nature of most case studies while providing a roadmap toward live readiness. 【F:README.md†L1-L120】【F:README.md†L121-L240】
+
+## Strengths Observed
+- **Transparent maturity signals:** The README and readiness blueprint outline simulation boundaries, readiness attestations, and automated checks (e.g., telemetry verification, guardian attestations) that signal disciplined operational thinking. 【F:README.md†L1-L160】【F:docs/live-rollout-readiness.md†L1-L80】
+- **Security-conscious core:** Core modules enforce wallet allowlisting and mandatory manifesto presence before activation, reducing the risk of unauthorized injections or misaligned deployments. 【F:vaultfire_core.js†L1-L120】
+- **Due diligence preparation:** Technical due diligence materials articulate threat models, mitigation steps, and audit history, which reduces onboarding friction for compliance-focused partners. 【F:docs/technical-due-diligence.md†L1-L80】
+
+## Gaps & Considerations
+- **Live deployment evidence:** Apart from the Ghostkey-316 wallet pilot, all showcased pilots remain simulations. Partners should account for additional validation cycles once real traffic flows, especially around telemetry sinks and revenue toggles. 【F:README.md†L1-L160】
+- **Operational complexity:** The breadth of tooling (CLI commands, scripts, readiness checks) is powerful but could challenge teams without dedicated enablement; bundling a quickstart runbook or interactive wizard may streamline adoption. 【F:README.md†L161-L240】
+
+## Recommendation
+While Vaultfire is not yet battle-tested at scale, the protocol exhibits thoughtful architecture, robust governance scaffolding, and clear ethical positioning. For partners aligned with wallet-first identity and willing to co-develop the first live cohorts, the potential appears high. Proceeding would make sense if accompanied by a joint validation plan that exercises the readiness blueprint, confirms telemetry safeguards, and stages revenue activation behind explicit compliance checkpoints. 【F:docs/live-rollout-readiness.md†L1-L120】【F:README.md†L1-L200】


### PR DESCRIPTION
## Summary
- add a partner-focused assessment summarizing Vaultfire strengths, gaps, and recommendation

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e1a0cdaf28832291136edfae24d1cb