### PR TITLE
docs: expand protocol safeguards with mission resonance tech

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Vaultfire Partner Changelog
 
+## 2025-10-28 — docs: quantum-aligned protocol expansion
+- Elevated `FORKABLE_PROTOCOL.md` to version 1.2 with mission resonance rollups,
+  confidential compute attestations, and FHE-streamed analytics channels while
+  keeping the manifesto lock intact.
+- Infused `vaultfire_3yr_protocol.yml` with sentinel mesh resilience, privacy-
+  preserving analytics, and sustainability metrics so the roadmap scales with
+  cutting-edge tech without compromising the core mission pillars.
+
 ## 2025-10-18 — docs: mission-locked protocol modernization
 - Upgraded `FORKABLE_PROTOCOL.md` to version 1.1 with zk-SNARK attestation, post-quantum key rotation, and AI collaboration loops that preserve the Ghostkey manifesto mission lock.
 - Expanded `vaultfire_3yr_protocol.yml` with innovation, security, and mission safeguard tracks that integrate edge inference meshes, zero-knowledge verification cadences, and alignment beacons.

--- a/FORKABLE_PROTOCOL.md
+++ b/FORKABLE_PROTOCOL.md
@@ -4,7 +4,7 @@ This document captures the baseline settings for Vaultfire forks. It mirrors the
 
 ```yaml
 forkable_protocol:
-  name: Vaultfire Codex v1.1
+  name: Vaultfire Codex v1.2
   origin: ghostkey316.eth
   registry: OpenRouter Alpha Sync (live)
   compatibility:
@@ -35,6 +35,9 @@ forkable_protocol:
     decentralized_identities:
       resolver: ENS + Spruce DIDKit
       revocation_window_days: 3
+    mission_resonance_rollups:
+      ledger: mirror/mission_resonance_ledger.json
+      audit_frequency: "bi-weekly council review"
   security_upgrades:
     post_quantum_ready: true
     pq_suite:
@@ -43,6 +46,12 @@ forkable_protocol:
     secure_inference_mesh:
       provider: EdgeBeam Secure Enclave
       failover: local_validator_pool
+    confidential_compute:
+      remote_attestation: proofs/enclave-attestation.json
+      shared_truth_anchor: proofs/mission_state_rollup.json
+    ai_red_team_ops:
+      cadence_days: 30
+      reporting_channel: governance/ai_red_team_playbooks.md
   ai_collaboration:
     co_processing_channels:
       - name: Symmetric Belief Loop
@@ -55,11 +64,20 @@ forkable_protocol:
         safeguards:
           - consent_required
           - ethics_guardian_alerts
+      - name: Quantum Mission Rollup
+        purpose: Stream mission resonance analytics through FHE-protected channels
+        safeguards:
+          - mission_lock_revalidation
+          - zero_trust_mesh_guard
   observability:
     realtime_dashboards:
       - guardian_loop.py
       - ghostloop_sync.py
     telemetry_sink: telemetry/telemetry_baseline.json
+    mission_streaming: hyperlane.mission_sync_channel
+  privacy_preserving_analytics:
+    fhe_cohort_model: analytics/fhe_mission_stewardship.json
+    secure_mpc_channel: guardian://mpc/mission-outcomes
   fork_id: "\U0001f510 Vaultfire-ForkCore-0001"
 ```
 

--- a/vaultfire_3yr_protocol.yml
+++ b/vaultfire_3yr_protocol.yml
@@ -9,6 +9,13 @@ technical_readiness:
     - zero_knowledge.attestation.zkSyncAnchor
     - ai_edge_inference.MeshGuardian
     - quantum_resilience.postQuantumKeySync
+    - holo_resonance.quantumHandoffOrchestrator
+    - privacy_preserving.fheStreamShield
+    - federated_learning.edgeAllianceCoordinator
+  edge_resilience:
+    sentinel_mesh_topology: mesh/sentinel_topology.json
+    zero_trust_overlay: overlays/mission_zero_trust.yaml
+    mission_state_rollup: proofs/mission_state_rollup.json
 
 pilot_metrics_validator:
   attestation_engine: engine.attestation_engine.attestation_engine
@@ -23,21 +30,36 @@ pilot_metrics_validator:
     prover: proofs/partner-proof-bundle.json
     verifier: trust/zkp-verifier.json
     cadence_days: 14
+  privacy_preserving_analytics:
+    fhe_cohort_model: analytics/fhe_mission_stewardship.json
+    secure_mpc_channel: guardian://mpc/mission-outcomes
+  synthetic_partner_datasets:
+    generator: simulators/mission_twin_generator.py
+    validation_window_days: 45
 
 innovation_stack:
   ai_co_governance:
     council_model: ai_collab.symbioticDeliberation.v2
     human_override: true
     feedback_loop: "user_signal -> AI synthesis -> council vote -> mission audit"
+  alignment_signal_graph:
+    resonance_ledger: mirror/mission_resonance_ledger.json
+    consensus_protocol: belief_quorum.zk_broadcast
+    escalation_threshold: 0.82
   consent_layer:
     personal_data_vault: secure_upload/consent_vault.json
     auditability: real_time
+    consent_verifier: proofs/consent_rollup.json
   interoperability:
     identity_mesh:
       - ENS
       - Spruce DIDKit
       - Worldcoin Proof of Personhood (opt-in)
     data_transport: libp2p-quic + TLS 1.3
+    mission_streaming: hyperlane.mission_sync_channel
+  sustainability:
+    carbon_accounting_oracle: sustainability/mission_carbon_feed.json
+    offset_commitment_ppm: 350
 
 security_posture:
   post_quantum:
@@ -48,6 +70,12 @@ security_posture:
     watchdog: system_watchdog.py
     failover_runbook: governance_runbook.yaml
     auto_isolation_seconds: 45
+  confidential_compute:
+    enclave_provider: EdgeBeam Secure Enclave
+    remote_attestation: proofs/enclave-attestation.json
+  ai_red_team_ops:
+    cadence_days: 30
+    playbooks: governance/ai_red_team_playbooks.md
 
 mission_safeguards:
   manifesto_uri: ghostkey_manifesto.md
@@ -59,6 +87,12 @@ mission_safeguards:
   alignment_beacons:
     - belief_engine/alignment_beacon.py
     - guardian_loop.py
+  covenant_rollups:
+    anchor_contract: vaultfire/protocol/mission_anchor.py
+    zk_history_digest: proofs/mission_lineage_digest.json
+  ethical_telemetry_filters:
+    bias_monitor: telemetry/bias_sentinel_config.json
+    consent_override: forbidden
 
 vaultfire:
   partnerReady: true
@@ -66,3 +100,4 @@ vaultfire:
     - "Year 1: Deploy mesh guardians across 5 pilot cohorts"
     - "Year 2: Expand zk attestation coverage to 90% of contributors"
     - "Year 3: Achieve post-quantum readiness certification and publish transparency ledger"
+    - "Year 3+: Stream mission resonance rollups to partner councils with FHE-protected analytics"


### PR DESCRIPTION
## Summary
- raise the forkable protocol spec to v1.2 with mission resonance rollups, confidential compute attestations, and FHE analytics channels that keep the manifesto lock in place
- extend the three-year roadmap with sentinel mesh resilience, privacy-preserving analytics, and sustainability commitments while preserving the core mission pillars
- log the protocol refresh in the changelog for partner visibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e35f80802083228f17b05bfe73a21d