### PR TITLE
Add legacy proof registry helper

### DIFF
--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -1,0 +1,72 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from vaultfire import legacy
+
+
+def _patch_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(legacy, "_REGISTRY_PATH", tmp_path / "registry.json")
+    monkeypatch.setattr(legacy, "_HISTORY_PATH", tmp_path / "history.log")
+
+
+def _sample_payload(**overrides):
+    payload = {
+        "identity": "Ghostkey-316",
+        "ENS": "ghostkey316.eth",
+        "wallet": "bpow20.cb.id",
+        "legacy_title": "The Face",
+        "ethical_core": "Ghostkey Ethics Framework v2.0",
+        "verified_contributor": True,
+        "metadata_locked": False,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_initiate_creates_registry(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    _patch_paths(monkeypatch, tmp_path)
+
+    record = legacy.initiate_eternal_proof_layer(**_sample_payload())
+
+    assert record["identity"] == "Ghostkey-316"
+    assert record["created_at"] == record["updated_at"]
+    assert (tmp_path / "registry.json").exists()
+
+    with open(tmp_path / "registry.json") as stream:
+        data = json.load(stream)
+    assert "Ghostkey-316" in data
+    assert data["Ghostkey-316"]["legacy_title"] == "The Face"
+
+    with open(tmp_path / "history.log") as stream:
+        history_line = stream.read().strip()
+    assert history_line
+
+
+def test_update_preserves_created_at(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    _patch_paths(monkeypatch, tmp_path)
+
+    first = legacy.initiate_eternal_proof_layer(**_sample_payload())
+    second = legacy.initiate_eternal_proof_layer(
+        **_sample_payload(legacy_title="The Eternal Face")
+    )
+
+    assert first["created_at"] == second["created_at"]
+    assert second["legacy_title"] == "The Eternal Face"
+
+
+def test_locked_metadata_cannot_be_updated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    _patch_paths(monkeypatch, tmp_path)
+
+    legacy.initiate_eternal_proof_layer(**_sample_payload(metadata_locked=True))
+
+    with pytest.raises(legacy.LegacyMetadataLockedError):
+        legacy.initiate_eternal_proof_layer(**_sample_payload(legacy_title="Updated"))
+
+
+def test_invalid_identity_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    _patch_paths(monkeypatch, tmp_path)
+
+    with pytest.raises(legacy.LegacyMetadataError):
+        legacy.initiate_eternal_proof_layer(**_sample_payload(identity="   "))

--- a/vaultfire/legacy.py
+++ b/vaultfire/legacy.py
@@ -1,0 +1,128 @@
+"""Legacy enrollment helpers for Vaultfire deployments.
+
+This module manages the "eternal proof" registry used by legacy partners.
+The :func:`initiate_eternal_proof_layer` helper validates the supplied
+metadata, persists it to the ``status`` directory, and returns the canonical
+record that was written.  The helpers are intentionally side-effect free
+outside of the designated registry paths so tests can patch them easily.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+__all__ = [
+    "LegacyMetadataError",
+    "LegacyMetadataLockedError",
+    "initiate_eternal_proof_layer",
+]
+
+
+class LegacyMetadataError(ValueError):
+    """Raised when the provided legacy metadata is invalid."""
+
+
+class LegacyMetadataLockedError(LegacyMetadataError):
+    """Raised when attempting to modify a metadata record that is locked."""
+
+
+_REGISTRY_PATH = Path("status") / "legacy_proofs.json"
+_HISTORY_PATH = Path("status") / "legacy_proofs.log"
+
+
+def _normalize_text(name: str, value: Any) -> str:
+    if not isinstance(value, str):
+        raise LegacyMetadataError(f"{name} must be a string")
+    value = value.strip()
+    if not value:
+        raise LegacyMetadataError(f"{name} cannot be empty")
+    return value
+
+
+def _normalize_bool(name: str, value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    raise LegacyMetadataError(f"{name} must be a boolean")
+
+
+def _load_registry() -> Dict[str, Dict[str, Any]]:
+    if not _REGISTRY_PATH.exists():
+        return {}
+    try:
+        with open(_REGISTRY_PATH) as stream:
+            data = json.load(stream)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    normalized: Dict[str, Dict[str, Any]] = {}
+    for key, value in data.items():
+        if isinstance(value, dict):
+            normalized[str(key)] = dict(value)
+    return normalized
+
+
+def _write_registry(registry: Mapping[str, Mapping[str, Any]]) -> None:
+    _REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(_REGISTRY_PATH, "w") as stream:
+        json.dump(registry, stream, indent=2, sort_keys=True)
+
+
+def _append_history(record: Mapping[str, Any]) -> None:
+    _HISTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(_HISTORY_PATH, "a") as stream:
+        stream.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def initiate_eternal_proof_layer(
+    *,
+    identity: str,
+    ENS: str,
+    wallet: str,
+    legacy_title: str,
+    ethical_core: str,
+    verified_contributor: bool,
+    metadata_locked: bool,
+) -> Mapping[str, Any]:
+    """Register or update an identity in the eternal proof registry.
+
+    Parameters are strictly validated to prevent accidental corruption of the
+    registry.  When ``metadata_locked`` is ``True`` an existing record can no
+    longer be modified and a :class:`LegacyMetadataLockedError` will be raised
+    if a subsequent call attempts to update it.
+    """
+
+    record_identity = _normalize_text("identity", identity)
+    payload: Dict[str, Any] = {
+        "identity": record_identity,
+        "ENS": _normalize_text("ENS", ENS),
+        "wallet": _normalize_text("wallet", wallet),
+        "legacy_title": _normalize_text("legacy_title", legacy_title),
+        "ethical_core": _normalize_text("ethical_core", ethical_core),
+        "verified_contributor": _normalize_bool(
+            "verified_contributor", verified_contributor
+        ),
+        "metadata_locked": _normalize_bool("metadata_locked", metadata_locked),
+    }
+
+    registry = _load_registry()
+    existing = registry.get(record_identity)
+    if existing and existing.get("metadata_locked"):
+        raise LegacyMetadataLockedError(
+            f"Metadata for {record_identity} is locked and cannot be updated"
+        )
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    if existing:
+        payload["created_at"] = existing.get("created_at", timestamp)
+    else:
+        payload["created_at"] = timestamp
+    payload["updated_at"] = timestamp
+
+    registry[record_identity] = payload
+    _write_registry(registry)
+    _append_history(payload)
+    return payload


### PR DESCRIPTION
## Summary
- add a `vaultfire.legacy` module that persists eternal proof records with validation and history logging
- raise clear exceptions when metadata is invalid or attempts are made to modify locked records
- cover the new helper with pytest-based regression tests

## Testing
- pytest tests/test_legacy.py

------
https://chatgpt.com/codex/tasks/task_e_68e35a397f40832285f2519650956fc3