### PR TITLE
Add sync trigger activation utilities and tests

### DIFF
--- a/tests/test_sync_triggers.py
+++ b/tests/test_sync_triggers.py
@@ -1,0 +1,98 @@
+"""Tests for ``vaultfire.signals.activate_sync_trigger``."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def signals_fixture(monkeypatch, tmp_path):
+    registry = tmp_path / "registry.json"
+    ledger = tmp_path / "ledger.json"
+    monkeypatch.setenv("VAULTFIRE_SYNC_TRIGGER_PATH", str(registry))
+    monkeypatch.setenv("VAULTFIRE_GOVERNANCE_LEDGER_PATH", str(ledger))
+    sys.modules.pop("vaultfire.signals", None)
+    module = importlib.import_module("vaultfire.signals")
+    monkeypatch.setattr(module, "log_signal", lambda *_, **__: None)
+    return module, registry, ledger
+
+
+def _read_json(path: Path):
+    return json.loads(path.read_text())
+
+
+def test_activate_sync_trigger_creates_registry_entry(signals_fixture):
+    module, registry_path, ledger_path = signals_fixture
+    module._current_timestamp = lambda: "2024-06-10T00:00:00+00:00"
+
+    record = module.activate_sync_trigger(
+        user_tag="Ghostkey316",
+        platform="X",
+        sync_type="Passive Signal Tracking",
+        notify_on_likes=True,
+        notify_on_tags=True,
+        ledger_tie=True,
+    )
+
+    registry = _read_json(registry_path)
+    key = "Ghostkey316@x"
+    assert key in registry
+    assert registry[key]["status"] == "active"
+    assert record["ledger_reference"] == "2024-06-10T00:00:00+00:00"
+
+    ledger = _read_json(ledger_path)
+    assert ledger[-1]["type"] == "sync-trigger"
+    assert ledger[-1]["details"]["registry_key"] == key
+
+
+def test_activate_sync_trigger_updates_existing_entry(signals_fixture):
+    module, registry_path, _ = signals_fixture
+
+    module._current_timestamp = lambda: "2024-06-10T01:00:00+00:00"
+    module.activate_sync_trigger(
+        user_tag="Ghostkey316",
+        platform="X",
+        sync_type="Passive Signal Tracking",
+        notify_on_likes=True,
+        notify_on_tags=True,
+        ledger_tie=False,
+    )
+
+    module._current_timestamp = lambda: "2024-06-10T02:00:00+00:00"
+    record = module.activate_sync_trigger(
+        user_tag="Ghostkey316",
+        platform="X",
+        sync_type="Passive Signal Tracking",
+        notify_on_likes=False,
+        notify_on_tags=False,
+        ledger_tie=False,
+    )
+
+    registry = _read_json(registry_path)
+    key = "Ghostkey316@x"
+    assert registry[key]["notify_on_likes"] is False
+    assert registry[key]["notify_on_tags"] is False
+    assert record["activated_at"] == "2024-06-10T02:00:00+00:00"
+
+
+def test_activate_sync_trigger_accepts_int_bool(signals_fixture):
+    module, _, _ = signals_fixture
+    module._current_timestamp = lambda: "2024-06-10T03:00:00+00:00"
+
+    record = module.activate_sync_trigger(
+        user_tag="Ghostkey316",
+        platform="X",
+        sync_type="Passive Signal Tracking",
+        notify_on_likes=1,
+        notify_on_tags=0,
+        ledger_tie=0,
+    )
+
+    assert record["notify_on_likes"] is True
+    assert record["notify_on_tags"] is False
+    assert "ledger_reference" not in record

--- a/vaultfire/__init__.py
+++ b/vaultfire/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "identity",
     "optimization",
     "systems",
+    "signals",
     "auto_refund",
     "should_refund",
     "freeze_refunds",
@@ -45,6 +46,7 @@ _LAZY_MODULES: Dict[str, str] = {
     "identity": ".identity",
     "optimization": ".optimization",
     "systems": ".systems",
+    "signals": ".signals",
 }
 
 _REFUND_EXPORTS: Iterable[str] = (

--- a/vaultfire/signals.py
+++ b/vaultfire/signals.py
@@ -1,0 +1,212 @@
+"""Signal activation utilities for Vaultfire passive tracking.
+
+This module persists lightweight sync trigger state for social platforms and
+optionally records an entry in the governance ledger so downstream systems can
+audit the activation trail. The API is intentionally small to support simple
+automation scripts, e.g.::
+
+    from vaultfire.signals import activate_sync_trigger
+
+    activate_sync_trigger(
+        user_tag="Ghostkey316",
+        platform="X",
+        sync_type="Passive Signal Tracking",
+        notify_on_likes=True,
+        notify_on_tags=True,
+        ledger_tie=True,
+    )
+
+The function stores the activation in ``status/sync_triggers.json`` by default
+and appends a ``sync-trigger`` record to ``governance-ledger.json`` when ledger
+linking is requested. Both paths are configurable via environment variables so
+tests or deployments can isolate their own state files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+from signal_log import log_signal
+
+SYNC_TRIGGER_PATH_ENV = "VAULTFIRE_SYNC_TRIGGER_PATH"
+LEDGER_PATH_ENV = "VAULTFIRE_GOVERNANCE_LEDGER_PATH"
+
+
+class SyncTriggerError(RuntimeError):
+    """Raised when activation parameters fail validation."""
+
+
+@dataclass
+class _SyncTriggerRecord:
+    user_tag: str
+    platform: str
+    sync_type: str
+    notify_on_likes: bool
+    notify_on_tags: bool
+    ledger_tie: bool
+    status: str
+    activated_at: str
+    ledger_reference: str | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        if self.ledger_reference is None:
+            data.pop("ledger_reference")
+        return data
+
+
+def _get_registry_path() -> Path:
+    custom = os.getenv(SYNC_TRIGGER_PATH_ENV)
+    if custom:
+        return Path(custom)
+    return Path("status") / "sync_triggers.json"
+
+
+def _get_ledger_path() -> Path:
+    custom = os.getenv(LEDGER_PATH_ENV)
+    if custom:
+        return Path(custom)
+    return Path("governance-ledger.json")
+
+
+def _current_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ensure_text(name: str, value: Any) -> str:
+    if not isinstance(value, str):
+        raise SyncTriggerError(f"{name} must be a string")
+    trimmed = value.strip()
+    if not trimmed:
+        raise SyncTriggerError(f"{name} cannot be empty")
+    return trimmed
+
+
+def _ensure_bool(name: str, value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    raise SyncTriggerError(f"{name} must be a boolean value")
+
+
+def _load_json_mapping(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def _write_json(path: Path, data: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(dict(data), indent=2) + "\n")
+
+
+def _load_ledger(path: Path) -> list[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return []
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def _write_ledger(path: Path, entries: list[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries, indent=2) + "\n")
+
+
+def activate_sync_trigger(
+    *,
+    user_tag: str,
+    platform: str,
+    sync_type: str,
+    notify_on_likes: bool,
+    notify_on_tags: bool,
+    ledger_tie: bool,
+) -> Dict[str, Any]:
+    """Register or update a passive sync trigger for a social identity."""
+
+    normalized_user = _ensure_text("user_tag", user_tag)
+    normalized_platform = _ensure_text("platform", platform).lower()
+    normalized_sync_type = _ensure_text("sync_type", sync_type)
+    likes_flag = _ensure_bool("notify_on_likes", notify_on_likes)
+    tags_flag = _ensure_bool("notify_on_tags", notify_on_tags)
+    ledger_flag = _ensure_bool("ledger_tie", ledger_tie)
+
+    registry_path = _get_registry_path()
+    registry = _load_json_mapping(registry_path)
+
+    key = f"{normalized_user}@{normalized_platform}"
+    timestamp = _current_timestamp()
+
+    record = _SyncTriggerRecord(
+        user_tag=normalized_user,
+        platform=normalized_platform,
+        sync_type=normalized_sync_type,
+        notify_on_likes=likes_flag,
+        notify_on_tags=tags_flag,
+        ledger_tie=ledger_flag,
+        status="active",
+        activated_at=timestamp,
+    )
+
+    ledger_reference: str | None = None
+    if ledger_flag:
+        ledger_path = _get_ledger_path()
+        ledger_entries = _load_ledger(ledger_path)
+        ledger_entry = {
+            "timestamp": timestamp,
+            "type": "sync-trigger",
+            "actor": normalized_user,
+            "details": {
+                "platform": normalized_platform,
+                "sync_type": normalized_sync_type,
+                "notify_on_likes": likes_flag,
+                "notify_on_tags": tags_flag,
+                "registry_key": key,
+            },
+        }
+        ledger_entries.append(ledger_entry)
+        _write_ledger(ledger_path, ledger_entries)
+        ledger_reference = ledger_entry["timestamp"]
+        record.ledger_reference = ledger_reference
+
+    registry[key] = record.to_dict()
+    _write_json(registry_path, registry)
+
+    try:
+        log_signal(
+            "sync-trigger",
+            {
+                "user_tag": normalized_user,
+                "platform": normalized_platform,
+                "sync_type": normalized_sync_type,
+                "notify_on_likes": likes_flag,
+                "notify_on_tags": tags_flag,
+                "ledger_tie": ledger_flag,
+                "ledger_reference": ledger_reference,
+            },
+        )
+    except Exception:
+        # Signal logging should not block registry updates.
+        pass
+
+    return record.to_dict()
+
+
+__all__ = ["activate_sync_trigger", "SyncTriggerError"]
+


### PR DESCRIPTION
## Summary
- add a vaultfire.signals module that persists passive sync trigger state and optional ledger entries
- expose the new signals helper via the package init for lazy loading
- cover registry, ledger, and boolean handling with targeted pytest cases

## Testing
- pytest tests/test_sync_triggers.py

------
https://chatgpt.com/codex/tasks/task_e_68e353c3ce1083228e88e103be87d1a1