### PR TITLE
Add Agent Builder deployment pipeline for Ghostkey

### DIFF
--- a/deploy/vaultfire_agent_builder.py
+++ b/deploy/vaultfire_agent_builder.py
@@ -1,0 +1,51 @@
+"""DevDay-ready Ghostkey Vaultfire Agent Builder deployment script."""
+
+from __future__ import annotations
+
+from vaultfire.agent_builder import GhostkeyVaultfireAgent
+from vaultfire.logging import MissionLogger
+from vaultfire.pilot_mode import mission_control_hooks, stealth_telemetry
+from vaultfire.security import onboarding_guardrails
+from vaultfire_widget_bundle import widget_manifest
+
+
+def main() -> None:
+    telemetry = stealth_telemetry.gradient_stream(mode="pilot")
+    mission_hooks_bundle = mission_control_hooks.setup(access_layer=telemetry.access_layer)
+    widgets = widget_manifest.load(mode="preview")
+    onboarding = onboarding_guardrails.secure_protocol()
+    logger = MissionLogger(enabled=True)
+
+    agent = GhostkeyVaultfireAgent(
+        name="Ghostkey316",
+        mission_id="vaultfire-devday-pilot",
+        telemetry=telemetry,
+        mission_hooks=mission_hooks_bundle,
+        widget_bundle=widgets,
+        onboarding=onboarding,
+        logger=logger,
+    )
+
+    export_payload = agent.export_to_builder(
+        include_ui_toggles=True,
+        enable_preview_publish=True,
+        devday_secure_mode=True,
+    )
+
+    registration = agent.register(
+        mode="stealth-pilot",
+        trace_id="ghostkey316_v1.1",
+        tags=["agent-builder", "devday", "vaultfire", "ghostkey"],
+    )
+
+    print("Builder export payload:")
+    print(export_payload)
+    print("\nRegistration summary:")
+    print(registration)
+
+    print("✅ Ghostkey Vaultfire Agent ready for DevDay Agent Builder.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_agent_builder_deployment.py
+++ b/tests/test_agent_builder_deployment.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from vaultfire.agent_builder import GhostkeyVaultfireAgent
+from vaultfire.logging import MissionLogger
+from vaultfire.pilot_mode import mission_control_hooks, stealth_telemetry
+from vaultfire.security import onboarding_guardrails
+from vaultfire_widget_bundle import stream_loader, widget_manifest
+
+
+def _bootstrap_agent(tmp_path: Path) -> GhostkeyVaultfireAgent:
+    telemetry = stealth_telemetry.gradient_stream(mode="pilot", base_path=tmp_path)
+    mission_hooks_bundle = mission_control_hooks.setup(access_layer=telemetry.access_layer)
+    widgets = widget_manifest.load(mode="preview")
+    onboarding = onboarding_guardrails.secure_protocol()
+    logger = MissionLogger(enabled=True)
+    return GhostkeyVaultfireAgent(
+        name="Ghostkey316",
+        mission_id="vaultfire-devday-pilot",
+        telemetry=telemetry,
+        mission_hooks=mission_hooks_bundle,
+        widget_bundle=widgets,
+        onboarding=onboarding,
+        logger=logger,
+    )
+
+
+def test_builder_export_contains_manifest(tmp_path: Path) -> None:
+    agent = _bootstrap_agent(tmp_path)
+
+    payload = agent.export_to_builder(
+        include_ui_toggles=True,
+        enable_preview_publish=True,
+        devday_secure_mode=True,
+    )
+
+    assert payload["agent"]["name"] == "Ghostkey316"
+    assert payload["telemetry"]["mode"] == "pilot"
+    assert payload["widget_manifest"]["mode"] == "preview"
+    assert payload["widget_manifest"]["ui_toggles"]  # toggles included
+    assert payload["onboarding"]["secure_mode"] is True
+
+
+def test_registration_and_streaming(tmp_path: Path) -> None:
+    agent = _bootstrap_agent(tmp_path)
+
+    export = agent.export_to_builder(include_ui_toggles=False)
+    assert export["telemetry"]["gradient_window_seconds"] == agent.telemetry.gradient_window_seconds
+
+    # Onboard and activate a pilot session
+    onboarding = agent.pilot_agent.onboard_contributor(
+        "ghost-partner",
+        api_keys=["ghost-api"],
+        wallet_addresses=["0xABC"],
+        metadata={"tier": "pilot"},
+        watermark=True,
+    )
+    protocol_key = onboarding["protocol_key"]
+    session = agent.pilot_agent.verify_trust(
+        "ghost-partner",
+        protocol_key=protocol_key,
+        api_key="ghost-api",
+        protocols=("Vaultfire", "Pilot"),
+    )
+
+    partner_profile = {
+        "ens": "ghostpartner.eth",
+        "mission": "Belief-secured intelligence for partners who lead with ethics.",
+        "missionTags": ["vaultfire", "devday"],
+        "beliefDensity": 0.91,
+        "empathyScore": 0.82,
+        "ethicsVerified": True,
+        "tags": ["agent-builder", "devday"],
+    }
+    launch_record = agent.mission_hooks.on_session_launch(
+        session,
+        partner_profile=partner_profile,
+    )
+    assert "reference_id" in launch_record
+
+    stealth_payload = agent.mission_hooks.on_stealth_activation(
+        session,
+        allow_confidential_sessions=True,
+        auto_expire_on_signal_mismatch=True,
+    )
+    agent.log_stealth_activation(session.session_id, stealth_payload)
+
+    packets = list(
+        stream_loader.build_streamer(
+            agent.telemetry,
+            session,
+            include_session_state=True,
+        )
+    )
+    assert packets, "expected telemetry packets"
+    assert packets[0].channel == "gradient"
+
+    registration = agent.register(
+        mode="stealth-pilot",
+        trace_id="ghostkey316_v1.1",
+        tags=["agent-builder", "devday"],
+    )
+    assert registration["mode"] == "stealth-pilot"
+    assert registration["resonance"]["signal_count"] >= 0
+
+    last_log = agent.logger.last()
+    assert last_log and last_log["event"] == "agent-registered"
+

--- a/vaultfire/agent_builder/__init__.py
+++ b/vaultfire/agent_builder/__init__.py
@@ -1,0 +1,216 @@
+"""Agent Builder orchestration helpers for Ghostkey Vaultfire deployments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Mapping, Optional, Sequence
+
+from vaultfire.enterprise.mission_control import EnterpriseMissionControl
+from vaultfire.pilot_mode.ghostkey_agent import GhostkeyVaultfireAgent as PilotGhostkeyVaultfireAgent
+from vaultfire.pilot_mode.stealth_telemetry import StealthTelemetryBundle
+from vaultfire.pilot_mode.mission_control_hooks import MissionControlHookBundle
+from vaultfire_widget_bundle.widget_manifest import WidgetBundle
+from vaultfire.security.onboarding_guardrails import OnboardingGuardrails
+from vaultfire.logging import MissionLogger
+
+__all__ = ["GhostkeyVaultfireAgent"]
+
+
+@dataclass
+class BuilderExport:
+    """Structured payload exported to the Agent Builder UI."""
+
+    agent: Mapping[str, object]
+    telemetry: Mapping[str, object]
+    widget_manifest: Mapping[str, object]
+    onboarding: Mapping[str, object]
+    secure_mode: bool
+    preview_publish: bool
+
+    def export(self) -> Mapping[str, object]:
+        payload = {
+            "agent": dict(self.agent),
+            "telemetry": dict(self.telemetry),
+            "widget_manifest": dict(self.widget_manifest),
+            "onboarding": dict(self.onboarding),
+            "secure_mode": self.secure_mode,
+            "preview_publish": self.preview_publish,
+        }
+        return payload
+
+
+@dataclass
+class RegistrationRecord:
+    """Registration metadata emitted after DevDay sync."""
+
+    mode: str
+    trace_id: str
+    tags: Sequence[str]
+    mission_control: Mapping[str, object]
+    resonance: Mapping[str, object]
+    widgets: Mapping[str, Mapping[str, object]]
+
+    def export(self) -> Mapping[str, object]:
+        return {
+            "mode": self.mode,
+            "trace_id": self.trace_id,
+            "tags": list(self.tags),
+            "mission_control": dict(self.mission_control),
+            "resonance": dict(self.resonance),
+            "widgets": {key: dict(value) for key, value in self.widgets.items()},
+        }
+
+
+class GhostkeyVaultfireAgent:
+    """High-level Agent Builder facade for Ghostkey Vaultfire deployments."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        mission_id: str,
+        telemetry: StealthTelemetryBundle,
+        mission_hooks: MissionControlHookBundle,
+        widget_bundle: WidgetBundle,
+        onboarding: OnboardingGuardrails,
+        logger: MissionLogger,
+        mission_control: Optional[EnterpriseMissionControl] = None,
+    ) -> None:
+        self.name = name
+        self.mission_id = mission_id
+        self.telemetry = telemetry
+        self.widget_bundle = widget_bundle
+        self.onboarding = onboarding
+        self.logger = logger
+        self._mission_control = mission_control or EnterpriseMissionControl()
+        self._pilot_agent = PilotGhostkeyVaultfireAgent(
+            access_layer=self.telemetry.access_layer,
+            mission_control=self._mission_control,
+        )
+        self._mission_hooks = mission_hooks
+        self._mission_hooks.rebind(self.telemetry.access_layer, mission_control=self._mission_control)
+        self._last_export: Optional[BuilderExport] = None
+        self._registration_log: List[RegistrationRecord] = []
+        self.logger.log(
+            "agent-initialised",
+            name=self.name,
+            mission_id=self.mission_id,
+            telemetry_mode=self.telemetry.mode,
+            gradient_window_seconds=self.telemetry.gradient_window_seconds,
+        )
+
+    # ------------------------------------------------------------------
+    # Public accessors
+    # ------------------------------------------------------------------
+    @property
+    def pilot_agent(self) -> PilotGhostkeyVaultfireAgent:
+        """Return the underlying pilot-mode agent instance."""
+
+        return self._pilot_agent
+
+    @property
+    def mission_hooks(self) -> MissionControlHookBundle:
+        """Expose the mission control hook bundle."""
+
+        return self._mission_hooks
+
+    @property
+    def exports(self) -> Optional[BuilderExport]:
+        """Return the last exported Builder payload."""
+
+        return self._last_export
+
+    @property
+    def registrations(self) -> Sequence[RegistrationRecord]:
+        """Return historical registration records."""
+
+        return tuple(self._registration_log)
+
+    # ------------------------------------------------------------------
+    # Builder integration
+    # ------------------------------------------------------------------
+    def export_to_builder(
+        self,
+        *,
+        include_ui_toggles: bool = False,
+        enable_preview_publish: bool = False,
+        devday_secure_mode: bool = False,
+    ) -> Mapping[str, object]:
+        """Materialise the payload consumed by the Agent Builder interface."""
+
+        agent_payload = {
+            "name": self.name,
+            "mission_id": self.mission_id,
+            "mission": self._mission_control.mission,
+            "widgets": [widget.name for widget in self._pilot_agent.config.widgets],
+        }
+        telemetry_payload = {
+            "mode": self.telemetry.mode,
+            "gradient_window_seconds": self.telemetry.gradient_window_seconds,
+            "accepted_enclaves": self.telemetry.accepted_enclaves,
+        }
+        widget_payload = self.widget_bundle.export(include_ui_toggles=include_ui_toggles)
+        onboarding_payload = self.onboarding.export()
+        export = BuilderExport(
+            agent=agent_payload,
+            telemetry=telemetry_payload,
+            widget_manifest=widget_payload,
+            onboarding=onboarding_payload,
+            secure_mode=bool(devday_secure_mode),
+            preview_publish=bool(enable_preview_publish),
+        )
+        self._last_export = export
+        self.logger.log(
+            "builder-export",
+            secure_mode=devday_secure_mode,
+            preview_publish=enable_preview_publish,
+            include_ui_toggles=include_ui_toggles,
+        )
+        return export.export()
+
+    def register(
+        self,
+        *,
+        mode: str,
+        trace_id: str,
+        tags: Iterable[str],
+    ) -> Mapping[str, object]:
+        """Register the agent for a deployment window and log mission state."""
+
+        launch_state = self._pilot_agent.launch(mode=mode, sync_with_devday_tools=True)
+        record = RegistrationRecord(
+            mode=mode,
+            trace_id=trace_id,
+            tags=tuple(tags),
+            mission_control=launch_state.mission_commitments,
+            resonance=launch_state.resonance_digest,
+            widgets=launch_state.widgets,
+        )
+        self._registration_log.append(record)
+        self.logger.log(
+            "agent-registered",
+            mode=mode,
+            trace_id=trace_id,
+            tags=list(tags),
+            resonance=launch_state.resonance_digest,
+        )
+        return record.export()
+
+    def log_stealth_activation(
+        self,
+        session_id: str,
+        payload,
+    ) -> None:
+        """Relay a stealth activation payload through the mission logger."""
+
+        if hasattr(payload, "export"):
+            payload_dict = payload.export()  # type: ignore[call-arg]
+        else:
+            payload_dict = dict(payload)
+        self.logger.log(
+            "stealth-activation",
+            session_id=session_id,
+            mission_reference=dict(payload_dict.get("mission_reference", {})),
+            options=dict(payload_dict.get("options", {})),
+        )
+

