### PR TITLE
Add signal anchor identity lifecycle module

### DIFF
--- a/tests/test_signal_anchor_drop.py
+++ b/tests/test_signal_anchor_drop.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from vaultfire.identity import (
+    AnchorRecord,
+    AuthorshipBurnRecord,
+    ContributionRecord,
+    GenesisRegistration,
+    MetadataRecord,
+    SignalAnchorError,
+    anchor_signal_origin,
+    burn_authorship_trace,
+    get_signal_anchor_state,
+    record_originator_metadata,
+    register_genesis_node,
+    reset_signal_anchor_state,
+    timestamp_contribution_start,
+)
+from vaultfire.protocol.constants import ARCHITECT_WALLET, ORIGIN_NODE_ID
+
+
+@pytest.fixture(autouse=True)
+def reset_anchor_state() -> None:
+    reset_signal_anchor_state()
+
+
+def test_anchor_signal_origin_normalises_inputs() -> None:
+    record = anchor_signal_origin("Ghostkey316", ARCHITECT_WALLET.upper())
+    assert isinstance(record, AnchorRecord)
+    assert record.origin_id == ORIGIN_NODE_ID
+    assert record.wallet_id == ARCHITECT_WALLET
+
+    same = anchor_signal_origin(ORIGIN_NODE_ID, ARCHITECT_WALLET)
+    assert same is record
+
+
+def test_anchor_signal_origin_rejects_conflicting_wallet() -> None:
+    anchor_signal_origin(ORIGIN_NODE_ID, ARCHITECT_WALLET)
+    with pytest.raises(SignalAnchorError):
+        anchor_signal_origin(ORIGIN_NODE_ID, "wallet.two")
+
+
+def test_timestamp_contribution_start_parses_iso_datetime() -> None:
+    anchor_signal_origin(ORIGIN_NODE_ID, ARCHITECT_WALLET)
+    timestamp = "2025-07-06T11:00:00-04:00"
+    record = timestamp_contribution_start("Ghostkey316", timestamp)
+    assert isinstance(record, ContributionRecord)
+    assert record.origin_id == ORIGIN_NODE_ID
+    assert record.started_at == datetime(2025, 7, 6, 15, 0, tzinfo=timezone.utc)
+
+    same = timestamp_contribution_start(ORIGIN_NODE_ID, record.started_at)
+    assert same.started_at == record.started_at
+
+
+def test_record_originator_metadata_tracks_latest_entry() -> None:
+    entry = record_originator_metadata(name="Ghostkey-316", wallet=ARCHITECT_WALLET)
+    assert isinstance(entry, MetadataRecord)
+    assert entry.wallet == ARCHITECT_WALLET
+    assert entry.name == "Ghostkey-316"
+
+    state = get_signal_anchor_state()
+    stored = state["metadata"][ARCHITECT_WALLET.lower()]
+    assert stored["name"] == "Ghostkey-316"
+
+
+def test_burn_authorship_trace_requires_anchor() -> None:
+    with pytest.raises(SignalAnchorError):
+        burn_authorship_trace(ORIGIN_NODE_ID)
+
+    anchor_signal_origin(ORIGIN_NODE_ID, ARCHITECT_WALLET)
+    burn = burn_authorship_trace("Ghostkey316")
+    assert isinstance(burn, AuthorshipBurnRecord)
+    assert burn.origin_id == ORIGIN_NODE_ID
+
+
+def test_register_genesis_node_requires_preconditions() -> None:
+    anchor_signal_origin(ORIGIN_NODE_ID, ARCHITECT_WALLET)
+    with pytest.raises(SignalAnchorError):
+        register_genesis_node(ORIGIN_NODE_ID)
+
+    timestamp_contribution_start(ORIGIN_NODE_ID, datetime(2025, 7, 6, 15, 0, tzinfo=timezone.utc))
+    registration = register_genesis_node("Ghostkey316")
+    assert isinstance(registration, GenesisRegistration)
+    assert registration.origin_id == ORIGIN_NODE_ID
+
+
+def test_register_genesis_node_records_snapshot() -> None:
+    anchor_signal_origin(ORIGIN_NODE_ID, ARCHITECT_WALLET)
+    timestamp_contribution_start(ORIGIN_NODE_ID, datetime.now(timezone.utc))
+    register_genesis_node(ORIGIN_NODE_ID)
+
+    snapshot = get_signal_anchor_state()
+    assert ORIGIN_NODE_ID in snapshot["genesis_nodes"]

--- a/vaultfire/__init__.py
+++ b/vaultfire/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "refund",
     "pilot_mode",
     "telemetry",
+    "identity",
     "auto_refund",
     "should_refund",
     "freeze_refunds",
