### PR TITLE
Add NS3 passive yield loop protocol module

### DIFF
--- a/install_ns3_passive_yield_loop.py
+++ b/install_ns3_passive_yield_loop.py
@@ -1,0 +1,29 @@
+"""CLI helper to install the NS3 passive yield loop for Ghostkey deployments."""
+
+from ns3.protocol import (
+    activate_weekly_yield_distribution,
+    apply_multiplier_for_ghostkey,
+    install_passive_yield_engine,
+    sync_behavior_to_loyalty_chain,
+    validate_origin_rewards,
+)
+
+WALLET = "bpow20.cb.id"
+ORIGIN = "Ghostkey316"
+
+
+def install_yield_loop() -> None:
+    """Run the coordinated passive yield loop installation sequence."""
+    print("🌱 Installing Passive Yield Loop...")
+
+    install_passive_yield_engine(wallet=WALLET)
+    sync_behavior_to_loyalty_chain(wallet=WALLET, origin=ORIGIN)
+    activate_weekly_yield_distribution(start_immediately=True)
+    validate_origin_rewards(origin_id=ORIGIN)
+    apply_multiplier_for_ghostkey(wallet=WALLET, level="Genesis++")
+
+    print("✅ NS3 Yield Loop Active – Passive System Initialized")
+
+
+if __name__ == "__main__":
+    install_yield_loop()

--- a/ns3/__init__.py
+++ b/ns3/__init__.py
@@ -1,0 +1,17 @@
+"""NS3 protocol helpers for Ghostkey Vaultfire integrations."""
+
+from .protocol import (
+    activate_weekly_yield_distribution,
+    apply_multiplier_for_ghostkey,
+    install_passive_yield_engine,
+    sync_behavior_to_loyalty_chain,
+    validate_origin_rewards,
+)
+
+__all__ = [
+    "activate_weekly_yield_distribution",
+    "apply_multiplier_for_ghostkey",
+    "install_passive_yield_engine",
+    "sync_behavior_to_loyalty_chain",
+    "validate_origin_rewards",
+]

