### PR TITLE
Add GhostkeyVaultfireAgent widget bundle for Agent Builder

### DIFF
--- a/vaultfire_widget_bundle/__init__.py
+++ b/vaultfire_widget_bundle/__init__.py
@@ -1,0 +1,49 @@
+"""Bundle packaging for the Ghostkey Vaultfire Agent Builder widget.
+
+This module exposes helper factories used by OpenAI's Agent Builder to
+wire the widget configuration with telemetry streaming utilities and
+Mission Control automation hooks.  The bundle is intentionally lightweight
+so the files can be uploaded directly to the Agent Builder UI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Mapping
+
+from .telemetry.gradient_stream import GradientStreamPacket, GradientStreamer
+from .telemetry.mission_hooks import MissionControlHooks
+from .mcp.signal_handler import MissionSignalResponder
+
+__all__ = [
+    "GradientStreamPacket",
+    "GradientStreamer",
+    "MissionControlHooks",
+    "MissionSignalResponder",
+    "load_widget_config",
+]
+
+
+def load_widget_config(base_path: Path | None = None) -> Mapping[str, object]:
+    """Return the parsed widget configuration as a mapping.
+
+    Parameters
+    ----------
+    base_path:
+        Optional base directory that contains :mod:`vaultfire_widget.json`.
+        When omitted, the file is resolved relative to this module.
+    """
+
+    if base_path is None:
+        base_path = Path(__file__).parent
+    config_path = base_path / "vaultfire_widget.json"
+    data = config_path.read_text(encoding="utf-8")
+    import json
+
+    return json.loads(data)
+
+
+def iter_stream_packets(streamer: GradientStreamer) -> Iterable[GradientStreamPacket]:
+    """Expose the gradient packets as an iterator for Agent Builder."""
+
+    return streamer.iter_packets()

--- a/vaultfire_widget_bundle/mcp/signal_handler.py
+++ b/vaultfire_widget_bundle/mcp/signal_handler.py
@@ -1,0 +1,92 @@
+"""Minimal MCP signal responder for the GhostkeyVaultfireAgent widget."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Dict, Mapping, MutableMapping, Optional
+
+from vaultfire.pilot_mode import PilotPrivacyLedger, PilotResonanceTelemetry, PilotSession
+
+__all__ = ["MCPResponse", "MissionSignalResponder"]
+
+
+@dataclass(frozen=True)
+class MCPResponse:
+    """Return type used for MCP signal acknowledgements."""
+
+    signal_type: str
+    payload: Mapping[str, object]
+    reference_id: Optional[str] = None
+
+    def export(self) -> Dict[str, object]:
+        data = {"signal_type": self.signal_type, "payload": dict(self.payload)}
+        if self.reference_id:
+            data["reference_id"] = self.reference_id
+        return data
+
+
+class MissionSignalResponder:
+    """Route Mission Control Protocol (MCP) signals to registered handlers."""
+
+    def __init__(
+        self,
+        *,
+        ledger: PilotPrivacyLedger,
+        telemetry: PilotResonanceTelemetry,
+    ) -> None:
+        self._ledger = ledger
+        self._telemetry = telemetry
+        self._handlers: MutableMapping[str, Callable[[PilotSession, Mapping[str, object]], Mapping[str, object]]] = {}
+
+    def register_handler(
+        self,
+        signal_type: str,
+        handler: Callable[[PilotSession, Mapping[str, object]], Mapping[str, object]],
+    ) -> None:
+        """Register a custom handler for the provided signal type."""
+
+        if not signal_type:
+            raise ValueError("signal_type must be provided")
+        self._handlers[signal_type] = handler
+
+    def handle_signal(
+        self,
+        session: PilotSession,
+        signal: Mapping[str, object],
+    ) -> MCPResponse:
+        """Handle an MCP signal and log the response to the ledger."""
+
+        signal_type = str(signal.get("type", "mission-digest"))
+        handler = self._handlers.get(signal_type, self._default_handler)
+        payload = handler(session, signal)
+        response_payload = {
+            "session_id": session.session_id,
+            "partner_tag": session.partner_tag,
+            "signal": signal_type,
+            "response": payload,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        reference = self._ledger.record_reference(
+            partner_tag=session.partner_tag,
+            reference_type="mcp-signal",
+            payload=response_payload,
+            metadata={"signal_type": signal_type, "stealth": session.pilot_mode},
+        )
+        return MCPResponse(signal_type=signal_type, payload=payload, reference_id=reference.reference_id)
+
+    # ------------------------------------------------------------------
+    # Default handler
+    # ------------------------------------------------------------------
+    def _default_handler(self, session: PilotSession, signal: Mapping[str, object]) -> Mapping[str, object]:
+        """Produce a mission digest using the current resonance telemetry."""
+
+        if session.resonance is None:
+            session.resonance = self._telemetry
+        digest = session.resonance_digest()
+        return {
+            "mission": signal.get("mission", "Ghostkey Vaultfire"),
+            "resonance": digest,
+            "protocols": list(session.protocols),
+            "stealth": session.pilot_mode,
+        }

--- a/vaultfire_widget_bundle/onboarding.md
+++ b/vaultfire_widget_bundle/onboarding.md
@@ -1,0 +1,44 @@
+# GhostkeyVaultfireAgent Secure Onboarding
+
+The GhostkeyVaultfireAgent bundle is designed for DevDay-ready deployments in
+OpenAI's Agent Builder. Follow the protocol below to bootstrap a new pilot or
+partner node safely.
+
+## 1. Identity Verification
+- Require partner submissions to provide an API key hash and a Vaultfire
+  contributor tag before uploading this bundle.
+- Confirm the partner wallet against the Vaultfire ledger snapshot distributed
+  with the release package or the most recent governance digest.
+- Reject any onboarding request that lacks a DevDay mission commitment badge.
+
+## 2. Key Exchange
+1. Generate a temporary protocol key via `ProtocolKeyManager`.
+2. Encrypt the key with the partner's public curve25519 key.
+3. Deliver the encrypted payload through the Vaultfire secure courier or
+   equivalent SFTP channel.
+4. Record the exchange in the PilotPrivacyLedger using the
+   `MissionControlHooks` helper to guarantee traceability.
+
+## 3. Stealth Pilot Activation
+- Toggle **Stealth Pilot Detection** to `active` in the widget UI when running in
+  production publish mode.
+- Confirm that `allow_confidential_sessions` is set to `True` for any pilot that
+  accesses belief-loop analytics.
+- Use the Gradient Resonance panel to ensure resonance score deltas remain
+  within the expected corridor (`±0.15` per 10 minutes).
+
+## 4. Compliance & Audit
+- Schedule an automatic belief-loop export weekly; the widget's telemetry
+  bindings persist gradient snapshots in JSONL format for audit readiness.
+- Mission Control references must be reviewed manually after every major pilot
+  milestone; escalate anomalies to the Ghostkey stewardship council.
+
+## 5. Offboarding
+- Revoke protocol keys immediately once a partner completes their pilot cycle.
+- Archive resonance and yield logs for 90 days, then purge according to the
+  Vaultfire retention policy.
+- Submit a final mission digest via the MCP Signal Responder to confirm the
+  offboarding handshake.
+
+This onboarding sequence keeps the Vaultfire mission and contributors safe while
+providing the Agent Builder team a turnkey DevDay deployment path.

--- a/vaultfire_widget_bundle/telemetry/gradient_stream.py
+++ b/vaultfire_widget_bundle/telemetry/gradient_stream.py
@@ -1,0 +1,117 @@
+"""Streaming utilities for gradient telemetry within Agent Builder widgets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Iterable, Iterator, Mapping, MutableMapping
+
+from vaultfire.pilot_mode import PilotResonanceTelemetry, PilotSession
+
+__all__ = ["GradientStreamPacket", "GradientStreamer"]
+
+
+@dataclass(frozen=True)
+class GradientStreamPacket:
+    """Serializable telemetry packet consumed by Agent Builder widgets."""
+
+    channel: str
+    timestamp: str
+    payload: Mapping[str, object]
+
+    def as_dict(self) -> Mapping[str, object]:
+        """Return the packet as a plain mapping."""
+
+        return {"channel": self.channel, "timestamp": self.timestamp, "payload": dict(self.payload)}
+
+
+class GradientStreamer:
+    """Render resonance gradients and pilot state snapshots as a stream."""
+
+    def __init__(
+        self,
+        *,
+        telemetry: PilotResonanceTelemetry,
+        session: PilotSession,
+        include_belief_loop_graph: bool = True,
+        include_session_state: bool = True,
+    ) -> None:
+        if session.resonance is None:
+            session.resonance = telemetry
+        self._telemetry = telemetry
+        self._session = session
+        self._include_graph = include_belief_loop_graph
+        self._include_state = include_session_state
+
+    @staticmethod
+    def _timestamp() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def _base_digest(self) -> Mapping[str, object]:
+        digest = self._telemetry.integrity_digest()
+        default_digest: MutableMapping[str, object] = {
+            "gradient_window_seconds": digest.get("gradient_window_seconds", 600),
+            "resonance_gradient": digest.get("resonance_gradient", 0.0),
+            "resonance_index": digest.get("resonance_index", 0.0),
+            "meets_threshold": digest.get("meets_threshold", False),
+            "signal_count": digest.get("signal_count", 0),
+        }
+        breakdown = digest.get("technique_breakdown")
+        if isinstance(breakdown, Mapping):
+            default_digest["technique_breakdown"] = dict(breakdown)
+        return default_digest
+
+    def _belief_loop_points(self, digest: Mapping[str, object]) -> Iterable[Mapping[str, float]]:
+        gradient = digest.get("resonance_gradient", 0.0)
+        if isinstance(gradient, Mapping):
+            return [
+                {"index": int(idx), "value": float(value)}
+                for idx, value in gradient.items()
+                if isinstance(idx, (int, str))
+            ]
+        if isinstance(gradient, (list, tuple)):
+            return [
+                {"index": idx, "value": float(value)}
+                for idx, value in enumerate(gradient)
+            ]
+        gradient_value = float(gradient)
+        return [
+            {"index": -1, "value": round(gradient_value * 0.85, 6)},
+            {"index": 0, "value": round(gradient_value, 6)},
+            {"index": 1, "value": round(gradient_value * 1.05, 6)},
+        ]
+
+    def iter_packets(self) -> Iterator[GradientStreamPacket]:
+        """Yield telemetry packets for Agent Builder consumption."""
+
+        digest = self._base_digest()
+        yield GradientStreamPacket(
+            channel="gradient",
+            timestamp=self._timestamp(),
+            payload=digest,
+        )
+
+        if self._include_graph:
+            payload = {
+                "points": list(self._belief_loop_points(digest)),
+                "label": "Belief Loop Resonance",
+            }
+            yield GradientStreamPacket(
+                channel="belief-loop",
+                timestamp=self._timestamp(),
+                payload=payload,
+            )
+
+        if self._include_state:
+            state_payload: Dict[str, object] = self._session.export_context()
+            state_payload["stealth_mode"] = bool(self._session.pilot_mode)
+            yield GradientStreamPacket(
+                channel="pilot-state",
+                timestamp=self._timestamp(),
+                payload=state_payload,
+            )
+
+    def stream(self) -> Iterable[GradientStreamPacket]:
+        """Alias for :meth:`iter_packets` used by some widget runtimes."""
+
+        return self.iter_packets()

--- a/vaultfire_widget_bundle/telemetry/mission_hooks.py
+++ b/vaultfire_widget_bundle/telemetry/mission_hooks.py
@@ -1,0 +1,151 @@
+"""Mission Control hook utilities for the GhostkeyVaultfireAgent widget."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Mapping, Optional
+
+from vaultfire.enterprise.mission_control import EnterpriseMissionControl
+from vaultfire.pilot_mode import MissionControlPoints, PilotPrivacyLedger, PilotResonanceTelemetry, PilotSession
+
+from .gradient_stream import GradientStreamPacket
+
+__all__ = ["StealthActivationPayload", "MissionControlHooks"]
+
+
+@dataclass(frozen=True)
+class StealthActivationPayload:
+    """Serialized result when a stealth pilot session is toggled."""
+
+    session_id: str
+    partner_tag: str
+    options: Mapping[str, object]
+    mission_reference: Mapping[str, object]
+
+    def export(self) -> Dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "partner_tag": self.partner_tag,
+            "options": dict(self.options),
+            "mission_reference": dict(self.mission_reference),
+        }
+
+
+class MissionControlHooks:
+    """High-level helpers that bind telemetry, ledger, and mission control."""
+
+    def __init__(
+        self,
+        *,
+        ledger: PilotPrivacyLedger,
+        telemetry: PilotResonanceTelemetry,
+        mission_control: Optional[EnterpriseMissionControl] = None,
+    ) -> None:
+        self._ledger = ledger
+        self._telemetry = telemetry
+        self._mission_control = mission_control or EnterpriseMissionControl()
+        self._points = MissionControlPoints(ledger=self._ledger, telemetry=self._telemetry)
+
+    def _attach_telemetry(self, session: PilotSession) -> None:
+        if session.resonance is None:
+            session.resonance = self._telemetry
+
+    def on_session_launch(
+        self,
+        session: PilotSession,
+        *,
+        partner_profile: Optional[Mapping[str, object]] = None,
+    ) -> Dict[str, object]:
+        """Record a launch event with an optional mission anchor payload."""
+
+        self._attach_telemetry(session)
+        anchor_payload = None
+        if partner_profile:
+            anchor_payload = self._mission_control.register_mission_anchor(dict(partner_profile))
+        resonance = session.resonance_digest()
+        reference = self._ledger.record_reference(
+            partner_tag=session.partner_tag,
+            reference_type="mission-launch",
+            payload={
+                "session_id": session.session_id,
+                "anchor": anchor_payload,
+                "resonance": resonance,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+            metadata={"protocols": list(session.protocols), "pilot_mode": session.pilot_mode},
+        )
+        return {
+            "reference_id": reference.reference_id,
+            "anchor": anchor_payload,
+            "resonance": resonance,
+        }
+
+    def on_stealth_activation(
+        self,
+        session: PilotSession,
+        *,
+        allow_confidential_sessions: bool,
+        auto_expire_on_signal_mismatch: bool,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> StealthActivationPayload:
+        """Persist a stealth activation record and return the structured payload."""
+
+        self._attach_telemetry(session)
+        mission_reference = self._points.log_resonance(
+            partner_tag=session.partner_tag,
+            session_id=session.session_id,
+        )
+        payload = StealthActivationPayload(
+            session_id=session.session_id,
+            partner_tag=session.partner_tag,
+            options={
+                "allow_confidential_sessions": allow_confidential_sessions,
+                "auto_expire_on_signal_mismatch": auto_expire_on_signal_mismatch,
+                "metadata": dict(metadata or {}),
+            },
+            mission_reference=mission_reference,
+        )
+        self._ledger.record_reference(
+            partner_tag=session.partner_tag,
+            reference_type="stealth-activation",
+            payload=payload.export(),
+            metadata={
+                "pilot_mode": session.pilot_mode,
+                "protocols": list(session.protocols),
+                "stealth": True,
+            },
+        )
+        return payload
+
+    def on_gradient_packet(
+        self,
+        session: PilotSession,
+        packet: GradientStreamPacket,
+        *,
+        store_payload: bool = False,
+    ) -> Dict[str, object]:
+        """Relay gradient packets into the mission ledger for observability."""
+
+        self._attach_telemetry(session)
+        metadata = {
+            "channel": packet.channel,
+            "stealth": session.pilot_mode,
+            "store_payload": store_payload,
+        }
+        payload = {"timestamp": packet.timestamp}
+        if store_payload:
+            payload["payload"] = dict(packet.payload)
+        reference = self._ledger.record_reference(
+            partner_tag=session.partner_tag,
+            reference_type="gradient-stream",
+            payload={
+                "session_id": session.session_id,
+                "channel": packet.channel,
+                "timestamp": packet.timestamp,
+                "stealth_mode": session.pilot_mode,
+                "payload": dict(packet.payload) if store_payload else {"keys": list(packet.payload.keys())},
+            },
+            metadata=metadata,
+        )
+        return {"reference_id": reference.reference_id, "metadata": metadata}

--- a/vaultfire_widget_bundle/vaultfire_widget.json
+++ b/vaultfire_widget_bundle/vaultfire_widget.json
@@ -1,0 +1,69 @@
+{
+  "name": "GhostkeyVaultfireAgent",
+  "version": "1.0.0-devday",
+  "description": "Mission-ready widget bundle for Vaultfire's stealth pilot orchestration with gradient telemetry streaming.",
+  "models": {
+    "default": "gpt-4o",
+    "fallback": ["gpt-4-turbo"]
+  },
+  "preview": {
+    "instructions": "Operate in DevDay preview mode. Prioritise gradient telemetry visibility while protecting stealth pilot context.",
+    "allowed_tools": ["MissionControl", "TelemetryStream", "MCP"],
+    "stealth_pilot_detection": "passive"
+  },
+  "publish": {
+    "instructions": "Maintain Vaultfire mission control commitments in production and emit resonance digests for every pilot action.",
+    "allowed_tools": ["MissionControl", "TelemetryStream", "MCP", "GradientDisplay"],
+    "stealth_pilot_detection": "active"
+  },
+  "ui": {
+    "panels": [
+      {
+        "id": "gradient-log",
+        "title": "Gradient Resonance Log",
+        "component": "GradientStream",
+        "options": {
+          "include_belief_loop_graph": true,
+          "stream_source": "telemetry/gradient_stream.py"
+        }
+      },
+      {
+        "id": "pilot-state",
+        "title": "Pilot Session State",
+        "component": "PilotState",
+        "options": {
+          "stealth_mode_badge": true,
+          "mission_reference_panel": true
+        }
+      }
+    ],
+    "toggles": [
+      {
+        "id": "temperature",
+        "label": "Model Temperature",
+        "type": "select",
+        "options": [0.2, 0.4, 0.6],
+        "default": 0.2
+      },
+      {
+        "id": "top_p",
+        "label": "Top-p Sampling",
+        "type": "select",
+        "options": [0.8, 0.9, 1.0],
+        "default": 0.9
+      }
+    ]
+  },
+  "telemetry": {
+    "gradient_stream": "telemetry/gradient_stream.py",
+    "mission_hooks": "telemetry/mission_hooks.py"
+  },
+  "mcp": {
+    "signals": "mcp/signal_handler.py"
+  },
+  "security": {
+    "onboarding": "onboarding.md",
+    "stealth_pilot_required": true,
+    "mission_commitment": "Ghostkey Vaultfire mission ledger"
+  }
+}


### PR DESCRIPTION
## Summary
- add a DevDay-ready GhostkeyVaultfireAgent widget bundle with config and secure onboarding notes
- implement telemetry streaming bindings and mission control hooks for stealth pilot monitoring
- provide an optional MCP signal responder for mission digest acknowledgements

## Testing
- pytest tests/test_ghostkey_vaultfire_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68e2e7b123a48322824e2c7df2b26216