### PR TITLE
Enable Vaultfire stealth pilot sandbox visibility

### DIFF
--- a/contributor_registry.json
+++ b/contributor_registry.json
@@ -13,6 +13,11 @@
       "ns3-ready"
     ],
     "ens": "ghostkey316.eth",
-    "title": "Core Architect of Vaultfire CLI"
+    "title": "Core Architect of Vaultfire CLI",
+    "metadata_lock": {
+      "wallet": "bpow20.cb.id",
+      "ens": "ghostkey316.eth"
+    },
+    "archive": "https://ghostkey316.cloud/index"
   }
 }

--- a/ghostkey_metadata_snapshot.json
+++ b/ghostkey_metadata_snapshot.json
@@ -1,9 +1,15 @@
 {
   "wallet": "bpow20.cb.id",
+  "ens": "ghostkey316.eth",
+  "metadata_lock": {
+    "wallet": "bpow20.cb.id",
+    "ens": "ghostkey316.eth"
+  },
+  "archive_url": "https://ghostkey316.cloud/index",
   "timestamp": "2025-08-21T22:25:18.099562+00:00",
   "checksums": {
     "ghostkey_asm_sync.py": "d328da60783eb030d0834aa77bc2e9aafcf96ba518f44d71227a3cab4a4c7a38",
-    "contributor_registry.json": "e9679a3ad0449fec83634ef9171bf1dbdf8b0eddb422b405a46d3aedb9798548"
+    "contributor_registry.json": "0085a01b955b5650de78b21399fd75e57949e6be55918e11d4f0d2c6d862c77c"
   },
   "commands": [
     "verify",

--- a/vaultfire-core/vaultfire_config.json
+++ b/vaultfire-core/vaultfire_config.json
@@ -23,5 +23,25 @@
     "mission": "Humanity First. Private. Decentralized. Ethical.",
     "loop_integrity_check": true,
     "partner_signal": "Ghostkey-316"
-  }
+  },
+  "stealth_pilot": {
+    "enabled": true,
+    "mode": "stealth-sandbox",
+    "notes": "Flagged for Codex Cloud stealth pilot activation.",
+    "visibility_channels": [
+      "OpenAI",
+      "NS3",
+      "Assemble AI"
+    ]
+  },
+  "partner_access": {
+    "scope": "pilot",
+    "sandbox_enabled": true,
+    "ping": true
+  },
+  "contributor_metadata_lock": {
+    "wallet": "bpow20.cb.id",
+    "ens": "ghostkey316.eth"
+  },
+  "contributor_archive": "https://ghostkey316.cloud/index"
 }

--- a/vaultfire_config.json
+++ b/vaultfire_config.json
@@ -33,5 +33,25 @@
     "ethics_priority_override": "enabled",
     "second_chance_window": "permanent",
     "public_forgiveness_layer": "active"
-  }
+  },
+  "stealth_pilot": {
+    "enabled": true,
+    "mode": "stealth-sandbox",
+    "notes": "Flagged for Codex Cloud stealth pilot activation.",
+    "visibility_channels": [
+      "OpenAI",
+      "NS3",
+      "Assemble AI"
+    ]
+  },
+  "partner_access": {
+    "scope": "pilot",
+    "sandbox_enabled": true,
+    "ping": true
+  },
+  "contributor_metadata_lock": {
+    "wallet": "bpow20.cb.id",
+    "ens": "ghostkey316.eth"
+  },
+  "contributor_archive": "https://ghostkey316.cloud/index"
 }

--- a/vaultfirerc.json
+++ b/vaultfirerc.json
@@ -1,6 +1,20 @@
 {
   "vaultfire": {
-    "partnerReady": true
+    "partnerReady": true,
+    "stealthPilot": true,
+    "partner": {
+      "scope": "pilot",
+      "sandboxEnabled": true,
+      "ping": true
+    },
+    "visibility": {
+      "backend": ["OpenAI", "NS3", "Assemble AI"]
+    },
+    "metadataLock": {
+      "wallet": "bpow20.cb.id",
+      "ens": "ghostkey316.eth",
+      "archive": "https://ghostkey316.cloud/index"
+    }
   },
   "deployment": {
     "defaultMode": "simulated",


### PR DESCRIPTION
## Summary
- flag Vaultfire configuration for stealth pilot mode and expose backend visibility to OpenAI, NS3, and Assemble AI
- enable partner sandbox ping plus metadata locks inside the runtime rc configuration
- anchor contributor registry records and snapshot metadata to the ghostkey316.cloud archive endpoint

## Testing
- npm run lint:guardrails

------
https://chatgpt.com/codex/tasks/task_e_68e2d150e6988322a0985dbe7b49dfd7