--- a/vaultfire/logging/__init__.py
+++ b/vaultfire/logging/__init__.py
@@ -1,0 +1,43 @@
+"""Logging helpers for Ghostkey Vaultfire mission workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, List, Mapping, MutableMapping, Optional
+
+__all__ = ["MissionLogger"]
+
+
+@dataclass
+class MissionLogger:
+    """Minimal structured logger for mission orchestration flows."""
+
+    enabled: bool = True
+    _entries: List[MutableMapping[str, object]] = field(default_factory=list)
+
+    def log(self, event: str, /, **context: object) -> Optional[Mapping[str, object]]:
+        if not self.enabled:
+            return None
+        if not event or not event.strip():
+            raise ValueError("event must be provided")
+        entry: MutableMapping[str, object] = {
+            "event": event.strip(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "context": dict(context),
+            "sequence": len(self._entries) + 1,
+        }
+        self._entries.append(entry)
+        return entry
+
+    def export(self) -> Iterable[Mapping[str, object]]:
+        return tuple(dict(entry) for entry in self._entries)
+
+    def last(self) -> Optional[Mapping[str, object]]:
+        if not self._entries:
+            return None
+        return dict(self._entries[-1])
+
+    def clear(self) -> None:
+        self._entries.clear()
+

--- a/vaultfire/pilot_mode/__init__.py
+++ b/vaultfire/pilot_mode/__init__.py
@@ -1,5 +1,7 @@
 """Pilot mode namespace for secure partner testing."""
 
+import importlib
+
 from .access_layer import PilotAccessLayer
 from .feedback import FeedbackCollector, FeedbackRecord
 from .ghostkey_agent import (
@@ -38,4 +40,27 @@ __all__ = [
     "YieldSandbox",
     "PilotSession",
     "SessionFactory",
+    "MissionControlHookBundle",
+    "mission_control_setup",
+    "mission_control_hooks",
+    "stealth_telemetry",
 ]
+
+_LAZY_ATTRS = {
+    "mission_control_hooks": ".mission_control_hooks",
+    "stealth_telemetry": ".stealth_telemetry",
+}
+
+
+def __getattr__(name):
+    if name == "MissionControlHookBundle" or name == "mission_control_setup":
+        module = importlib.import_module(".mission_control_hooks", __name__)
+        value = getattr(module, "MissionControlHookBundle" if name == "MissionControlHookBundle" else "setup")
+        globals()[name] = value
+        return value
+    if name in _LAZY_ATTRS:
+        module = importlib.import_module(_LAZY_ATTRS[name], __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(name)
+

--- a/vaultfire/pilot_mode/mission_control_hooks.py
+++ b/vaultfire/pilot_mode/mission_control_hooks.py
@@ -1,0 +1,96 @@
+"""Convenience wrappers around Mission Control hooks for Agent Builder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+from vaultfire.enterprise.mission_control import EnterpriseMissionControl
+from vaultfire_widget_bundle.telemetry.mission_hooks import MissionControlHooks
+
+from .access_layer import PilotAccessLayer
+from .privacy import PilotPrivacyLedger
+from .resonance import PilotResonanceTelemetry
+from .session import PilotSession
+
+__all__ = ["MissionControlHookBundle", "setup"]
+
+
+@dataclass
+class MissionControlHookBundle:
+    """Bundle binding Mission Control hooks to the current access layer."""
+
+    hooks: MissionControlHooks
+    mission_control: EnterpriseMissionControl
+
+    def rebind(
+        self,
+        access_layer: PilotAccessLayer,
+        *,
+        mission_control: Optional[EnterpriseMissionControl] = None,
+    ) -> None:
+        """Rebind hooks to ``access_layer`` while preserving Mission Control."""
+
+        control = mission_control or self.mission_control
+        self.hooks = MissionControlHooks(
+            ledger=access_layer.ledger,
+            telemetry=access_layer.resonance,
+            mission_control=control,
+        )
+        self.mission_control = control
+
+    def on_session_launch(
+        self,
+        session: PilotSession,
+        *,
+        partner_profile: Optional[Mapping[str, object]] = None,
+    ) -> Mapping[str, object]:
+        return self.hooks.on_session_launch(session, partner_profile=partner_profile)
+
+    def on_stealth_activation(
+        self,
+        session: PilotSession,
+        *,
+        allow_confidential_sessions: bool,
+        auto_expire_on_signal_mismatch: bool,
+        metadata: Optional[Mapping[str, object]] = None,
+    ):
+        return self.hooks.on_stealth_activation(
+            session,
+            allow_confidential_sessions=allow_confidential_sessions,
+            auto_expire_on_signal_mismatch=auto_expire_on_signal_mismatch,
+            metadata=metadata,
+        )
+
+    def on_gradient_packet(
+        self,
+        session: PilotSession,
+        packet,
+        *,
+        store_payload: bool = False,
+    ):
+        return self.hooks.on_gradient_packet(session, packet, store_payload=store_payload)
+
+
+def setup(
+    *,
+    access_layer: Optional[PilotAccessLayer] = None,
+    mission_control: Optional[EnterpriseMissionControl] = None,
+) -> MissionControlHookBundle:
+    """Initialise a :class:`MissionControlHookBundle`."""
+
+    if access_layer is None:
+        ledger = PilotPrivacyLedger()
+        telemetry = PilotResonanceTelemetry(ledger=ledger)
+        control = mission_control or EnterpriseMissionControl()
+        hooks = MissionControlHooks(ledger=ledger, telemetry=telemetry, mission_control=control)
+        return MissionControlHookBundle(hooks=hooks, mission_control=control)
+
+    control = mission_control or EnterpriseMissionControl()
+    hooks = MissionControlHooks(
+        ledger=access_layer.ledger,
+        telemetry=access_layer.resonance,
+        mission_control=control,
+    )
+    return MissionControlHookBundle(hooks=hooks, mission_control=control)
+

