### PR TITLE
Add MCP-triggered auto deployment lambda for Ghostkey agent

### DIFF
--- a/tests/test_auto_deploy_lambda.py
+++ b/tests/test_auto_deploy_lambda.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+import pytest
+from pytest import CaptureFixture
+
+
+@pytest.fixture(autouse=True)
+def _configure_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VAULTFIRE_ENV", "pilot")
+    monkeypatch.setenv("VAULTFIRE_SIGNAL_SECRET", "signal-secret")
+    monkeypatch.setenv("VAULTFIRE_DEPLOY_SECRET", "deploy-secret")
+
+
+def _build_signal(timestamp: str) -> Dict[str, Any]:
+    from vaultfire.utils import validate_integrity
+
+    secret = os.getenv("VAULTFIRE_SIGNAL_SECRET", "signal-secret")
+    import hmac
+    import hashlib
+
+    hash_value = hmac.new(secret.encode(), timestamp.encode(), hashlib.sha256).hexdigest()
+    assert validate_integrity(hash_value, timestamp)
+    return {
+        "signal_key": "vaultfire_pilot_sync",
+        "timestamp": timestamp,
+        "hash": hash_value,
+    }
+
+
+def test_auto_deploy_lambda_triggers_deployment(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vaultfire import auto_deploy
+
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    signal = _build_signal(timestamp)
+
+    captured: Dict[str, Any] = {}
+
+    def fake_deploy_agent_bundle(**kwargs: Any) -> Dict[str, Any]:
+        captured.update(kwargs)
+        return {"status": "queued"}
+
+    monkeypatch.setattr(auto_deploy, "deploy_agent_bundle", fake_deploy_agent_bundle)
+
+    auto_deploy.auto_deploy_lambda(signal)
+
+    assert captured["agent_id"] == "Ghostkey316"
+    assert captured["env"] == "pilot"
+    assert captured["mode"] == "pilot"
+    assert captured["telemetry"] == "stealth"
+    assert len(captured["config_signature"]) == 64
+
+
+def test_auto_deploy_lambda_rejects_invalid_hash() -> None:
+    from vaultfire import auto_deploy
+
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    signal = {
+        "signal_key": "vaultfire_pilot_sync",
+        "timestamp": timestamp,
+        "hash": "not-a-valid-hash",
+    }
+
+    with pytest.raises(auto_deploy.AutoDeployError) as exc:
+        auto_deploy.auto_deploy_lambda(signal)
+
+    assert "❌ Signal integrity check failed" in str(exc.value)
+
+
+def test_auto_deploy_lambda_ignores_unknown_signal(
+    monkeypatch: pytest.MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    from vaultfire import auto_deploy
+
+    called = False
+
+    def fake_deploy_agent_bundle(**_: Any) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(auto_deploy, "deploy_agent_bundle", fake_deploy_agent_bundle)
+
+    auto_deploy.auto_deploy_lambda({"signal_key": "unknown"})
+
+    captured = capsys.readouterr()
+    assert "Unknown signal" in captured.out
+    assert not called

--- a/vaultfire/auto_deploy.py
+++ b/vaultfire/auto_deploy.py
@@ -1,0 +1,56 @@
+"""Auto deployment Lambda triggered by MCP signals."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from vaultfire.config import VAULTFIRE_ENV
+from vaultfire.deploy import deploy_agent_bundle
+from vaultfire.utils import sign_deployment, validate_integrity
+
+_SIGNAL_KEY = "vaultfire_pilot_sync"
+
+
+class AutoDeployError(RuntimeError):
+    """Raised when an auto deployment signal fails validation."""
+
+
+def _require_field(payload: Mapping[str, Any], field: str) -> str:
+    try:
+        value = payload[field]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise AutoDeployError(f"Signal payload missing required field: {field}") from exc
+    if not value:
+        raise AutoDeployError(f"Signal payload field '{field}' is empty")
+    return str(value)
+
+
+def auto_deploy_lambda(signal_payload: Mapping[str, Any]) -> None:
+    """Handle the incoming MCP signal and trigger a deployment if valid."""
+
+    if signal_payload.get("signal_key") != _SIGNAL_KEY:
+        print("⚠️ Unknown signal received. No action taken.")
+        return
+
+    print("🟢 Activation signal received from MCP. Preparing deployment...")
+
+    timestamp = _require_field(signal_payload, "timestamp")
+    payload_hash = _require_field(signal_payload, "hash")
+
+    if not validate_integrity(payload_hash, timestamp):
+        raise AutoDeployError("❌ Signal integrity check failed. Abort.")
+
+    signature = sign_deployment(agent_id="Ghostkey316", env=str(VAULTFIRE_ENV), timestamp=timestamp)
+
+    deploy_agent_bundle(
+        agent_id="Ghostkey316",
+        env=str(VAULTFIRE_ENV),
+        config_signature=signature,
+        mode=signal_payload.get("mode", "pilot"),
+        telemetry=signal_payload.get("telemetry", "stealth"),
+    )
+
+    print("✅ GhostkeyVaultfireAgent deployed successfully in pilot mode.")
+
+
+__all__ = ["AutoDeployError", "auto_deploy_lambda"]

--- a/vaultfire/config.py
+++ b/vaultfire/config.py
@@ -1,0 +1,39 @@
+"""Configuration helpers for Vaultfire deployments."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Iterable
+
+_DEFAULT_ENVIRONMENT = "pilot"
+_ALLOWED_ENVIRONMENTS: Iterable[str] = ("pilot", "staging", "production")
+
+
+@dataclass(frozen=True)
+class VaultfireEnvironment:
+    """Represents the runtime environment for Vaultfire services."""
+
+    name: str
+
+    def __post_init__(self) -> None:
+        if self.name not in _ALLOWED_ENVIRONMENTS:
+            raise ValueError(
+                f"Unsupported Vaultfire environment: {self.name}. "
+                f"Expected one of: {', '.join(_ALLOWED_ENVIRONMENTS)}"
+            )
+
+    def __str__(self) -> str:  # pragma: no cover - dataclass convenience
+        return self.name
+
+
+def _detect_environment() -> VaultfireEnvironment:
+    env = os.getenv("VAULTFIRE_ENV", _DEFAULT_ENVIRONMENT).strip().lower()
+    if not env:
+        env = _DEFAULT_ENVIRONMENT
+    return VaultfireEnvironment(env)
+
+
+VAULTFIRE_ENV = _detect_environment()
+
+__all__ = ["VAULTFIRE_ENV", "VaultfireEnvironment"]

--- a/vaultfire/deploy.py
+++ b/vaultfire/deploy.py
@@ -1,0 +1,88 @@
+"""Deployment helpers for Vaultfire agents."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+DeploymentMode = Literal["pilot", "staging", "production"]
+TelemetryMode = Literal["stealth", "observability", "diagnostic"]
+
+
+@dataclass(frozen=True)
+class DeploymentRequest:
+    """Immutable representation of a deployment request."""
+
+    agent_id: str
+    env: str
+    config_signature: str
+    mode: DeploymentMode
+    telemetry: TelemetryMode
+
+
+@dataclass(frozen=True)
+class DeploymentResult:
+    """Summary returned after a deployment has been triggered."""
+
+    request: DeploymentRequest
+    status: Literal["queued", "completed"]
+
+
+class DeploymentError(RuntimeError):
+    """Raised when a deployment cannot be initiated."""
+
+
+def deploy_agent_bundle(
+    *,
+    agent_id: str,
+    env: str,
+    config_signature: str,
+    mode: DeploymentMode,
+    telemetry: TelemetryMode,
+) -> DeploymentResult:
+    """Trigger a Vaultfire agent deployment.
+
+    The function performs lightweight validation and logs the deployment
+    metadata. In a production system this would hand off to the Vaultfire
+    orchestrator. Here we simulate the hand-off and return a structured
+    summary that can be asserted in tests.
+    """
+
+    if not agent_id:
+        raise DeploymentError("Agent identifier is required for deployment")
+    if len(config_signature) < 16:
+        raise DeploymentError("Configuration signature is invalid or too short")
+    if mode not in ("pilot", "staging", "production"):
+        raise DeploymentError(f"Unsupported deployment mode: {mode}")
+    if telemetry not in ("stealth", "observability", "diagnostic"):
+        raise DeploymentError(f"Unsupported telemetry mode: {telemetry}")
+
+    request = DeploymentRequest(
+        agent_id=agent_id,
+        env=env,
+        config_signature=config_signature,
+        mode=mode,
+        telemetry=telemetry,
+    )
+
+    logger.info(
+        "Queued deployment for agent %s in %s (%s telemetry)",
+        agent_id,
+        env,
+        telemetry,
+    )
+
+    return DeploymentResult(request=request, status="queued")
+
+
+__all__ = [
+    "DeploymentError",
+    "DeploymentMode",
+    "DeploymentRequest",
+    "DeploymentResult",
+    "TelemetryMode",
+    "deploy_agent_bundle",
+]

--- a/vaultfire/utils.py
+++ b/vaultfire/utils.py
@@ -1,0 +1,59 @@
+"""Utility helpers for Vaultfire deployment flows."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+from datetime import datetime, timezone
+from typing import Optional
+
+_DEFAULT_SIGNAL_SECRET = "vaultfire-dev-secret"
+_DEFAULT_DEPLOY_SECRET = "vaultfire-deploy-secret"
+_TIME_TOLERANCE_SECONDS = 5 * 60
+
+
+def _load_secret(var_name: str, default: str) -> str:
+    value = os.getenv(var_name, default).strip()
+    return value or default
+
+
+def _parse_timestamp(timestamp: str) -> Optional[datetime]:
+    try:
+        parsed = datetime.fromisoformat(timestamp)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def validate_integrity(hash_value: str, timestamp: str) -> bool:
+    """Validate that the payload hash matches the expected HMAC signature."""
+
+    parsed_timestamp = _parse_timestamp(timestamp)
+    if not parsed_timestamp:
+        return False
+
+    now = datetime.now(timezone.utc)
+    if abs((now - parsed_timestamp).total_seconds()) > _TIME_TOLERANCE_SECONDS:
+        return False
+
+    secret = _load_secret("VAULTFIRE_SIGNAL_SECRET", _DEFAULT_SIGNAL_SECRET)
+    expected = hmac.new(
+        secret.encode("utf-8"),
+        timestamp.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(expected, str(hash_value))
+
+
+def sign_deployment(*, agent_id: str, env: str, timestamp: str) -> str:
+    """Generate a deterministic signature for deployment metadata."""
+
+    secret = _load_secret("VAULTFIRE_DEPLOY_SECRET", _DEFAULT_DEPLOY_SECRET)
+    payload = f"{agent_id}:{env}:{timestamp}".encode("utf-8")
+    return hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+
+
+__all__ = ["sign_deployment", "validate_integrity"]


### PR DESCRIPTION
## Summary
- add configuration, deployment, and utility modules that support Ghostkey auto deployments
- implement the MCP-triggered `auto_deploy_lambda` workflow for the Ghostkey316 agent
- cover integrity validation and signal handling paths with targeted unit tests

## Testing
- pytest tests/test_auto_deploy_lambda.py

------
https://chatgpt.com/codex/tasks/task_e_68e338f55f188322a9b1a6d343a0f603