@@ -37,6 +38,7 @@ _LAZY_MODULES: Dict[str, str] = {
     "refund": ".refund",
     "pilot_mode": ".pilot_mode",
     "telemetry": ".telemetry",
+    "identity": ".identity",
 }
 
 _REFUND_EXPORTS: Iterable[str] = (

--- a/vaultfire/identity/__init__.py
+++ b/vaultfire/identity/__init__.py
@@ -1,0 +1,255 @@
+"""Signal anchor identity management for Vaultfire genesis events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Mapping, MutableMapping
+
+from vaultfire.protocol.constants import ARCHITECT_WALLET, ORIGIN_NODE_ID
+
+__all__ = [
+    "SignalAnchorError",
+    "AnchorRecord",
+    "ContributionRecord",
+    "MetadataRecord",
+    "AuthorshipBurnRecord",
+    "GenesisRegistration",
+    "anchor_signal_origin",
+    "timestamp_contribution_start",
+    "record_originator_metadata",
+    "burn_authorship_trace",
+    "register_genesis_node",
+    "get_signal_anchor_state",
+    "reset_signal_anchor_state",
+]
+
+
+class SignalAnchorError(RuntimeError):
+    """Raised when the signal anchor lifecycle encounters an invalid state."""
+
+
+@dataclass(slots=True)
+class AnchorRecord:
+    """Represents a canonical origin → wallet anchor."""
+
+    origin_id: str
+    wallet_id: str
+    anchored_at: datetime
+
+    def export(self) -> Mapping[str, object]:
+        return {
+            "origin_id": self.origin_id,
+            "wallet_id": self.wallet_id,
+            "anchored_at": self.anchored_at.isoformat(),
+        }
+
+
+@dataclass(slots=True)
+class ContributionRecord:
+    """Timestamped record for when a contribution officially began."""
+
+    origin_id: str
+    started_at: datetime
+
+    def export(self) -> Mapping[str, object]:
+        return {
+            "origin_id": self.origin_id,
+            "started_at": self.started_at.isoformat(),
+        }
+
+
+@dataclass(slots=True)
+class MetadataRecord:
+    """Human readable metadata about the identity establishing the anchor."""
+
+    name: str
+    wallet: str
+    recorded_at: datetime
+
+    def export(self) -> Mapping[str, object]:
+        return {
+            "name": self.name,
+            "wallet": self.wallet,
+            "recorded_at": self.recorded_at.isoformat(),
+        }
+
+
+@dataclass(slots=True)
+class AuthorshipBurnRecord:
+    """Immutable record showing when authorship traces were purged."""
+
+    origin_id: str
+    burned_at: datetime
+
+    def export(self) -> Mapping[str, object]:
+        return {
+            "origin_id": self.origin_id,
+            "burned_at": self.burned_at.isoformat(),
+        }
+
+
+@dataclass(slots=True)
+class GenesisRegistration:
+    """Confirms that the origin has been registered as a genesis node."""
+
+    origin_id: str
+    registered_at: datetime
+
+    def export(self) -> Mapping[str, object]:
+        return {
+            "origin_id": self.origin_id,
+            "registered_at": self.registered_at.isoformat(),
+        }
+
+
+@dataclass
+class _SignalAnchorState:
+    """In-memory store backing the signal anchor lifecycle."""
+
+    anchors: MutableMapping[str, AnchorRecord] = field(default_factory=dict)
+    contributions: MutableMapping[str, ContributionRecord] = field(default_factory=dict)
+    metadata: MutableMapping[str, MetadataRecord] = field(default_factory=dict)
+    burns: MutableMapping[str, AuthorshipBurnRecord] = field(default_factory=dict)
+    genesis_nodes: MutableMapping[str, GenesisRegistration] = field(default_factory=dict)
+
+    def snapshot(self) -> Mapping[str, object]:
+        return {
+            "anchors": {key: record.export() for key, record in self.anchors.items()},
+            "contributions": {key: record.export() for key, record in self.contributions.items()},
+            "metadata": {key: record.export() for key, record in self.metadata.items()},
+            "burns": {key: record.export() for key, record in self.burns.items()},
+            "genesis_nodes": {key: record.export() for key, record in self.genesis_nodes.items()},
+        }
+
+    def reset(self) -> None:
+        self.anchors.clear()
+        self.contributions.clear()
+        self.metadata.clear()
+        self.burns.clear()
+        self.genesis_nodes.clear()
+
+
+_STATE = _SignalAnchorState()
+
+
+def _normalize_origin(origin_id: str) -> str:
+    if not isinstance(origin_id, str):
+        raise TypeError("origin_id must be a string")
+    value = origin_id.strip()
+    if not value:
+        raise ValueError("origin_id must be provided")
+    canonical = ORIGIN_NODE_ID.lower().replace("-", "")
+    if value.lower().replace("-", "") == canonical:
+        return ORIGIN_NODE_ID
+    return value
+
+
+def _normalize_wallet(wallet_id: str) -> str:
+    if not isinstance(wallet_id, str):
+        raise TypeError("wallet_id must be a string")
+    value = wallet_id.strip()
+    if not value:
+        raise ValueError("wallet_id must be provided")
+    if value.lower() == ARCHITECT_WALLET.lower():
+        return ARCHITECT_WALLET
+    return value
+
+
+def _coerce_datetime(value: str | datetime) -> datetime:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if not isinstance(value, str):
+        raise TypeError("timestamp must be an ISO 8601 string or datetime")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:  # pragma: no cover - defensive, but should not occur in tests
+        raise ValueError("timestamp must be ISO 8601 compliant") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed
+
+
+def anchor_signal_origin(origin_id: str, wallet_id: str) -> AnchorRecord:
+    """Anchor the provided origin to a wallet, ensuring immutability on repeat calls."""
+
+    origin = _normalize_origin(origin_id)
+    wallet = _normalize_wallet(wallet_id)
+    existing = _STATE.anchors.get(origin)
+    if existing:
+        if existing.wallet_id != wallet:
+            raise SignalAnchorError(
+                f"origin {origin} is already anchored to wallet {existing.wallet_id}"
+            )
+        return existing
+    record = AnchorRecord(origin_id=origin, wallet_id=wallet, anchored_at=datetime.now(timezone.utc))
+    _STATE.anchors[origin] = record
+    return record
+
+
+def timestamp_contribution_start(origin_id: str, timestamp: str | datetime) -> ContributionRecord:
+    """Persist the official contribution start timestamp for an origin."""
+
+    origin = _normalize_origin(origin_id)
+    started_at = _coerce_datetime(timestamp)
+    existing = _STATE.contributions.get(origin)
+    if existing and existing.started_at != started_at:
+        raise SignalAnchorError(
+            f"origin {origin} already has a different contribution start timestamp registered"
+        )
+    record = ContributionRecord(origin_id=origin, started_at=started_at)
+    _STATE.contributions[origin] = record
+    return record
+
+
+def record_originator_metadata(*, name: str, wallet: str) -> MetadataRecord:
+    """Store human-readable metadata for the originator of the signal anchor."""
+
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("name must be provided")
+    normalized_wallet = _normalize_wallet(wallet)
+    record = MetadataRecord(name=name.strip(), wallet=normalized_wallet, recorded_at=datetime.now(timezone.utc))
+    _STATE.metadata[normalized_wallet.lower()] = record
+    return record
+
+
+def burn_authorship_trace(origin_id: str) -> AuthorshipBurnRecord:
+    """Record that the authorship trace for the origin has been intentionally cleared."""
+
+    origin = _normalize_origin(origin_id)
+    if origin not in _STATE.anchors:
+        raise SignalAnchorError(f"origin {origin} must be anchored before authorship can be burned")
+    record = AuthorshipBurnRecord(origin_id=origin, burned_at=datetime.now(timezone.utc))
+    _STATE.burns[origin] = record
+    return record
+
+
+def register_genesis_node(origin_id: str) -> GenesisRegistration:
+    """Register the origin as a genesis node once anchoring prerequisites are satisfied."""
+
+    origin = _normalize_origin(origin_id)
+    if origin not in _STATE.anchors:
+        raise SignalAnchorError(f"origin {origin} must be anchored before genesis registration")
+    if origin not in _STATE.contributions:
+        raise SignalAnchorError(
+            f"origin {origin} requires a contribution start timestamp before genesis registration"
+        )
+    registration = GenesisRegistration(origin_id=origin, registered_at=datetime.now(timezone.utc))
+    _STATE.genesis_nodes[origin] = registration
+    return registration
+
+
+def get_signal_anchor_state() -> Mapping[str, object]:
+    """Return a snapshot of the current signal anchor state for diagnostics and testing."""
+
+    return _STATE.snapshot()
+
+
+def reset_signal_anchor_state() -> None:
+    """Clear the anchor state. Intended for use in tests only."""
+
+    _STATE.reset()


### PR DESCRIPTION
## Summary
- add a dedicated `vaultfire.identity` module that manages signal anchor lifecycles with strongly typed records and validation
- expose the identity helpers through the root package lazy loader for ergonomic imports
- cover the anchor workflow with focused pytest coverage around anchoring, timestamps, metadata, burns, and genesis registration

## Testing
- `pytest tests/test_signal_anchor_drop.py`


------
https://chatgpt.com/codex/tasks/task_e_68e342dbbe708322bc1fa8a7f8daeb3b