--- a/vaultfire/pilot_mode/stealth_telemetry.py
+++ b/vaultfire/pilot_mode/stealth_telemetry.py
@@ -1,0 +1,108 @@
+"""Stealth telemetry helpers tailored for Ghostkey Vaultfire Agent Builder flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Optional
+
+from .access_layer import PilotAccessLayer
+from .feedback import FeedbackCollector
+from .keys import ProtocolKeyManager
+from .privacy import PilotPrivacyLedger
+from .registry import PilotAccessRegistry
+from .resonance import PilotResonanceTelemetry
+from .sandbox import YieldSandbox
+from .session import PilotSession
+from vaultfire_widget_bundle.telemetry.gradient_stream import GradientStreamer, GradientStreamPacket
+
+__all__ = ["StealthTelemetryBundle", "gradient_stream"]
+
+
+@dataclass
+class StealthTelemetryBundle:
+    """Container describing the configured telemetry stack."""
+
+    mode: str
+    access_layer: PilotAccessLayer
+    gradient_window_seconds: float
+    accepted_enclaves: Mapping[str, str]
+
+    def stream(
+        self,
+        session: PilotSession,
+        *,
+        include_belief_loop_graph: bool = True,
+        include_session_state: bool = True,
+    ) -> GradientStreamer:
+        """Return a :class:`GradientStreamer` for ``session``."""
+
+        return GradientStreamer(
+            telemetry=self.access_layer.resonance,
+            session=session,
+            include_belief_loop_graph=include_belief_loop_graph,
+            include_session_state=include_session_state,
+        )
+
+    def iter_packets(
+        self,
+        session: PilotSession,
+        *,
+        include_belief_loop_graph: bool = True,
+        include_session_state: bool = True,
+    ) -> Iterable[GradientStreamPacket]:
+        """Yield gradient packets for ``session``."""
+
+        streamer = self.stream(
+            session,
+            include_belief_loop_graph=include_belief_loop_graph,
+            include_session_state=include_session_state,
+        )
+        return streamer.iter_packets()
+
+
+def _path_or_none(base_path: Optional[Path], filename: str) -> Optional[Path]:
+    if base_path is None:
+        return None
+    return base_path / filename
+
+
+def gradient_stream(
+    *,
+    mode: str = "pilot",
+    base_path: Optional[Path] = None,
+    accepted_enclaves: Optional[Mapping[str, str]] = None,
+) -> StealthTelemetryBundle:
+    """Build a stealth telemetry bundle for Agent Builder usage."""
+
+    gradient_window = 600.0 if mode == "pilot" else 420.0
+    base_dir = Path(base_path) if base_path is not None else None
+    ledger = PilotPrivacyLedger(reference_log_path=_path_or_none(base_dir, "ledger.jsonl"))
+    registry = PilotAccessRegistry(path=_path_or_none(base_dir, "partners.json"))
+    key_manager = ProtocolKeyManager(path=_path_or_none(base_dir, "protocol_keys.json"))
+    sandbox = YieldSandbox(
+        yield_log_path=_path_or_none(base_dir, "yield.jsonl"),
+        behavior_log_path=_path_or_none(base_dir, "behavior.jsonl"),
+        ledger=ledger,
+    )
+    feedback = FeedbackCollector(log_path=_path_or_none(base_dir, "feedback.jsonl"), ledger=ledger)
+    resonance = PilotResonanceTelemetry(
+        ledger=ledger,
+        accepted_measurements=accepted_enclaves,
+        gradient_window_seconds=gradient_window,
+    )
+    access_layer = PilotAccessLayer(
+        registry=registry,
+        key_manager=key_manager,
+        sandbox=sandbox,
+        feedback=feedback,
+        ledger=ledger,
+        resonance=resonance,
+    )
+    return StealthTelemetryBundle(
+        mode=mode,
+        access_layer=access_layer,
+        gradient_window_seconds=gradient_window,
+        accepted_enclaves=dict(accepted_enclaves or {}),
+    )
+

--- a/vaultfire/security/__init__.py
+++ b/vaultfire/security/__init__.py
@@ -13,6 +13,7 @@ from .fhe import (
     PrivacyEngine,
     SoulboundKey,
 )
+from .onboarding_guardrails import OnboardingGuardrails, secure_protocol
 from .resilience_simulator import (
     PilotConfig,
     PilotRunResult,
@@ -31,6 +32,8 @@ __all__ = [
     "PrivacyEngine",
     "SoulboundKey",
     "validate_securestore_fallback",
+    "OnboardingGuardrails",
+    "secure_protocol",
     "PilotConfig",
     "PilotRunResult",
     "ResilienceScenario",

--- a/vaultfire/security/onboarding_guardrails.py
+++ b/vaultfire/security/onboarding_guardrails.py
@@ -1,0 +1,49 @@
+"""Onboarding guardrails for DevDay Agent Builder deployments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = ["OnboardingGuardrails", "secure_protocol"]
+
+
+@dataclass
+class OnboardingGuardrails:
+    """Represents onboarding requirements for Vaultfire agents."""
+
+    required_steps: Sequence[str] = field(default_factory=tuple)
+    required_tags: Sequence[str] = field(default_factory=tuple)
+    secure_mode: bool = True
+
+    def export(self) -> Mapping[str, object]:
+        return {
+            "required_steps": list(self.required_steps),
+            "required_tags": list(self.required_tags),
+            "secure_mode": self.secure_mode,
+        }
+
+    def validate_profile(self, profile: Mapping[str, object]) -> MutableMapping[str, object]:
+        missing_steps = [step for step in self.required_steps if not profile.get(step)]
+        missing_tags = [tag for tag in self.required_tags if tag not in profile.get("tags", [])]
+        return {
+            "missing_steps": missing_steps,
+            "missing_tags": missing_tags,
+            "eligible": not missing_steps and not missing_tags,
+        }
+
+
+def secure_protocol(
+    *,
+    required_steps: Iterable[str] = ("kyc", "mission_alignment", "wallet_verification"),
+    required_tags: Iterable[str] = ("agent-builder", "vaultfire"),
+    secure_mode: bool = True,
+) -> OnboardingGuardrails:
+    """Return default guardrails for DevDay onboarding flows."""
+
+    return OnboardingGuardrails(
+        required_steps=tuple(required_steps),
+        required_tags=tuple(required_tags),
+        secure_mode=secure_mode,
+    )
+