--- a/ns3/protocol.py
+++ b/ns3/protocol.py
@@ -1,0 +1,158 @@
+"""Utilities for installing and tracking the NS3 passive yield loop."""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_LOG_PATH = Path(
+    os.environ.get("NS3_YIELD_LOG", _REPO_ROOT / "telemetry" / "yield_activation.log")
+)
+_METADATA_PATH = Path(
+    os.environ.get("NS3_METADATA_PATH", _REPO_ROOT / "ghostkey_metadata_snapshot.json")
+)
+
+
+@dataclass(slots=True)
+class _YieldEvent:
+    action: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the event."""
+        return {
+            "id": uuid.uuid4().hex,
+            "action": self.action,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            **self.payload,
+        }
+
+
+def _append_event(event: _YieldEvent) -> Dict[str, Any]:
+    record = event.to_dict()
+    log_path = _DEFAULT_LOG_PATH
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(record, sort_keys=True))
+        stream.write("\n")
+    return record
+
+
+def _load_origin_metadata() -> Optional[Dict[str, Any]]:
+    path = _METADATA_PATH
+    if not path.exists():
+        return None
+    try:
+        with path.open(encoding="utf-8") as source:
+            return json.load(source)
+    except json.JSONDecodeError:
+        return None
+
+
+def install_passive_yield_engine(*, wallet: str) -> Dict[str, Any]:
+    """Record the installation of the passive yield engine for a wallet."""
+    if not wallet or not wallet.strip():
+        raise ValueError("wallet must be provided")
+
+    return _append_event(
+        _YieldEvent(
+            action="install_passive_yield_engine",
+            payload={"wallet": wallet, "status": "installed"},
+        )
+    )
+
+
+def sync_behavior_to_loyalty_chain(*, wallet: str, origin: str) -> Dict[str, Any]:
+    """Log a loyalty sync alignment for the given wallet and origin."""
+    if not wallet or not wallet.strip():
+        raise ValueError("wallet must be provided")
+    if not origin or not origin.strip():
+        raise ValueError("origin must be provided")
+
+    metadata = _load_origin_metadata() or {}
+    loyalty_anchor = metadata.get("metadata_lock", {}).get("ens")
+
+    return _append_event(
+        _YieldEvent(
+            action="sync_behavior_to_loyalty_chain",
+            payload={
+                "wallet": wallet,
+                "origin": origin,
+                "loyalty_anchor": loyalty_anchor,
+            },
+        )
+    )
+
+
+def activate_weekly_yield_distribution(*, start_immediately: bool) -> Dict[str, Any]:
+    """Capture activation status for the weekly yield distribution."""
+    return _append_event(
+        _YieldEvent(
+            action="activate_weekly_yield_distribution",
+            payload={"start_immediately": bool(start_immediately)},
+        )
+    )
+
+
+def validate_origin_rewards(*, origin_id: str) -> Dict[str, Any]:
+    """Validate an origin id against the Ghostkey metadata snapshot."""
+    if not origin_id or not origin_id.strip():
+        raise ValueError("origin_id must be provided")
+
+    metadata = _load_origin_metadata()
+    metadata_origin: Optional[str] = None
+    if metadata:
+        metadata_origin = metadata.get("metadata_lock", {}).get("ens") or metadata.get("ens")
+    verified = False
+    if metadata_origin:
+        metadata_origin_normalized = metadata_origin.split(".")[0].lower()
+        if metadata_origin_normalized != origin_id.lower():
+            raise ValueError(
+                f"origin_id '{origin_id}' does not match registered origin '{metadata_origin}'"
+            )
+        verified = True
+
+    return _append_event(
+        _YieldEvent(
+            action="validate_origin_rewards",
+            payload={"origin_id": origin_id, "verified": verified},
+        )
+    )
+
+
+_MULTIPLIERS = {
+    "Genesis": 1.0,
+    "Genesis+": 1.12,
+    "Genesis++": 1.25,
+    "Ascendant": 1.4,
+}
+
+
+def apply_multiplier_for_ghostkey(*, wallet: str, level: str) -> Dict[str, Any]:
+    """Apply a belief multiplier tier to the provided wallet."""
+    if not wallet or not wallet.strip():
+        raise ValueError("wallet must be provided")
+    if level not in _MULTIPLIERS:
+        raise ValueError(f"unknown multiplier level '{level}'")
+
+    multiplier = _MULTIPLIERS[level]
+    return _append_event(
+        _YieldEvent(
+            action="apply_multiplier_for_ghostkey",
+            payload={"wallet": wallet, "level": level, "multiplier": multiplier},
+        )
+    )
+
+
+__all__ = [
+    "activate_weekly_yield_distribution",
+    "apply_multiplier_for_ghostkey",
+    "install_passive_yield_engine",
+    "sync_behavior_to_loyalty_chain",
+    "validate_origin_rewards",
+]

--- a/tests/test_ns3_protocol.py
+++ b/tests/test_ns3_protocol.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+def _reload_protocol():
+    module = importlib.import_module("ns3.protocol")
+    return importlib.reload(module)
+
+
+def test_yield_loop_events(tmp_path, monkeypatch):
+    log_path = tmp_path / "yield.log"
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(
+        json.dumps({"metadata_lock": {"ens": "ghostkey316.eth"}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("NS3_YIELD_LOG", str(log_path))
+    monkeypatch.setenv("NS3_METADATA_PATH", str(metadata_path))
+
+    protocol = _reload_protocol()
+
+    install_record = protocol.install_passive_yield_engine(wallet="wallet_123")
+    loyalty_record = protocol.sync_behavior_to_loyalty_chain(
+        wallet="wallet_123", origin="Ghostkey316"
+    )
+    activation_record = protocol.activate_weekly_yield_distribution(start_immediately=True)
+    validation_record = protocol.validate_origin_rewards(origin_id="Ghostkey316")
+    multiplier_record = protocol.apply_multiplier_for_ghostkey(
+        wallet="wallet_123", level="Genesis++"
+    )
+
+    assert install_record["status"] == "installed"
+    assert loyalty_record["origin"] == "Ghostkey316"
+    assert activation_record["start_immediately"] is True
+    assert validation_record["verified"] is True
+    assert multiplier_record["multiplier"] > 1
+
+    entries = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    assert [entry["action"] for entry in entries] == [
+        "install_passive_yield_engine",
+        "sync_behavior_to_loyalty_chain",
+        "activate_weekly_yield_distribution",
+        "validate_origin_rewards",
+        "apply_multiplier_for_ghostkey",
+    ]
+    assert entries[-1]["level"] == "Genesis++"
+
+
+def test_invalid_multiplier_level(tmp_path, monkeypatch):
+    log_path = tmp_path / "yield.log"
+    monkeypatch.setenv("NS3_YIELD_LOG", str(log_path))
+    monkeypatch.delenv("NS3_METADATA_PATH", raising=False)
+
+    protocol = _reload_protocol()
+
+    with pytest.raises(ValueError):
+        protocol.apply_multiplier_for_ghostkey(wallet="wallet_123", level="Unknown")


### PR DESCRIPTION
## Summary
- introduce an ns3.protocol module that logs yield loop lifecycle steps and validates origin metadata
- expose an install_ns3_passive_yield_loop helper that orchestrates the passive yield installation sequence
- add pytest coverage to exercise the protocol flows and multiplier validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e34a58d3cc8322aaa5d5d20ee1b416