### PR TITLE
Add optimization utilities for Vaultfire performance

### DIFF
--- a/tests/test_optimization_module.py
+++ b/tests/test_optimization_module.py
@@ -1,0 +1,94 @@
+"""Tests for the Vaultfire optimization helpers."""
+
+import pytest
+
+from vaultfire import optimization
+from vaultfire.optimization import (
+    enable_coin_cross_compatibility,
+    enhance_protocol_speed,
+    get_optimization_state,
+    improve_logic_routing,
+    increase_yield_capture,
+    reset_optimization_state,
+    upgrade_error_resilience,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Ensure every test starts from the default optimization state."""
+
+    reset_optimization_state()
+    yield
+    reset_optimization_state()
+
+
+def test_reset_restores_defaults():
+    enhance_protocol_speed(level="max")
+    improve_logic_routing(depth="deep")
+    reset_optimization_state()
+
+    state = get_optimization_state()
+    assert state.protocol_speed == "balanced"
+    assert state.logic_depth == "standard"
+    assert state.cross_compatible is False
+    assert state.supported_coins == ()
+    assert state.yield_multiplier == pytest.approx(1.0)
+    assert state.error_resilience == "baseline"
+
+
+def test_enhance_protocol_speed_updates_state():
+    state = enhance_protocol_speed(level="high")
+    assert state.protocol_speed == "high"
+    assert get_optimization_state().protocol_speed == "high"
+
+
+def test_enhance_protocol_speed_rejects_unknown_level():
+    with pytest.raises(ValueError):
+        enhance_protocol_speed(level="warp")
+
+
+def test_improve_logic_routing_rejects_unknown_depth():
+    with pytest.raises(ValueError):
+        improve_logic_routing(depth="infinite")
+
+
+def test_enable_coin_cross_compatibility_requires_coins_when_not_all():
+    with pytest.raises(ValueError):
+        enable_coin_cross_compatibility()
+
+
+def test_enable_coin_cross_compatibility_sets_sorted_uppercase_coins():
+    state = enable_coin_cross_compatibility(coins=["eth", "btc", " eth "])
+    assert state.cross_compatible is True
+    assert state.supported_coins == ("BTC", "ETH")
+
+
+def test_enable_coin_cross_compatibility_include_all():
+    state = enable_coin_cross_compatibility(include_all=True)
+    assert state.supported_coins == ("*",)
+
+
+def test_increase_yield_capture_requires_positive_multiplier():
+    with pytest.raises(ValueError):
+        increase_yield_capture(multiplier=0)
+
+
+def test_increase_yield_capture_updates_state():
+    state = increase_yield_capture(multiplier=2.5)
+    assert state.yield_multiplier == pytest.approx(2.5)
+
+
+def test_upgrade_error_resilience_accepts_known_method():
+    state = upgrade_error_resilience(method="auto-recovery")
+    assert state.error_resilience == "auto-recovery"
+
+
+def test_upgrade_error_resilience_rejects_unknown_method():
+    with pytest.raises(ValueError):
+        upgrade_error_resilience(method="quantum")
+
+
+def test_module_is_available_via_package_namespace():
+    # Accessing the module via the package ensures lazy loading is configured.
+    assert hasattr(optimization, "enhance_protocol_speed")

--- a/vaultfire/__init__.py
+++ b/vaultfire/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "pilot_mode",
     "telemetry",
     "identity",
+    "optimization",
     "auto_refund",
     "should_refund",
     "freeze_refunds",
@@ -39,6 +40,7 @@ _LAZY_MODULES: Dict[str, str] = {
     "pilot_mode": ".pilot_mode",
     "telemetry": ".telemetry",
     "identity": ".identity",
+    "optimization": ".optimization",
 }
 
 _REFUND_EXPORTS: Iterable[str] = (

--- a/vaultfire/optimization/__init__.py
+++ b/vaultfire/optimization/__init__.py
@@ -1,0 +1,149 @@
+"""Runtime optimization utilities for Vaultfire deployments."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Iterable, Tuple
+
+__all__ = [
+    "enhance_protocol_speed",
+    "improve_logic_routing",
+    "enable_coin_cross_compatibility",
+    "increase_yield_capture",
+    "upgrade_error_resilience",
+    "get_optimization_state",
+    "reset_optimization_state",
+]
+
+_ALLOWED_SPEED_LEVELS = {"baseline", "balanced", "high", "max"}
+_ALLOWED_ROUTING_DEPTHS = {"shallow", "standard", "deep", "ultra"}
+_ALLOWED_RESILIENCE_METHODS = {"baseline", "auto-recovery", "redundant", "distributed"}
+
+
+@dataclass
+class OptimizationState:
+    """Track the current optimization settings applied to Vaultfire."""
+
+    protocol_speed: str = "balanced"
+    logic_depth: str = "standard"
+    cross_compatible: bool = False
+    supported_coins: Tuple[str, ...] = field(default_factory=tuple)
+    yield_multiplier: float = 1.0
+    error_resilience: str = "baseline"
+
+    def snapshot(self) -> dict[str, object]:
+        """Return a representation of the current state."""
+
+        return {
+            "protocol_speed": self.protocol_speed,
+            "logic_depth": self.logic_depth,
+            "cross_compatible": self.cross_compatible,
+            "supported_coins": tuple(self.supported_coins),
+            "yield_multiplier": self.yield_multiplier,
+            "error_resilience": self.error_resilience,
+        }
+
+
+_state = OptimizationState()
+_state_lock = threading.Lock()
+
+
+def _update_state(**updates: object) -> OptimizationState:
+    with _state_lock:
+        for key, value in updates.items():
+            setattr(_state, key, value)
+        return OptimizationState(**_state.snapshot())
+
+
+def get_optimization_state() -> OptimizationState:
+    """Return a copy of the current optimization state."""
+
+    with _state_lock:
+        return OptimizationState(**_state.snapshot())
+
+
+def reset_optimization_state() -> None:
+    """Reset the optimization state to its defaults."""
+
+    with _state_lock:
+        global _state
+        _state = OptimizationState()
+
+
+def enhance_protocol_speed(*, level: str = "balanced") -> OptimizationState:
+    """Increase the protocol speed to the requested level.
+
+    Args:
+        level: One of ``baseline``, ``balanced``, ``high``, or ``max``.
+
+    Returns:
+        A copy of the updated :class:`OptimizationState`.
+
+    Raises:
+        ValueError: If ``level`` is not recognised.
+    """
+
+    normalized = level.strip().lower()
+    if normalized not in _ALLOWED_SPEED_LEVELS:
+        raise ValueError(f"Unknown protocol speed level: {level!r}")
+    return _update_state(protocol_speed=normalized)
+
+
+def improve_logic_routing(*, depth: str = "standard") -> OptimizationState:
+    """Tune the logic routing depth."""
+
+    normalized = depth.strip().lower()
+    if normalized not in _ALLOWED_ROUTING_DEPTHS:
+        raise ValueError(f"Unknown logic routing depth: {depth!r}")
+    return _update_state(logic_depth=normalized)
+
+
+def enable_coin_cross_compatibility(
+    *, include_all: bool = False, coins: Iterable[str] | None = None
+) -> OptimizationState:
+    """Activate coin interoperability across Vaultfire surfaces.
+
+    Args:
+        include_all: When ``True`` the engine will mark all coins as supported.
+        coins: Specific coin identifiers to allow when ``include_all`` is ``False``.
+
+    Returns:
+        A copy of the updated :class:`OptimizationState`.
+
+    Raises:
+        ValueError: If no coins are provided when ``include_all`` is ``False``.
+    """
+
+    normalized_coins: Tuple[str, ...]
+    if include_all:
+        normalized_coins = ("*",)
+    else:
+        if coins is None:
+            raise ValueError("coins must be provided when include_all is False")
+        unique = {coin.strip().upper() for coin in coins if coin and coin.strip()}
+        if not unique:
+            raise ValueError("coins must contain at least one non-empty identifier")
+        normalized_coins = tuple(sorted(unique))
+
+    return _update_state(
+        cross_compatible=True,
+        supported_coins=normalized_coins,
+    )
+
+
+def increase_yield_capture(*, multiplier: float = 1.0) -> OptimizationState:
+    """Adjust the expected yield multiplier for the protocol."""
+
+    if multiplier <= 0:
+        raise ValueError("multiplier must be greater than zero")
+    return _update_state(yield_multiplier=float(multiplier))
+
+
+def upgrade_error_resilience(*, method: str = "baseline") -> OptimizationState:
+    """Select an error recovery strategy."""
+
+    normalized = method.strip().lower()
+    if normalized not in _ALLOWED_RESILIENCE_METHODS:
+        raise ValueError(f"Unknown error resilience method: {method!r}")
+    return _update_state(error_resilience=normalized)


### PR DESCRIPTION
## Summary
- add a new `vaultfire.optimization` module with runtime tuning helpers and state management
- expose the optimization module through the package namespace
- cover the optimization helpers with dedicated pytest tests

## Testing
- pytest tests/test_optimization_module.py

------
https://chatgpt.com/codex/tasks/task_e_68e348e4f51083229da1a823dfcf463e