### PR TITLE
Add status beacon sync utilities

### DIFF
--- a/status/agent_status.json
+++ b/status/agent_status.json
@@ -1,0 +1,3 @@
+{
+  "Ghostkey316": "pending"
+}

--- a/status/beacon_sync.py
+++ b/status/beacon_sync.py
@@ -1,0 +1,63 @@
+"""Continuously publish Ghostkey status beacons for the dashboard."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except ModuleNotFoundError:  # pragma: no cover - fallback when requests missing
+    requests = None  # type: ignore
+
+from vaultfire.beacon import log_status, update_beacon_light
+from vaultfire.status import get_agent_status
+
+AGENT_ID = "Ghostkey316"
+BEACON_URL = "https://vaultfire.status/api/beacon"
+POLL_INTERVAL_SECONDS = 10
+
+
+def _post_status(status: str) -> Optional[Dict[str, Any]]:
+    if not requests:
+        return None
+    try:
+        response = requests.post(
+            BEACON_URL,
+            json={"agent": AGENT_ID, "status": status},
+            timeout=5,
+        )
+        response.raise_for_status()
+        return response.json() if response.headers.get("content-type", "").startswith("application/json") else None
+    except Exception:
+        return None
+
+
+def beacon_sync_loop() -> None:
+    print("🔄 Starting Beacon Sync Loop...")
+    while True:
+        try:
+            status = get_agent_status(agent_id=AGENT_ID)
+
+            if status == "active":
+                update_beacon_light(AGENT_ID, "green")
+                log_status(AGENT_ID, "🟢 Agent live and synced.")
+            elif status == "pending":
+                update_beacon_light(AGENT_ID, "yellow")
+                log_status(AGENT_ID, "🟡 Agent deployed, awaiting confirmation.")
+            elif status == "error":
+                update_beacon_light(AGENT_ID, "red")
+                log_status(AGENT_ID, "🔴 Error in deployment.")
+            else:
+                update_beacon_light(AGENT_ID, "gray")
+                log_status(AGENT_ID, f"⚪ Unknown status: {status}")
+
+            _post_status(status)
+        except Exception as exc:
+            print(f"⚠️ Beacon sync error: {exc}")
+
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    beacon_sync_loop()

--- a/vaultfire/beacon.py
+++ b/vaultfire/beacon.py
@@ -1,0 +1,82 @@
+"""Beacon helpers for Ghostkey Vaultfire deployments."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
+
+_STATE_PATH = Path("status") / "beacon_state.json"
+_LOG_PATH = Path("status") / "beacon_log.jsonl"
+
+
+def _load_state() -> Dict[str, Mapping[str, str]]:
+    if not _STATE_PATH.exists():
+        return {}
+    try:
+        with open(_STATE_PATH) as stream:
+            data = json.load(stream)
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(data, dict):
+        return {str(key): dict(value) for key, value in data.items() if isinstance(value, dict)}
+    return {}
+
+
+def _write_state(state: Dict[str, Mapping[str, str]]) -> None:
+    _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(_STATE_PATH, "w") as stream:
+        json.dump(state, stream, indent=2, sort_keys=True)
+
+
+def update_beacon_light(agent_id: str, color: str) -> Mapping[str, str]:
+    """Persist the current beacon ``color`` for ``agent_id`` and return state."""
+
+    state = _load_state()
+    payload = {
+        "color": color,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    state[agent_id] = payload
+    _write_state(state)
+    return payload
+
+
+def log_status(agent_id: str, message: str) -> Mapping[str, str]:
+    """Append a structured log entry for ``agent_id`` and return the entry."""
+
+    entry = {
+        "agent": agent_id,
+        "message": message,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(_LOG_PATH, "a") as stream:
+        stream.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def iter_status_log() -> Iterable[Mapping[str, str]]:
+    """Yield log entries in chronological order."""
+
+    if not _LOG_PATH.exists():
+        return []
+    entries = []
+    with open(_LOG_PATH) as stream:
+        for line in stream:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return tuple(entries)
+
+
+__all__ = [
+    "iter_status_log",
+    "log_status",
+    "update_beacon_light",
+]

--- a/vaultfire/status.py
+++ b/vaultfire/status.py
@@ -1,0 +1,53 @@
+"""Deployment status helpers for Vaultfire agents."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+StatusMap = Dict[str, str]
+
+_STATUS_PATH = Path("status") / "agent_status.json"
+
+
+def _load_status_map() -> StatusMap:
+    if not _STATUS_PATH.exists():
+        return {}
+    try:
+        with open(_STATUS_PATH) as stream:
+            data = json.load(stream)
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(data, dict):
+        return {str(key): str(value) for key, value in data.items()}
+    return {}
+
+
+def _write_status_map(mapping: StatusMap) -> None:
+    _STATUS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(_STATUS_PATH, "w") as stream:
+        json.dump(mapping, stream, indent=2, sort_keys=True)
+
+
+def get_agent_status(*, agent_id: str) -> str:
+    """Return the recorded deployment status for ``agent_id``.
+
+    Falls back to ``"pending"`` when no prior state is available.  The helper
+    never raises to make it safe for background tasks such as beacon sync
+    loops.
+    """
+
+    status = _load_status_map().get(agent_id)
+    return status or "pending"
+
+
+def set_agent_status(*, agent_id: str, status: str) -> None:
+    """Persist a deployment ``status`` for ``agent_id``."""
+
+    mapping = _load_status_map()
+    mapping[agent_id] = status
+    _write_status_map(mapping)
+
+
+__all__ = ["get_agent_status", "set_agent_status"]


### PR DESCRIPTION
## Summary
- add a persistent agent status registry and beacon helpers under the vaultfire package
- implement a background beacon sync loop that reports Ghostkey316 deployment status
- seed a default status snapshot for Ghostkey316 to drive the beacon dashboard

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e33d1174f48322bab242b2fe52a2b1