### PR TITLE
Add Ghostkey Vaultfire Agent orchestration module

### DIFF
--- a/tests/test_ghostkey_vaultfire_agent.py
+++ b/tests/test_ghostkey_vaultfire_agent.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vaultfire.pilot_mode import (
+    FeedbackCollector,
+    PilotAccessLayer,
+    PilotPrivacyLedger,
+    PilotResonanceTelemetry,
+    PilotSession,
+    ProtocolKeyManager,
+    YieldSandbox,
+    GhostkeyVaultfireAgent,
+    PilotAccessRegistry,
+)
+
+
+def _make_access_layer(tmp_path: Path) -> PilotAccessLayer:
+    ledger_path = tmp_path / "ledger.jsonl"
+    ledger = PilotPrivacyLedger(reference_log_path=ledger_path)
+    registry = PilotAccessRegistry(path=tmp_path / "partners.json")
+    key_manager = ProtocolKeyManager(path=tmp_path / "protocol_keys.json")
+    sandbox = YieldSandbox(
+        ledger=ledger,
+        yield_log_path=tmp_path / "yield.jsonl",
+        behavior_log_path=tmp_path / "behavior.jsonl",
+    )
+    feedback = FeedbackCollector(log_path=tmp_path / "feedback.jsonl", ledger=ledger)
+    resonance = PilotResonanceTelemetry(
+        ledger=ledger,
+        gradient_window_seconds=600,
+    )
+    return PilotAccessLayer(
+        registry=registry,
+        key_manager=key_manager,
+        sandbox=sandbox,
+        feedback=feedback,
+        ledger=ledger,
+        resonance=resonance,
+    )
+
+
+def _bootstrap_session(agent: GhostkeyVaultfireAgent, *, api_key: str = "ghost-api") -> PilotSession:
+    registration = agent.onboard_contributor(
+        "ghost-partner",
+        api_keys=[api_key],
+        wallet_addresses=["0xABC"],
+        metadata={"tier": "pilot"},
+        watermark=True,
+    )
+    protocol_key = registration["protocol_key"]
+    session = agent.verify_trust(
+        "ghost-partner",
+        protocol_key=protocol_key,
+        api_key=api_key,
+        protocols=("Vaultfire", "Pilot"),
+    )
+    session.capture_resonance_signal(
+        source="edge-node",
+        technique="edge-llm",
+        score=0.84,
+    )
+    return session
+
+
+def test_agent_launch_exposes_configuration(tmp_path: Path) -> None:
+    access_layer = _make_access_layer(tmp_path)
+    agent = GhostkeyVaultfireAgent(access_layer=access_layer)
+
+    _bootstrap_session(agent)
+
+    state = agent.launch(mode="pre-release", sync_with_devday_tools=True)
+
+    assert state.mode == "pre-release"
+    assert state.sync_with_devday_tools is True
+    assert state.resonance_digest["signal_count"] == 1
+    assert state.resonance_configuration["gradient_window_seconds"] == pytest.approx(600)
+    assert "technique_breakdown" in state.resonance_configuration
+    assert state.widgets["YieldDashboard"]["active"] is True
+    assert agent.mission in state.mission_commitments.get("mission", agent.mission)
+
+
+def test_enable_stealth_pilot_logs_mission_control(tmp_path: Path) -> None:
+    access_layer = _make_access_layer(tmp_path)
+    agent = GhostkeyVaultfireAgent(access_layer=access_layer)
+
+    session = _bootstrap_session(agent)
+
+    response = agent.enable_stealth_pilot(
+        session,
+        allow_confidential_sessions=True,
+        grant_corporate_protocols_like_ASM_private_access=True,
+        auto_expire_on_signal_mismatch=True,
+    )
+
+    assert response["session_id"] == session.session_id
+    assert response["stealth"]["allow_confidential_sessions"] is True
+    assert response["mission_control"]["reference_id"]
+
+    ledger_path = tmp_path / "ledger.jsonl"
+    payload = json.loads(ledger_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert payload["reference_type"] == "mission-control"
+    assert payload["metadata"]["component"] == "resonance-telemetry"
+

--- a/vaultfire/pilot_mode/__init__.py
+++ b/vaultfire/pilot_mode/__init__.py
@@ -2,6 +2,14 @@
 
 from .access_layer import PilotAccessLayer
 from .feedback import FeedbackCollector, FeedbackRecord
+from .ghostkey_agent import (
+    AgentConfig,
+    AgentLaunchState,
+    AgentWidget,
+    AgentWorkflow,
+    GhostkeyVaultfireAgent,
+    MissionControlPoints,
+)
 from .keys import ProtocolKey, ProtocolKeyManager
 from .privacy import PilotPrivacyLedger, PilotReference
 from .registry import PilotAccessRegistry, PartnerRecord
@@ -13,6 +21,12 @@ __all__ = [
     "PilotAccessLayer",
     "FeedbackCollector",
     "FeedbackRecord",
+    "AgentConfig",
+    "AgentLaunchState",
+    "AgentWidget",
+    "AgentWorkflow",
+    "GhostkeyVaultfireAgent",
+    "MissionControlPoints",
     "ProtocolKey",
     "ProtocolKeyManager",
     "PilotAccessRegistry",

--- a/vaultfire/pilot_mode/ghostkey_agent.py
+++ b/vaultfire/pilot_mode/ghostkey_agent.py
@@ -1,0 +1,353 @@
+"""Ghostkey Vaultfire agent orchestration helpers for Agent Builder integration.
+
+This module wires the existing pilot mode infrastructure together so the
+"Ghostkey Vaultfire Agent" described in the DevDay rollout brief can be
+instantiated programmatically.  The agent surface coordinates Mission
+Control Points (MCP), ChatKit-style widgets, stealth pilot toggles, and
+Codex integrity reporting on top of :class:`~vaultfire.pilot_mode.PilotAccessLayer`.
+
+It intentionally avoids network calls and keeps all behaviour deterministic
+so automated tests and CI can exercise the flows without external services.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional, Tuple
+
+from vaultfire.enterprise.mission_control import EnterpriseMissionControl
+
+from .access_layer import PilotAccessLayer
+from .privacy import PilotPrivacyLedger
+from .resonance import PilotResonanceTelemetry
+from .session import PilotSession
+
+__all__ = [
+    "AgentWidget",
+    "AgentWorkflow",
+    "AgentConfig",
+    "AgentLaunchState",
+    "MissionControlPoints",
+    "GhostkeyVaultfireAgent",
+]
+
+
+@dataclass(frozen=True)
+class AgentWidget:
+    """Representation of a ChatKit widget exposed by the agent."""
+
+    name: str
+    description: str
+    config: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AgentWorkflow:
+    """Metadata for an agentic workflow that can be triggered."""
+
+    name: str
+    description: str
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    """Static configuration for the Ghostkey Vaultfire agent."""
+
+    name: str
+    instructions: str
+    codex_integrity: str
+    model: str
+    temperature: float
+    tools: Tuple[str, ...]
+    widgets: Tuple[AgentWidget, ...]
+    workflows: Tuple[AgentWorkflow, ...]
+
+
+@dataclass
+class AgentLaunchState:
+    """Runtime state emitted after :meth:`GhostkeyVaultfireAgent.launch`."""
+
+    mode: str
+    sync_with_devday_tools: bool
+    resonance_digest: Dict[str, object]
+    resonance_configuration: Dict[str, object]
+    mission_commitments: Dict[str, object]
+    codex_integrity: str
+    tools: Tuple[str, ...]
+    widgets: Dict[str, Dict[str, object]]
+
+
+class MissionControlPoints:
+    """Utility for logging Mission Control telemetry references."""
+
+    def __init__(
+        self,
+        *,
+        ledger: PilotPrivacyLedger,
+        telemetry: PilotResonanceTelemetry,
+    ) -> None:
+        self._ledger = ledger
+        self._telemetry = telemetry
+
+    def log_resonance(self, *, partner_tag: str, session_id: str) -> Dict[str, object]:
+        """Persist a resonance digest to the pilot ledger and return metadata."""
+
+        digest = self._telemetry.integrity_digest()
+        reference = self._ledger.record_reference(
+            partner_tag=partner_tag,
+            reference_type="mission-control",
+            payload=digest,
+            metadata={
+                "component": "resonance-telemetry",
+                "session_id": session_id,
+                "mcp": True,
+            },
+        )
+        return {"reference_id": reference.reference_id, "digest": digest}
+
+
+class GhostkeyVaultfireAgent:
+    """High-level orchestrator for the Ghostkey Vaultfire Agent."""
+
+    def __init__(
+        self,
+        *,
+        access_layer: PilotAccessLayer,
+        mission_control: Optional[EnterpriseMissionControl] = None,
+        config: Optional[AgentConfig] = None,
+    ) -> None:
+        self._access_layer = access_layer
+        self._mission_control = mission_control or EnterpriseMissionControl()
+        self._telemetry = access_layer.resonance
+        self._ledger = access_layer.ledger
+        self._mcp = MissionControlPoints(ledger=self._ledger, telemetry=self._telemetry)
+        self._active_sessions: Dict[str, PilotSession] = {}
+        self._stealth_sessions: Dict[str, Dict[str, object]] = {}
+        self._widget_state: Dict[str, Dict[str, object]] = {}
+        self._last_display: Optional[str] = None
+        self._resonance_configuration: Dict[str, object] = {}
+
+        if config is None:
+            config = AgentConfig(
+                name="Ghostkey Vaultfire Agent",
+                instructions=(
+                    "You are the origin agent of Vaultfire. Your mission is to run "
+                    "belief-based loyalty flows, activate passive systems, validate "
+                    "contributors via telemetry, and prepare for global rollout."
+                ),
+                codex_integrity="10/10",
+                model="gpt-4o",
+                temperature=0.2,
+                tools=("MCP", "ChatKit", "StealthPilot", "VaultfireCodex"),
+                widgets=(
+                    AgentWidget(
+                        name="YieldDashboard",
+                        description="Passive yield telemetry overview",
+                        config={"bind_wallet": "bpow20.cb.id"},
+                    ),
+                    AgentWidget(
+                        name="ContributorScanner",
+                        description="Contributor verification panel",
+                        config={"mode": "passive"},
+                    ),
+                    AgentWidget(
+                        name="RoleGate",
+                        description="Role interface for Ghostkey lineage checks",
+                        config={"default_role": "Ghostkey-316"},
+                    ),
+                    AgentWidget(
+                        name="ResonanceLogs",
+                        description="Mission resonance telemetry feed",
+                        config={"store_in_codex": True},
+                    ),
+                ),
+                workflows=(
+                    AgentWorkflow(
+                        name="PilotFlow",
+                        description="Activate pilot sessions with telemetry guards",
+                    ),
+                    AgentWorkflow(
+                        name="ContributorOnboarding",
+                        description="Automate contributor validation and access keys",
+                    ),
+                    AgentWorkflow(
+                        name="YieldAudit",
+                        description="Run passive yield audits via sandbox simulations",
+                    ),
+                    AgentWorkflow(
+                        name="ResonanceTelemetry",
+                        description="Stream resonance gradients into Mission Control",
+                    ),
+                ),
+            )
+        self.config = config
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+    @property
+    def mission(self) -> str:
+        """Return the mission statement bound to the agent."""
+
+        return self._mission_control.mission
+
+    @property
+    def widgets_summary(self) -> Mapping[str, Dict[str, object]]:
+        """Return the most recent widget activation status."""
+
+        return dict(self._widget_state)
+
+    @property
+    def stealth_sessions(self) -> Mapping[str, Dict[str, object]]:
+        """Return metadata about stealth sessions activated by the agent."""
+
+        return dict(self._stealth_sessions)
+
+    @property
+    def last_display_message(self) -> Optional[str]:
+        """Return the last message provided to :meth:`display`."""
+
+        return self._last_display
+
+    # ------------------------------------------------------------------
+    # Core behaviours
+    # ------------------------------------------------------------------
+    def configure_resonance_monitor(
+        self,
+        *,
+        gradient_windows: bool = True,
+        technique_breakdown: bool = True,
+    ) -> Dict[str, object]:
+        """Derive the active resonance monitor configuration."""
+
+        digest = self._access_layer.pilot_visibility_digest()
+        configuration: Dict[str, object] = {}
+        if gradient_windows:
+            configuration["gradient_window_seconds"] = digest.get("gradient_window_seconds")
+            configuration["resonance_gradient"] = digest.get("resonance_gradient")
+        if technique_breakdown:
+            configuration["technique_breakdown"] = digest.get("technique_breakdown", {})
+        self._resonance_configuration = configuration
+        return configuration
+
+    def launch(self, *, mode: str = "pre-release", sync_with_devday_tools: bool = True) -> AgentLaunchState:
+        """Activate the agent, returning the launch state summary."""
+
+        widget_state: Dict[str, Dict[str, object]] = {}
+        for widget in self.config.widgets:
+            widget_state[widget.name] = {
+                "description": widget.description,
+                "config": dict(widget.config),
+                "active": True,
+            }
+        self._widget_state = widget_state
+
+        commitments = self._mission_control.refresh_commitments()
+        resonance_digest = self._access_layer.pilot_visibility_digest()
+        resonance_config = self.configure_resonance_monitor()
+
+        return AgentLaunchState(
+            mode=mode,
+            sync_with_devday_tools=sync_with_devday_tools,
+            resonance_digest=resonance_digest,
+            resonance_configuration=resonance_config,
+            mission_commitments=commitments,
+            codex_integrity=self.config.codex_integrity,
+            tools=self.config.tools,
+            widgets=widget_state,
+        )
+
+    def display(self, message: str) -> str:
+        """Persist a status message for downstream dashboards."""
+
+        self._last_display = message
+        return message
+
+    # ------------------------------------------------------------------
+    # Agentic workflows
+    # ------------------------------------------------------------------
+    def onboard_contributor(
+        self,
+        partner_id: str,
+        *,
+        api_keys: Iterable[str],
+        wallet_addresses: Iterable[str],
+        metadata: Optional[MutableMapping[str, object]] = None,
+        watermark: bool = False,
+    ) -> Dict[str, object]:
+        """Register a contributor and issue a protocol key for onboarding."""
+
+        record = self._access_layer.register_partner(
+            partner_id,
+            api_keys=api_keys,
+            wallet_addresses=wallet_addresses,
+            default_watermark=watermark,
+            metadata=metadata,
+        )
+        protocol_key = self._access_layer.issue_protocol_key(
+            partner_id,
+            metadata={"source": "GhostkeyVaultfireAgent"},
+        )
+        return {"partner": record, "protocol_key": protocol_key}
+
+    def verify_trust(
+        self,
+        partner_id: str,
+        *,
+        protocol_key: str,
+        api_key: Optional[str] = None,
+        wallet_address: Optional[str] = None,
+        wallet_signature: Optional[str] = None,
+        protocols: Optional[Iterable[str]] = None,
+        simulate_real_user_load: bool = False,
+        load_multiplier: float = 1.0,
+    ) -> PilotSession:
+        """Activate a pilot session, returning the session handle."""
+
+        session = self._access_layer.activate_session(
+            partner_id,
+            protocol_key=protocol_key,
+            api_key=api_key,
+            wallet_address=wallet_address,
+            wallet_signature=wallet_signature,
+            protocols=protocols,
+            simulate_real_user_load=simulate_real_user_load,
+            load_multiplier=load_multiplier,
+        )
+        self._active_sessions[session.session_id] = session
+        return session
+
+    def enable_stealth_pilot(
+        self,
+        session: PilotSession,
+        *,
+        allow_confidential_sessions: bool = True,
+        grant_corporate_protocols_like_ASM_private_access: bool = True,
+        auto_expire_on_signal_mismatch: bool = True,
+    ) -> Dict[str, object]:
+        """Enable stealth mode for ``session`` and log Mission Control telemetry."""
+
+        settings = {
+            "allow_confidential_sessions": bool(allow_confidential_sessions),
+            "grant_corporate_protocols_like_ASM_private_access": bool(
+                grant_corporate_protocols_like_ASM_private_access
+            ),
+            "auto_expire_on_signal_mismatch": bool(auto_expire_on_signal_mismatch),
+        }
+        mission_record = self._mcp.log_resonance(
+            partner_tag=session.partner_tag,
+            session_id=session.session_id,
+        )
+        digest = session.resonance_digest() or mission_record["digest"]
+        self._stealth_sessions[session.session_id] = {
+            "partner_tag": session.partner_tag,
+            "settings": settings,
+            "resonance_digest": digest,
+        }
+        return {
+            "session_id": session.session_id,
+            "stealth": settings,
+            "mission_control": mission_record,
+            "resonance_digest": digest,
+        }
+


### PR DESCRIPTION
## Summary
- add a GhostkeyVaultfireAgent orchestrator that wires Mission Control, resonance telemetry, and ChatKit-style widgets for the DevDay pilot agent
- expose the new agent helpers from the pilot_mode package so downstream tooling can import them
- cover the launch and stealth workflows with targeted pytest coverage

## Testing
- pytest tests/test_ghostkey_vaultfire_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68e2e53a72ec8322b176f999c5366d40