--- a/vaultfire_widget_bundle/stream_loader.py
+++ b/vaultfire_widget_bundle/stream_loader.py
@@ -1,0 +1,50 @@
+"""Convenience utilities for streaming telemetry into Agent Builder widgets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from vaultfire.pilot_mode.session import PilotSession
+from vaultfire.pilot_mode.stealth_telemetry import StealthTelemetryBundle
+from vaultfire_widget_bundle.telemetry.gradient_stream import GradientStreamPacket
+
+__all__ = ["StreamLoader", "build_streamer"]
+
+
+@dataclass
+class StreamLoader:
+    """Adapter that exposes gradient packets for a pilot session."""
+
+    telemetry: StealthTelemetryBundle
+
+    def packets(
+        self,
+        session: PilotSession,
+        *,
+        include_belief_loop_graph: bool = True,
+        include_session_state: bool = True,
+    ) -> Iterable[GradientStreamPacket]:
+        return self.telemetry.iter_packets(
+            session,
+            include_belief_loop_graph=include_belief_loop_graph,
+            include_session_state=include_session_state,
+        )
+
+
+def build_streamer(
+    telemetry: StealthTelemetryBundle,
+    session: PilotSession,
+    *,
+    include_belief_loop_graph: bool = True,
+    include_session_state: bool = True,
+) -> Iterable[GradientStreamPacket]:
+    """Return an iterator of telemetry packets for ``session``."""
+
+    loader = StreamLoader(telemetry=telemetry)
+    return loader.packets(
+        session,
+        include_belief_loop_graph=include_belief_loop_graph,
+        include_session_state=include_session_state,
+    )
+

--- a/vaultfire_widget_bundle/widget_manifest.py
+++ b/vaultfire_widget_bundle/widget_manifest.py
@@ -1,0 +1,48 @@
+"""Widget manifest helpers for Ghostkey Vaultfire Agent Builder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, MutableMapping, Optional
+
+from . import load_widget_config
+
+__all__ = ["WidgetBundle", "load"]
+
+
+@dataclass
+class WidgetBundle:
+    """Lightweight wrapper around the widget manifest JSON."""
+
+    manifest: Mapping[str, object]
+    mode: str
+
+    def export(self, *, include_ui_toggles: bool = False) -> Mapping[str, object]:
+        manifest_dict = dict(self.manifest)
+        payload: MutableMapping[str, object] = {
+            "mode": self.mode,
+            "manifest": manifest_dict,
+        }
+        profile = manifest_dict.get(self.mode)
+        if isinstance(profile, Mapping):
+            payload["profile"] = dict(profile)
+        if include_ui_toggles:
+            ui_config = manifest_dict.get("ui")
+            toggles = []
+            if isinstance(ui_config, Mapping):
+                raw_toggles = ui_config.get("toggles", [])
+                if isinstance(raw_toggles, Mapping):
+                    toggles = list(raw_toggles.values())
+                else:
+                    toggles = list(raw_toggles) if isinstance(raw_toggles, (list, tuple)) else []
+            payload["ui_toggles"] = toggles
+        return payload
+
+
+def load(*, mode: str = "preview", base_path: Optional[Path] = None) -> WidgetBundle:
+    """Load the widget manifest with the requested ``mode`` profile."""
+
+    manifest = load_widget_config(base_path)
+    return WidgetBundle(manifest=manifest, mode=mode)
+


### PR DESCRIPTION
## Summary
- add a GhostkeyVaultfireAgent facade and builder deployment script for DevDay-ready workflows
- expose stealth telemetry, mission control hook, onboarding guardrails, widget manifest, and logging utilities for Agent Builder integrations
- cover the pipeline with automated tests that exercise builder export, session activation, mission hooks, and telemetry streaming

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e2eca11d2c83228e6e133a2e89fe89