### PR TITLE
Integrate mission resonance telemetry into pilot mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Partners who want a step-by-step launch plan can review the new [Live Rollout Re
 - **Integrity snapshot for partners:** `MissionResonanceEngine.integrity_report()` exports a readiness digest (mission, blended resonance index, technique mix, and threshold check) that compliance teams can sign before a new cohort goes live.
 - **Confidential compute verification:** `ConfidentialComputeAttestor` pairs with `MissionResonanceEngine` so confidential-ML enclaves deliver remote-attested signals without exposing model weights or contributor telemetry.
 - **Real-time gradient telemetry:** `MissionResonanceEngine.resonance_gradient()` and `technique_breakdown()` surface time-based resonance deltas and per-technique averages, helping stewards catch mission drift before it impacts the covenant.
+- **Stealth pilot visibility:** [`PilotResonanceTelemetry`](./vaultfire/pilot_mode/resonance.py) feeds confidential-ML signals from pilot sessions into the ledger with gradient breakdowns and attested enclave manifests for private dashboards.
 
 ## Mission Covenant Chain (Foundational)
 - **Exclusive to Vaultfire:** The new `MissionCovenantLedger` forges an unstoppable covenant hash chain that no other protocol ships, binding every partner action to the canonical mission without drift.

--- a/tests/test_mission_resonance_engine.py
+++ b/tests/test_mission_resonance_engine.py
@@ -55,6 +55,8 @@ def test_integrity_report_exposes_breakdown_and_attested_enclaves() -> None:
     assert report["technique_breakdown"]["confidential-ml"]["count"] == 1
     assert report["technique_breakdown"]["edge-llm"]["avg_score"] == 0.75
     assert report["attested_enclaves"] == {"enclave-alpha": "verified", "enclave-beta": "verified"}
+    assert report["gradient_window_seconds"] == engine.gradient_window_seconds
+    assert "confidential-ml" in report["gradient_breakdown"]
 
 
 def test_resonance_gradient_uses_recent_window(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -93,3 +95,43 @@ def test_resonance_gradient_requires_positive_window() -> None:
 
     with pytest.raises(ValueError):
         engine.resonance_gradient(window_seconds=0)
+
+
+def test_technique_gradients_track_recent_and_historical(monkeypatch: pytest.MonkeyPatch) -> None:
+    attestor = _make_attestor()
+    engine = MissionResonanceEngine(confidential_attestor=attestor)
+
+    clock = {"now": 1_000_000.0}
+
+    def fake_time() -> float:
+        return clock["now"]
+
+    monkeypatch.setattr(mission_resonance.time, "time", fake_time)
+
+    engine.ingest_signal(source="historical-edge", technique="edge-llm", score=0.4)
+    engine.ingest_signal(
+        source="historical-confidential",
+        technique="confidential-ml",
+        score=0.5,
+        metadata={"enclave_id": "enclave-alpha", "measurement": "m-123"},
+    )
+
+    clock["now"] += 4000
+
+    engine.ingest_signal(source="recent-edge", technique="edge-llm", score=0.9)
+    engine.ingest_signal(
+        source="recent-confidential",
+        technique="confidential-ml",
+        score=0.7,
+        metadata={"enclave_id": "enclave-beta", "measurement": "m-456"},
+    )
+
+    gradients = engine.technique_gradients(window_seconds=3600)
+
+    assert gradients["edge-llm"]["recent_avg"] == pytest.approx(0.9, abs=1e-6)
+    assert gradients["edge-llm"]["historical_avg"] == pytest.approx(0.4, abs=1e-6)
+    assert gradients["edge-llm"]["gradient"] == pytest.approx(0.5, abs=1e-6)
+
+    assert gradients["confidential-ml"]["recent_avg"] == pytest.approx(0.7, abs=1e-6)
+    assert gradients["confidential-ml"]["historical_avg"] == pytest.approx(0.5, abs=1e-6)
+    assert gradients["confidential-ml"]["gradient"] == pytest.approx(0.2, abs=1e-6)

--- a/tests/test_pilot_mode.py
+++ b/tests/test_pilot_mode.py
@@ -183,3 +183,60 @@ def test_wallet_signature_activation_and_feedback_identity(tmp_path):
             wallet_signature=signature,
             signature_message=signature_message,
         )
+
+
+def test_resonance_signal_capture_and_visibility(tmp_path):
+    layer = PilotAccessLayer(accepted_enclaves={"enclave-alpha": "m-123"})
+
+    partner = layer.register_partner("stealth-ai", api_keys=["stealth-key"], default_watermark=False)
+    token = layer.issue_protocol_key(partner.partner_id, max_uses=5)
+
+    session = layer.activate_session(
+        partner.partner_id,
+        protocol_key=token,
+        api_key="stealth-key",
+    )
+
+    first_signal = session.capture_resonance_signal(
+        source="alpha-node",
+        technique="confidential-ml",
+        score=0.82,
+        metadata={"enclave_id": "enclave-alpha", "measurement": "m-123"},
+    )
+    assert first_signal.signal.technique == "confidential-ml"
+
+    with pytest.raises(PermissionError):
+        session.capture_resonance_signal(
+            source="beta-node",
+            technique="confidential-ml",
+            score=0.91,
+            metadata={"enclave_id": "enclave-beta", "measurement": "m-456"},
+        )
+
+    layer.register_confidential_enclave(enclave_id="enclave-beta", measurement="m-456")
+
+    second_signal = session.capture_resonance_signal(
+        source="beta-node",
+        technique="confidential-ml",
+        score=0.91,
+        metadata={"enclave_id": "enclave-beta", "measurement": "m-456"},
+    )
+    assert second_signal.signal.source == "beta-node"
+
+    digest = session.resonance_digest()
+    assert digest["signal_count"] == 2
+    assert "confidential-ml" in digest["gradient_breakdown"]
+
+    visibility = layer.pilot_visibility_digest()
+    assert visibility["signal_count"] == digest["signal_count"]
+    assert visibility["attested_enclaves"] == {
+        "enclave-alpha": "verified",
+        "enclave-beta": "verified",
+    }
+
+    references = _entries_of_type(_load_references(), "mission-resonance")
+    assert len(references) == 2
+    latest_entry, latest_payload = references[-1]
+    assert latest_payload["session_id"] == session.session_id
+    assert latest_entry["metadata"]["resonance_index"] == visibility["resonance_index"]
+    assert latest_entry["metadata"]["technique"] == "confidential-ml"

--- a/vaultfire/pilot_mode/__init__.py
+++ b/vaultfire/pilot_mode/__init__.py
@@ -5,6 +5,7 @@ from .feedback import FeedbackCollector, FeedbackRecord
 from .keys import ProtocolKey, ProtocolKeyManager
 from .privacy import PilotPrivacyLedger, PilotReference
 from .registry import PilotAccessRegistry, PartnerRecord
+from .resonance import PilotResonanceTelemetry
 from .sandbox import SandboxResult, YieldSandbox
 from .session import PilotSession, SessionFactory
 
@@ -18,6 +19,7 @@ __all__ = [
     "PartnerRecord",
     "PilotPrivacyLedger",
     "PilotReference",
+    "PilotResonanceTelemetry",
     "SandboxResult",
     "YieldSandbox",
     "PilotSession",

--- a/vaultfire/pilot_mode/access_layer.py
+++ b/vaultfire/pilot_mode/access_layer.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping, MutableMapping, Optional
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
 
 from .feedback import FeedbackCollector
 from .keys import ProtocolKeyManager
 from .privacy import PilotPrivacyLedger
 from .registry import PilotAccessRegistry, PartnerRecord
+from .resonance import PilotResonanceTelemetry
 from .sandbox import YieldSandbox
 from .session import PilotSession, SessionFactory
 
@@ -25,6 +26,9 @@ class PilotAccessLayer:
         sandbox: Optional[YieldSandbox] = None,
         feedback: Optional[FeedbackCollector] = None,
         ledger: Optional[PilotPrivacyLedger] = None,
+        resonance: Optional[PilotResonanceTelemetry] = None,
+        accepted_enclaves: Optional[Mapping[str, str]] = None,
+        gradient_window_seconds: Optional[float] = None,
     ) -> None:
         self._registry = registry or PilotAccessRegistry()
         self._keys = key_manager or ProtocolKeyManager()
@@ -35,10 +39,16 @@ class PilotAccessLayer:
         feedback_instance = feedback or FeedbackCollector(ledger=self._ledger)
         if feedback and hasattr(feedback, "attach_ledger"):
             feedback.attach_ledger(self._ledger)
+        self._resonance = resonance or PilotResonanceTelemetry(
+            ledger=self._ledger,
+            accepted_measurements=accepted_enclaves,
+            gradient_window_seconds=gradient_window_seconds,
+        )
         self._session_factory = SessionFactory(
             sandbox=sandbox_instance,
             feedback=feedback_instance,
             ledger=self._ledger,
+            resonance=self._resonance,
         )
 
     @property
@@ -52,6 +62,10 @@ class PilotAccessLayer:
     @property
     def ledger(self) -> PilotPrivacyLedger:
         return self._ledger
+
+    @property
+    def resonance(self) -> PilotResonanceTelemetry:
+        return self._resonance
 
     def register_partner(
         self,
@@ -138,3 +152,13 @@ class PilotAccessLayer:
 
     def prune_expired_keys(self) -> None:
         self._keys.prune_expired()
+
+    def register_confidential_enclave(self, *, enclave_id: str, measurement: str) -> None:
+        """Allow runtime registration of attested enclaves."""
+
+        self._resonance.register_enclave(enclave_id=enclave_id, measurement=measurement)
+
+    def pilot_visibility_digest(self) -> Dict[str, Any]:
+        """Expose mission resonance integrity for private pilot dashboards."""
+
+        return self._resonance.integrity_digest()

--- a/vaultfire/pilot_mode/resonance.py
+++ b/vaultfire/pilot_mode/resonance.py
@@ -1,0 +1,176 @@
+"""Mission resonance telemetry pipeline for Vaultfire pilot sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+
+from vaultfire.protocol.mission_resonance import (
+    ConfidentialComputeAttestor,
+    MissionResonanceEngine,
+    MissionSignal,
+)
+
+from .privacy import PilotPrivacyLedger
+
+__all__ = ["ResonanceSignal", "PilotResonanceTelemetry"]
+
+
+@dataclass(slots=True)
+class ResonanceSignal:
+    """Structured record for mission resonance telemetry exports."""
+
+    session_id: str
+    partner_tag: str
+    signal: MissionSignal
+    integrity_digest: Dict[str, Any]
+
+    def export_payload(self) -> Dict[str, Any]:
+        """Return a JSON serializable payload for private ledger storage."""
+
+        payload: Dict[str, Any] = {
+            "session_id": self.session_id,
+            "partner_tag": self.partner_tag,
+            "technique": self.signal.technique,
+            "source": self.signal.source,
+            "score": self.signal.score,
+            "timestamp": self.signal.timestamp,
+            "mission_snapshot": self.signal.mission_snapshot,
+            "metadata": dict(self.signal.metadata),
+        }
+        return payload
+
+    def export_metadata(self) -> Dict[str, Any]:
+        """Return summary metadata suitable for ledger annotations."""
+
+        metadata = {
+            "technique": self.signal.technique,
+            "resonance_index": self.integrity_digest["resonance_index"],
+            "resonance_gradient": self.integrity_digest["resonance_gradient"],
+            "gradient_window_seconds": self.integrity_digest["gradient_window_seconds"],
+            "meets_threshold": self.integrity_digest["meets_threshold"],
+        }
+        return metadata
+
+
+class PilotResonanceTelemetry:
+    """Wraps :class:`MissionResonanceEngine` for pilot mode telemetry."""
+
+    def __init__(
+        self,
+        *,
+        ledger: Optional[PilotPrivacyLedger] = None,
+        mission_engine: Optional[MissionResonanceEngine] = None,
+        confidential_attestor: Optional[ConfidentialComputeAttestor] = None,
+        accepted_measurements: Optional[Mapping[str, str]] = None,
+        gradient_window_seconds: Optional[float] = None,
+    ) -> None:
+        self._ledger = ledger
+        accepted: MutableMapping[str, str] = {
+            enclave: measurement
+            for enclave, measurement in (accepted_measurements or {}).items()
+            if enclave and measurement
+        }
+        if mission_engine is not None:
+            self._engine = mission_engine
+            if confidential_attestor is not None:
+                self._engine.attach_attestor(confidential_attestor)
+                self._attestor = confidential_attestor
+            else:
+                existing = self._engine.attestor
+                if existing is None:
+                    existing = ConfidentialComputeAttestor(accepted_measurements=accepted)
+                    self._engine.attach_attestor(existing)
+                else:
+                    for enclave, measurement in accepted.items():
+                        existing.register(enclave_id=enclave, measurement=measurement)
+                self._attestor = existing
+        else:
+            attestor = confidential_attestor or ConfidentialComputeAttestor(
+                accepted_measurements=accepted
+            )
+            engine_window = (
+                gradient_window_seconds
+                if gradient_window_seconds is not None
+                else None
+            )
+            if engine_window is None:
+                self._engine = MissionResonanceEngine(confidential_attestor=attestor)
+            else:
+                self._engine = MissionResonanceEngine(
+                    confidential_attestor=attestor,
+                    gradient_window_seconds=engine_window,
+                )
+            self._attestor = attestor
+        self._gradient_window = (
+            gradient_window_seconds
+            if gradient_window_seconds is not None
+            else self._engine.gradient_window_seconds
+        )
+
+    @property
+    def engine(self) -> MissionResonanceEngine:
+        return self._engine
+
+    @property
+    def attestor(self) -> ConfidentialComputeAttestor:
+        return self._attestor
+
+    @property
+    def gradient_window_seconds(self) -> float:
+        return self._gradient_window
+
+    def register_enclave(self, *, enclave_id: str, measurement: str) -> None:
+        """Register additional attested enclaves for confidential telemetry."""
+
+        self._attestor.register(enclave_id=enclave_id, measurement=measurement)
+
+    def ingest_signal(
+        self,
+        *,
+        partner_tag: str,
+        session_id: str,
+        source: str,
+        technique: str,
+        score: float,
+        metadata: Optional[Mapping[str, Any]] = None,
+        mission_override: Optional[str] = None,
+    ) -> ResonanceSignal:
+        """Capture a mission resonance signal and persist a private record."""
+
+        signal = self._engine.ingest_signal(
+            source=source,
+            technique=technique,
+            score=score,
+            metadata=metadata,
+            mission_override=mission_override,
+        )
+        digest = self._engine.integrity_report(
+            gradient_window_seconds=self._gradient_window
+        )
+        record = ResonanceSignal(
+            session_id=session_id,
+            partner_tag=partner_tag,
+            signal=signal,
+            integrity_digest=digest,
+        )
+        if self._ledger is not None:
+            self._ledger.record_reference(
+                partner_tag=partner_tag,
+                reference_type="mission-resonance",
+                payload=record.export_payload(),
+                metadata=record.export_metadata(),
+            )
+        return record
+
+    def integrity_digest(self) -> Dict[str, Any]:
+        """Return the current mission resonance integrity snapshot."""
+
+        return self._engine.integrity_report(
+            gradient_window_seconds=self._gradient_window
+        )
+
+    def attested_manifest(self) -> Mapping[str, str]:
+        """Expose the attested enclave manifest."""
+
+        return self._attestor.manifest()

--- a/vaultfire/pilot_mode/session.py
+++ b/vaultfire/pilot_mode/session.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Dict, Iterable, Mapping, MutableMapping, Optional
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
 
 from .feedback import FeedbackCollector
 from .keys import ProtocolKey
 from .registry import PartnerRecord
 from .sandbox import YieldSandbox
 from .privacy import PilotPrivacyLedger
+from .resonance import PilotResonanceTelemetry, ResonanceSignal
 from . import storage
 
 __all__ = ["PilotSession", "SessionFactory"]
@@ -30,6 +31,7 @@ class PilotSession:
     feedback: FeedbackCollector
     protocol_key: ProtocolKey
     ledger: PilotPrivacyLedger
+    resonance: Optional[PilotResonanceTelemetry] = None
     protocols: tuple[str, ...] = ()
     real_load_enabled: bool = False
     load_multiplier: float = 1.0
@@ -207,6 +209,36 @@ class PilotSession:
             "load_profile": dict(self.load_profile),
         }
 
+    def capture_resonance_signal(
+        self,
+        *,
+        source: str,
+        technique: str,
+        score: float,
+        metadata: Optional[Mapping[str, Any]] = None,
+        mission_override: Optional[str] = None,
+    ) -> ResonanceSignal:
+        """Ingest a mission resonance signal for this pilot session."""
+
+        if self.resonance is None:
+            raise RuntimeError("resonance telemetry is not configured for this session")
+        return self.resonance.ingest_signal(
+            partner_tag=self.partner_tag,
+            session_id=self.session_id,
+            source=source,
+            technique=technique,
+            score=score,
+            metadata=metadata,
+            mission_override=mission_override,
+        )
+
+    def resonance_digest(self) -> Dict[str, Any]:
+        """Return the mission resonance integrity digest for this session."""
+
+        if self.resonance is None:
+            return {}
+        return self.resonance.integrity_digest()
+
 
 class SessionFactory:
     """Factory for initializing pilot sessions with logging."""
@@ -218,6 +250,7 @@ class SessionFactory:
         feedback: Optional[FeedbackCollector] = None,
         session_log_path=None,
         ledger: Optional[PilotPrivacyLedger] = None,
+        resonance: Optional[PilotResonanceTelemetry] = None,
     ) -> None:
         self._ledger = ledger or PilotPrivacyLedger()
         if sandbox is None:
@@ -233,6 +266,7 @@ class SessionFactory:
             if hasattr(self._feedback, "attach_ledger"):
                 self._feedback.attach_ledger(self._ledger)
         self._session_log_path = session_log_path or storage.SESSION_LOG_PATH
+        self._resonance = resonance
 
     def _log_session(self, record: Dict[str, object]) -> None:
         if self._ledger:
@@ -274,6 +308,7 @@ class SessionFactory:
             feedback=self._feedback,
             protocol_key=protocol_key,
             ledger=self._ledger,
+            resonance=self._resonance,
             protocols=protocol_list,
         )
         log_record: Dict[str, object] = {

--- a/vaultfire/protocol/mission_resonance.py
+++ b/vaultfire/protocol/mission_resonance.py
@@ -107,11 +107,15 @@ class MissionResonanceEngine:
         post_quantum_verifier: PostQuantumSignatureVerifier | None = None,
         confidential_attestor: ConfidentialComputeAttestor | None = None,
         default_threshold: float = 0.72,
+        gradient_window_seconds: float = 3600.0,
     ) -> None:
         self._signals: MutableSequence[MissionSignal] = []
         self._verifier = post_quantum_verifier
         self._attestor = confidential_attestor
         self._threshold = default_threshold
+        if gradient_window_seconds <= 0:
+            raise ValueError("gradient_window_seconds must be positive")
+        self._gradient_window = float(gradient_window_seconds)
 
     @property
     def mission(self) -> str:
@@ -120,6 +124,25 @@ class MissionResonanceEngine:
     @property
     def signals(self) -> Sequence[MissionSignal]:
         return tuple(self._signals)
+
+    @property
+    def gradient_window_seconds(self) -> float:
+        """Return the default gradient window used for telemetry snapshots."""
+
+        return self._gradient_window
+
+    @property
+    def attestor(self) -> ConfidentialComputeAttestor | None:
+        """Return the configured confidential compute attestor, if any."""
+
+        return self._attestor
+
+    def attach_attestor(self, attestor: ConfidentialComputeAttestor) -> None:
+        """Attach ``attestor`` to the engine for confidential ML verification."""
+
+        if attestor is None:
+            raise ValueError("attestor must be provided")
+        self._attestor = attestor
 
     def ingest_signal(
         self,
@@ -180,9 +203,16 @@ class MissionResonanceEngine:
         scores = [signal.score for signal in self._signals]
         return round(fmean(scores), 4)
 
-    def integrity_report(self) -> Dict[str, Any]:
+    def integrity_report(self, *, gradient_window_seconds: float | None = None) -> Dict[str, Any]:
         """Summarise mission protection posture for dashboards and attestations."""
 
+        window = (
+            float(gradient_window_seconds)
+            if gradient_window_seconds is not None
+            else self._gradient_window
+        )
+        if window <= 0:
+            raise ValueError("gradient_window_seconds must be positive")
         resonance = self.resonance_index()
         contributing_techniques = {
             signal.technique for signal in self._signals
@@ -194,7 +224,9 @@ class MissionResonanceEngine:
             "techniques": sorted(contributing_techniques),
             "signal_count": len(self._signals),
             "technique_breakdown": self.technique_breakdown(),
-            "resonance_gradient": self.resonance_gradient(),
+            "resonance_gradient": self.resonance_gradient(window_seconds=window),
+            "gradient_window_seconds": window,
+            "gradient_breakdown": self.technique_gradients(window_seconds=window),
             "attested_enclaves": self._attestor.manifest() if self._attestor else {},
         }
 
@@ -219,10 +251,11 @@ class MissionResonanceEngine:
             }
         return dict(sorted(breakdown.items()))
 
-    def resonance_gradient(self, window_seconds: float = 3600.0) -> float:
+    def resonance_gradient(self, window_seconds: float | None = None) -> float:
         """Compute the mission resonance delta between recent and historical signals."""
 
-        if window_seconds <= 0:
+        window = window_seconds if window_seconds is not None else self._gradient_window
+        if window <= 0:
             raise ValueError("window_seconds must be positive")
         if not self._signals:
             return 0.0
@@ -230,11 +263,41 @@ class MissionResonanceEngine:
         recent: MutableSequence[float] = []
         historical: MutableSequence[float] = []
         for signal in self._signals:
-            bucket = recent if now - signal.timestamp <= window_seconds else historical
+            bucket = recent if now - signal.timestamp <= window else historical
             bucket.append(signal.score)
         if not recent or not historical:
             return 0.0
         return round(fmean(recent) - fmean(historical), 4)
+
+    def technique_gradients(
+        self, window_seconds: float | None = None
+    ) -> Dict[str, Dict[str, float]]:
+        """Return gradient metrics per technique using ``window_seconds`` buckets."""
+
+        window = window_seconds if window_seconds is not None else self._gradient_window
+        if window <= 0:
+            raise ValueError("window_seconds must be positive")
+        if not self._signals:
+            return {}
+        now = time.time()
+        recent_scores: MutableMapping[str, MutableSequence[float]] = defaultdict(list)
+        historical_scores: MutableMapping[str, MutableSequence[float]] = defaultdict(list)
+        for signal in self._signals:
+            bucket = recent_scores if now - signal.timestamp <= window else historical_scores
+            bucket[signal.technique].append(signal.score)
+        techniques = set(recent_scores) | set(historical_scores)
+        gradients: Dict[str, Dict[str, float]] = {}
+        for technique in sorted(techniques):
+            recent_list = recent_scores.get(technique, [])
+            historical_list = historical_scores.get(technique, [])
+            recent_avg = round(fmean(recent_list), 4) if recent_list else 0.0
+            historical_avg = round(fmean(historical_list), 4) if historical_list else 0.0
+            gradients[technique] = {
+                "recent_avg": recent_avg,
+                "historical_avg": historical_avg,
+                "gradient": round(recent_avg - historical_avg, 4),
+            }
+        return gradients
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- add gradient window configuration and technique gradient reporting to the mission resonance engine
- introduce pilot-mode resonance telemetry with confidential compute attestation and private ledger exports
- wire resonance telemetry into pilot activation/session flows and document stealth pilot visibility support

## Testing
- pytest tests/test_mission_resonance_engine.py tests/test_pilot_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68e2d5aa6b308322899d354abf4e8747