### PR TITLE
feat: add stealth partner sync framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Vaultfire Partner Changelog
 
+## 2025-11-05 — feature: stealth partner sync and token registry
+- Introduced `vaultfire.partner.sync` to coordinate MPC-backed handshakes with
+  zk attestations and mission ledger mirroring while preserving wallet-only
+  identity semantics.
+- Added the Vaultfire Token Registry with cross-chain wallet commitments,
+  stealth yield minting hooks, and attested ledger logging for Base, Ethereum,
+  and Zora networks.
+- Delivered a stealth yield layer emitter featuring encrypted batch tracking,
+  rollback arbitration, and private loyalty emission aligned with Ghostkey-316.
+
 ## 2025-10-28 — docs: quantum-aligned protocol expansion
 - Elevated `FORKABLE_PROTOCOL.md` to version 1.2 with mission resonance rollups,
   confidential compute attestations, and FHE-streamed analytics channels while

--- a/missions/pilot_logs/mission_gamma.json
+++ b/missions/pilot_logs/mission_gamma.json
@@ -8,5 +8,20 @@
   "activation_signals": [
     {"signal": "referral_generated", "weight": 0.5},
     {"signal": "upgrade_click", "weight": 0.5}
+  ],
+  "partner_sync_snapshots": [
+    {
+      "handshake_id": "mission-gamma-sync-01",
+      "wallet_commitment": "8d9c1f7fd36fbe205de0682a7e75f6d84c21b7f623f7f7769446f8c9d0d33711",
+      "protocol": "ASM",
+      "chain": "base",
+      "stealth_yield_batches": [
+        {
+          "batch_id": "mission-gamma-yield-01",
+          "mission_event": "mission-gamma",
+          "attestation_hash": "1f55e1d1140d92a8e0942db1c3f850248f9c02d4b983f0d9e08913de53b25d5a"
+        }
+      ]
+    }
   ]
 }

--- a/tests/test_partner_sync.py
+++ b/tests/test_partner_sync.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vaultfire.mission import MissionLedger
+from vaultfire.partner.sync import HandshakeRequest, PartnerSyncEngine, PartnerSyncError
+
+
+def _read_ledger(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def test_partner_handshake_writes_ledger(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "mission-ledger.jsonl"
+    ledger = MissionLedger(path=ledger_path, component="test-partner")
+    engine = PartnerSyncEngine(ledger=ledger)
+
+    request = HandshakeRequest(
+        wallet_id="0xABCD1234",
+        partner_protocol="ASM",
+        signal_payload={"loyalty_signal": 7, "alignment": "ghostkey"},
+        chain="ethereum",
+        mission_reference="mission-gamma",
+    )
+
+    result = engine.initiate_handshake(request)
+    assert engine.verify_attestation(result)
+
+    entries = _read_ledger(ledger_path)
+    assert len(entries) == 1
+    payload = entries[0]["payload"]
+    assert payload["handshake_id"] == result.handshake_id
+    assert payload["wallet_commitment"] == result.wallet_commitment
+    serialized = json.dumps(entries[0])
+    assert "0xabcd1234" not in serialized
+
+    engine.mirror_handshake(result, component="mission-audit")
+    mirrored_entries = _read_ledger(ledger_path)
+    assert any(entry["category"] == "partner-sync-handshake-mirror" for entry in mirrored_entries)
+
+
+def test_rejects_unknown_protocol(tmp_path: Path) -> None:
+    ledger = MissionLedger(path=tmp_path / "ledger.jsonl", component="test")
+    engine = PartnerSyncEngine(ledger=ledger)
+
+    with pytest.raises(PartnerSyncError):
+        engine.initiate_handshake(
+            HandshakeRequest(
+                wallet_id="0xEF",
+                partner_protocol="unsupported",
+                signal_payload={},
+                chain="base",
+            )
+        )

--- a/tests/test_stealth_yield_emitter.py
+++ b/tests/test_stealth_yield_emitter.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from vaultfire.mission import MissionLedger
+
+stealth_module = importlib.import_module("vaultfire.yield.stealth_emitter")
+StealthYieldBatch = getattr(stealth_module, "StealthYieldBatch")
+StealthYieldEmitter = getattr(stealth_module, "StealthYieldEmitter")
+
+
+def _read_ledger(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def test_emitter_produces_attested_batch(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "ledger.jsonl"
+    ledger = MissionLedger(path=ledger_path, component="test-stealth-yield")
+    emitter = StealthYieldEmitter(ledger=ledger)
+
+    distribution_one = emitter.build_distribution(
+        wallet_id="0xabc1",
+        amount=10.5,
+        loyalty_points=1.0,
+        traits={"mission": "gamma"},
+    )
+    distribution_two = emitter.build_distribution(
+        wallet_id="0xabc2",
+        amount=5.25,
+        loyalty_points=0.5,
+    )
+
+    batch = emitter.emit(
+        mission_event="mission-gamma",
+        chain="ethereum",
+        distributions=[distribution_one, distribution_two],
+        attestation_context={"handshake_id": "handshake-123"},
+    )
+    assert isinstance(batch, StealthYieldBatch)
+    assert emitter.verify_batch(batch)
+    assert len(batch.wallet_commitments) == 2
+
+    rollback_record_id = emitter.request_rollback(batch, reason="alignment-check")
+    assert rollback_record_id
+
+    dispute_resolution = emitter.resolve_dispute(
+        batch,
+        wallet_commitment=batch.wallet_commitments[0],
+        evidence={"note": "resolved"},
+    )
+    assert dispute_resolution["wallet_commitment"] == batch.wallet_commitments[0]
+
+    entries = _read_ledger(ledger_path)
+    categories = {entry["category"] for entry in entries}
+    assert {"stealth-yield-batch", "stealth-yield-rollback", "stealth-yield-dispute"}.issubset(categories)
+    serialized = json.dumps(entries)
+    assert "0xabc1" not in serialized
+
+
+def test_emitter_validates_distribution_amounts(tmp_path: Path) -> None:
+    emitter = StealthYieldEmitter(ledger=MissionLedger(path=tmp_path / "ledger.jsonl"))
+
+    with pytest.raises(ValueError):
+        emitter.build_distribution(wallet_id="0xabc", amount=0, loyalty_points=0)
+
+    with pytest.raises(ValueError):
+        emitter.build_distribution(wallet_id="0xabc", amount=1, loyalty_points=-1)

--- a/tests/test_token_registry.py
+++ b/tests/test_token_registry.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vaultfire.mission import MissionLedger
+from vaultfire.partner.sync import HandshakeRequest, PartnerSyncEngine
+from vaultfire.token_registry import TokenRegistryRecord, VaultfireTokenRegistry
+
+
+def _read_ledger(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def test_registry_maps_signal_and_mints_yield(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "ledger.jsonl"
+    ledger = MissionLedger(path=ledger_path, component="test-token-registry")
+    engine = PartnerSyncEngine(ledger=ledger)
+    registry = VaultfireTokenRegistry(ledger=ledger)
+
+    handshake = engine.initiate_handshake(
+        HandshakeRequest(
+            wallet_id="0x998877",
+            partner_protocol="ASM",
+            signal_payload={"score": 88},
+            chain="base",
+        )
+    )
+
+    registration = registry.register_wallet("0x998877", chain="base", traits={"tier": "silver"})
+    assert registry.is_wallet_registered("0x998877", chain="base")
+
+    record = registry.map_yield_signal(
+        wallet_id="0x998877",
+        chain="base",
+        signal_type="loyalty",
+        payload={"boost": 1.25},
+        handshake=handshake,
+    )
+    assert isinstance(record, TokenRegistryRecord)
+    assert record.wallet_commitment == registration.commitment
+    assert record.chain == "base"
+
+    batch = registry.stealth_mint_yield(
+        wallet_id="0x998877",
+        chain="base",
+        mission_event="mission-gamma",
+        amount=42.5,
+        handshake=handshake,
+        loyalty_points=5.0,
+    )
+    assert registry.supported_chains
+    assert batch.wallet_commitments[0] == registration.commitment
+
+    entries = _read_ledger(ledger_path)
+    categories = {entry["category"] for entry in entries}
+    assert "token-registry-registration" in categories
+    assert "token-registry-signal" in categories
+    assert "token-registry-yield" in categories
+    serialized = json.dumps(entries)
+    assert "0x998877" not in serialized

--- a/vaultfire/__init__.py
+++ b/vaultfire/__init__.py
@@ -27,6 +27,9 @@ __all__ = [
     "signals",
     "quantum",
     "anchor",
+    "partner",
+    "token_registry",
+    "yield_layer",
     "auto_refund",
     "should_refund",
     "freeze_refunds",
@@ -51,6 +54,9 @@ _LAZY_MODULES: Dict[str, str] = {
     "signals": ".signals",
     "quantum": ".quantum",
     "anchor": ".anchor",
+    "partner": ".partner",
+    "token_registry": ".token_registry",
+    "yield_layer": ".yield",
 }
 
 _REFUND_EXPORTS: Iterable[str] = (

--- a/vaultfire/partner/__init__.py
+++ b/vaultfire/partner/__init__.py
@@ -1,0 +1,15 @@
+"""Stealth-compatible partner sync orchestration."""
+
+from .sync import (
+    HandshakeRequest,
+    HandshakeResult,
+    PartnerSyncEngine,
+    PartnerSyncError,
+)
+
+__all__ = [
+    "HandshakeRequest",
+    "HandshakeResult",
+    "PartnerSyncEngine",
+    "PartnerSyncError",
+]

--- a/vaultfire/partner/sync.py
+++ b/vaultfire/partner/sync.py
@@ -1,0 +1,252 @@
+"""Partner sync handshake orchestration with stealth safeguards."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+from uuid import uuid4
+
+from vaultfire.mission import LedgerMetadata, MissionLedger
+from vaultfire.security.fhe import Ciphertext, FHECipherSuite
+
+_SUPPORTED_PROTOCOLS = frozenset({"ASM", "NS3", "VX-STEALTH"})
+
+
+class PartnerSyncError(RuntimeError):
+    """Raised when a partner sync handshake cannot be completed."""
+
+
+def _normalize_wallet(wallet_id: str) -> str:
+    if not isinstance(wallet_id, str):
+        raise ValueError("wallet_id must be a string")
+    candidate = wallet_id.strip()
+    if not candidate:
+        raise ValueError("wallet_id cannot be empty")
+    return candidate.lower()
+
+
+def _normalize_protocol(protocol: str, *, supported: Iterable[str]) -> str:
+    if not isinstance(protocol, str):
+        raise ValueError("partner_protocol must be a string")
+    candidate = protocol.strip().upper()
+    if not candidate:
+        raise ValueError("partner_protocol cannot be empty")
+    if candidate not in supported:
+        raise PartnerSyncError(f"protocol {candidate} is not whitelisted")
+    return candidate
+
+
+def _normalize_chain(chain: str) -> str:
+    if not isinstance(chain, str):
+        raise ValueError("chain must be a string")
+    candidate = chain.strip().lower()
+    if candidate not in {"base", "ethereum", "zora"}:
+        raise ValueError("chain must be base, ethereum, or zora")
+    return candidate
+
+
+def _hash_wallet(wallet_id: str) -> str:
+    return hashlib.shake_256(wallet_id.encode("utf-8")).hexdigest(64)
+
+
+def _fingerprint_ciphertext(ciphertext: Ciphertext) -> str:
+    serialized = ciphertext.serialize()
+    digest = hashlib.blake2b(
+        repr(sorted(serialized.items())).encode("utf-8"), digest_size=32
+    ).hexdigest()
+    return digest
+
+
+@dataclass(frozen=True)
+class HandshakeRequest:
+    """Input payload for initiating a partner sync handshake."""
+
+    wallet_id: str
+    partner_protocol: str
+    signal_payload: Mapping[str, Any] = field(default_factory=dict)
+    chain: str = "ethereum"
+    mission_reference: Optional[str] = None
+    nonce: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class HandshakeResult:
+    """Immutable representation of a completed handshake."""
+
+    handshake_id: str
+    wallet_commitment: str
+    protocol: str
+    chain: str
+    zk_attestation: Mapping[str, Any]
+    mpc_ciphertext: Ciphertext
+    timestamp: str
+    mission_reference: Optional[str]
+    ledger_record_id: str
+
+    def fingerprint(self) -> str:
+        """Return a deterministic fingerprint for downstream registries."""
+
+        return hashlib.blake2b(
+            (
+                self.handshake_id
+                + self.wallet_commitment
+                + self.protocol
+                + self.chain
+                + self.timestamp
+            ).encode("utf-8"),
+            digest_size=32,
+        ).hexdigest()
+
+
+class PartnerSyncEngine:
+    """Coordinates stealth partner handshakes with MPC+zk guarantees."""
+
+    def __init__(
+        self,
+        *,
+        ledger: MissionLedger | None = None,
+        cipher_suite: FHECipherSuite | None = None,
+        supported_protocols: Iterable[str] | None = None,
+    ) -> None:
+        self._ledger = ledger or MissionLedger(component="vaultfire.partner.sync")
+        self._cipher_suite = cipher_suite or FHECipherSuite()
+        self._supported_protocols = frozenset(supported_protocols or _SUPPORTED_PROTOCOLS)
+        self._sessions: MutableMapping[str, Mapping[str, Any]] = {}
+
+    @property
+    def supported_protocols(self) -> frozenset[str]:
+        return frozenset(self._supported_protocols)
+
+    def register_protocol(self, protocol: str) -> None:
+        """Allow an additional protocol to complete handshakes."""
+
+        normalized = protocol.strip().upper()
+        if not normalized:
+            raise ValueError("protocol cannot be empty")
+        self._supported_protocols = frozenset(
+            set(self._supported_protocols) | {normalized}
+        )
+
+    def initiate_handshake(self, request: HandshakeRequest) -> HandshakeResult:
+        """Create a stealth handshake with zk+MPC attestations."""
+
+        wallet = _normalize_wallet(request.wallet_id)
+        protocol = _normalize_protocol(
+            request.partner_protocol, supported=self._supported_protocols
+        )
+        chain = _normalize_chain(request.chain)
+        nonce = request.nonce or secrets.token_hex(16)
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        wallet_commitment = _hash_wallet(wallet)
+        payload_digest = {
+            "wallet_commitment": wallet_commitment,
+            "protocol": protocol,
+            "nonce": nonce,
+            "chain": chain,
+            "timestamp": timestamp,
+            "mission_reference": request.mission_reference,
+            "signal_payload": dict(request.signal_payload),
+        }
+
+        ciphertext = self._cipher_suite.encrypt_record(
+            payload_digest,
+            sensitive_fields=("signal_payload", "wallet_commitment"),
+        )
+        zk_attestation = self._cipher_suite.generate_zero_knowledge_commitment(
+            ciphertext,
+            context=f"partner-sync::{protocol}::{chain}",
+        )
+        handshake_id = uuid4().hex
+        record = self._ledger.append(
+            category="partner-sync-handshake",
+            payload={
+                "handshake_id": handshake_id,
+                "wallet_commitment": wallet_commitment,
+                "protocol": protocol,
+                "chain": chain,
+                "nonce": nonce,
+                "zk_attestation": zk_attestation,
+                "mpc_fingerprint": _fingerprint_ciphertext(ciphertext),
+                "mission_reference": request.mission_reference,
+            },
+            metadata=LedgerMetadata(
+                partner_id=None,
+                narrative="Stealth partner handshake",
+                tags=("partner-sync", protocol.lower(), chain),
+                extra={
+                    "handshake_id": handshake_id,
+                    "protocol": protocol,
+                    "chain": chain,
+                },
+            ),
+        )
+
+        result = HandshakeResult(
+            handshake_id=handshake_id,
+            wallet_commitment=wallet_commitment,
+            protocol=protocol,
+            chain=chain,
+            zk_attestation=zk_attestation,
+            mpc_ciphertext=ciphertext,
+            timestamp=timestamp,
+            mission_reference=request.mission_reference,
+            ledger_record_id=record.record_id,
+        )
+        self._sessions[handshake_id] = {
+            "wallet_commitment": wallet_commitment,
+            "protocol": protocol,
+            "chain": chain,
+            "nonce": nonce,
+            "timestamp": timestamp,
+            "zk_attestation": zk_attestation,
+            "mpc_fingerprint": _fingerprint_ciphertext(ciphertext),
+            "mission_reference": request.mission_reference,
+        }
+        return result
+
+    def mirror_handshake(self, result: HandshakeResult, *, component: str) -> None:
+        """Mirror an existing handshake into another mission component."""
+
+        if result.handshake_id not in self._sessions:
+            raise PartnerSyncError("handshake is not recognised")
+        self._ledger.append(
+            category="partner-sync-handshake-mirror",
+            payload={
+                "handshake_id": result.handshake_id,
+                "component": component,
+                "zk_attestation": result.zk_attestation,
+                "mpc_fingerprint": _fingerprint_ciphertext(result.mpc_ciphertext),
+            },
+            metadata=LedgerMetadata(
+                partner_id=None,
+                narrative="Mirror handshake to mission component",
+                tags=("partner-sync", component),
+                extra={"handshake_id": result.handshake_id},
+            ),
+        )
+
+    def verify_attestation(self, result: HandshakeResult) -> bool:
+        """Validate that a handshake result matches the stored zk commitment."""
+
+        session = self._sessions.get(result.handshake_id)
+        if not session:
+            return False
+        if session["wallet_commitment"] != result.wallet_commitment:
+            return False
+        recalculated = self._cipher_suite.generate_zero_knowledge_commitment(
+            result.mpc_ciphertext,
+            context=f"partner-sync::{result.protocol}::{result.chain}",
+        )
+        return recalculated == result.zk_attestation
+
+
+__all__ = [
+    "HandshakeRequest",
+    "HandshakeResult",
+    "PartnerSyncEngine",
+    "PartnerSyncError",
+]

--- a/vaultfire/token_registry/__init__.py
+++ b/vaultfire/token_registry/__init__.py
@@ -1,0 +1,277 @@
+"""Vaultfire Token Registry (VTR) with stealth yield coordination."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence, TYPE_CHECKING
+from uuid import uuid4
+
+from vaultfire.mission import LedgerMetadata, MissionLedger
+from vaultfire.partner.sync import HandshakeResult
+from vaultfire.security.fhe import Ciphertext, FHECipherSuite
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    import importlib
+
+    _stealth_module = importlib.import_module("vaultfire.yield.stealth_emitter")
+    StealthYieldBatch = _stealth_module.StealthYieldBatch
+    StealthYieldDistribution = _stealth_module.StealthYieldDistribution
+    StealthYieldEmitter = _stealth_module.StealthYieldEmitter
+else:  # pragma: no cover - runtime fallbacks for typing only names
+    StealthYieldBatch = Any  # type: ignore[assignment]
+    StealthYieldDistribution = Any  # type: ignore[assignment]
+    StealthYieldEmitter = Any  # type: ignore[assignment]
+
+_SUPPORTED_CHAINS = ("base", "ethereum", "zora")
+
+
+def _normalize_wallet(wallet_id: str) -> str:
+    if not isinstance(wallet_id, str):
+        raise ValueError("wallet_id must be a string")
+    candidate = wallet_id.strip()
+    if not candidate:
+        raise ValueError("wallet_id cannot be empty")
+    return candidate.lower()
+
+
+def _normalize_chain(chain: str) -> str:
+    normalized = chain.strip().lower()
+    if normalized not in _SUPPORTED_CHAINS:
+        raise ValueError("Unsupported chain for token registry")
+    return normalized
+
+
+def _shake_commitment(value: str) -> str:
+    digest = hashlib.shake_256(value.encode("utf-8"))
+    return digest.hexdigest(64)
+
+
+def _ledger_tags(chain: str, signal_type: str) -> Sequence[str]:
+    return ("token-registry", chain, signal_type)
+
+
+@dataclass(frozen=True)
+class WalletRegistration:
+    """Immutable snapshot of a registered wallet commitment."""
+
+    wallet_id: str
+    chain: str
+    commitment: str
+    registered_at: str
+    traits: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TokenRegistryRecord:
+    """Record produced when mapping a yield or loyalty signal."""
+
+    record_id: str
+    wallet_commitment: str
+    chain: str
+    signal_type: str
+    ciphertext: Ciphertext
+    attestation: Mapping[str, Any]
+    handshake_fingerprint: str
+    created_at: str
+
+
+class VaultfireTokenRegistry:
+    """Registry linking partner signals to wallets with stealth security."""
+
+    def __init__(
+        self,
+        *,
+        ledger: MissionLedger | None = None,
+        cipher_suite: FHECipherSuite | None = None,
+        supported_chains: Sequence[str] | None = None,
+    ) -> None:
+        self._ledger = ledger or MissionLedger(component="vaultfire.token-registry")
+        self._cipher_suite = cipher_suite or FHECipherSuite()
+        chains = tuple((_SUPPORTED_CHAINS if supported_chains is None else supported_chains))
+        normalized = {_normalize_chain(chain) for chain in chains}
+        self._supported_chains = tuple(sorted(normalized))
+        self._registry: MutableMapping[str, WalletRegistration] = {}
+
+    @property
+    def supported_chains(self) -> Sequence[str]:
+        return self._supported_chains
+
+    def register_wallet(
+        self,
+        wallet_id: str,
+        *,
+        chain: str,
+        traits: Mapping[str, Any] | None = None,
+    ) -> WalletRegistration:
+        """Register a wallet commitment for stealth tracking."""
+
+        normalized_wallet = _normalize_wallet(wallet_id)
+        normalized_chain = _normalize_chain(chain)
+        if normalized_chain not in self._supported_chains:
+            raise ValueError("Chain not enabled in this registry")
+        commitment = _shake_commitment(normalized_wallet)
+        timestamp = datetime.now(timezone.utc).isoformat()
+        registration = WalletRegistration(
+            wallet_id=normalized_wallet,
+            chain=normalized_chain,
+            commitment=commitment,
+            registered_at=timestamp,
+            traits=dict(traits or {}),
+        )
+        self._registry[f"{normalized_chain}:{commitment}"] = registration
+        self._ledger.append(
+            category="token-registry-registration",
+            payload={
+                "wallet_commitment": commitment,
+                "chain": normalized_chain,
+                "traits": dict(traits or {}),
+                "registration_id": uuid4().hex,
+            },
+            metadata=LedgerMetadata(
+                partner_id=None,
+                narrative="Wallet registered for stealth yield tracking",
+                tags=("token-registry", normalized_chain),
+                extra={"commitment": commitment},
+            ),
+        )
+        return registration
+
+    def is_wallet_registered(self, wallet_id: str, *, chain: str) -> bool:
+        normalized_chain = _normalize_chain(chain)
+        normalized_wallet = _normalize_wallet(wallet_id)
+        commitment = _shake_commitment(normalized_wallet)
+        return f"{normalized_chain}:{commitment}" in self._registry
+
+    def map_yield_signal(
+        self,
+        *,
+        wallet_id: str,
+        chain: str,
+        signal_type: str,
+        payload: Mapping[str, Any],
+        handshake: HandshakeResult,
+    ) -> TokenRegistryRecord:
+        """Map a yield or loyalty signal to a registered wallet."""
+
+        normalized_chain = _normalize_chain(chain)
+        normalized_wallet = _normalize_wallet(wallet_id)
+        commitment = _shake_commitment(normalized_wallet)
+        if f"{normalized_chain}:{commitment}" not in self._registry:
+            raise ValueError("wallet must be registered before mapping signals")
+
+        ciphertext = self._cipher_suite.encrypt_record(
+            {
+                "wallet_commitment": commitment,
+                "signal_type": signal_type,
+                "payload": dict(payload),
+                "handshake_fingerprint": handshake.fingerprint(),
+            },
+            sensitive_fields=("payload", "wallet_commitment"),
+        )
+        attestation = self._cipher_suite.generate_zero_knowledge_commitment(
+            ciphertext,
+            context=f"token-registry::{signal_type}::{normalized_chain}",
+        )
+        timestamp = datetime.now(timezone.utc).isoformat()
+        record_id = uuid4().hex
+        self._ledger.append(
+            category="token-registry-signal",
+            payload={
+                "record_id": record_id,
+                "wallet_commitment": commitment,
+                "chain": normalized_chain,
+                "signal_type": signal_type,
+                "handshake_id": handshake.handshake_id,
+                "attestation": attestation,
+            },
+            metadata=LedgerMetadata(
+                partner_id=None,
+                narrative="Mapped partner signal to wallet commitment",
+                tags=_ledger_tags(normalized_chain, signal_type),
+                extra={
+                    "handshake_fingerprint": handshake.fingerprint(),
+                    "signal_type": signal_type,
+                },
+            ),
+        )
+        return TokenRegistryRecord(
+            record_id=record_id,
+            wallet_commitment=commitment,
+            chain=normalized_chain,
+            signal_type=signal_type,
+            ciphertext=ciphertext,
+            attestation=attestation,
+            handshake_fingerprint=handshake.fingerprint(),
+            created_at=timestamp,
+        )
+
+    def stealth_mint_yield(
+        self,
+        *,
+        wallet_id: str,
+        chain: str,
+        mission_event: str,
+        amount: float,
+        handshake: HandshakeResult,
+        emitter: "StealthYieldEmitter" | None = None,
+        loyalty_points: float | None = None,
+    ) -> "StealthYieldBatch":
+        """Stealth mint a yield token tied to a mission event."""
+
+        normalized_chain = _normalize_chain(chain)
+        normalized_wallet = _normalize_wallet(wallet_id)
+        commitment = _shake_commitment(normalized_wallet)
+        if f"{normalized_chain}:{commitment}" not in self._registry:
+            raise ValueError("wallet must be registered before minting yield")
+        if emitter is None:
+            import importlib
+
+            stealth_module = importlib.import_module("vaultfire.yield.stealth_emitter")
+            StealthYieldEmitter = getattr(stealth_module, "StealthYieldEmitter")
+            emitter = StealthYieldEmitter(ledger=self._ledger, cipher_suite=self._cipher_suite)
+
+        distribution: "StealthYieldDistribution" = emitter.build_distribution(
+            wallet_id=normalized_wallet,
+            amount=amount,
+            loyalty_points=loyalty_points or 0.0,
+            traits={"wallet_commitment": commitment},
+        )
+        batch = emitter.emit(
+            mission_event=mission_event,
+            chain=normalized_chain,
+            distributions=[distribution],
+            attestation_context={
+                "handshake_id": handshake.handshake_id,
+                "handshake_commitment": handshake.wallet_commitment,
+                "handshake_fingerprint": handshake.fingerprint(),
+            },
+        )
+        self._ledger.append(
+            category="token-registry-yield",
+            payload={
+                "mission_event": mission_event,
+                "wallet_commitment": commitment,
+                "chain": normalized_chain,
+                "batch_id": batch.batch_id,
+                "attestation": batch.integrity_attestation,
+            },
+            metadata=LedgerMetadata(
+                partner_id=None,
+                narrative="Stealth yield minted",
+                tags=("token-registry", normalized_chain, "yield"),
+                extra={
+                    "handshake_fingerprint": handshake.fingerprint(),
+                    "batch_id": batch.batch_id,
+                },
+            ),
+        )
+        return batch
+
+
+__all__ = [
+    "VaultfireTokenRegistry",
+    "TokenRegistryRecord",
+    "WalletRegistration",
+]

--- a/vaultfire/yield/__init__.py
+++ b/vaultfire/yield/__init__.py
@@ -1,0 +1,13 @@
+"""Stealth yield layer utilities."""
+
+from .stealth_emitter import (
+    StealthYieldBatch,
+    StealthYieldDistribution,
+    StealthYieldEmitter,
+)
+
+__all__ = [
+    "StealthYieldBatch",
+    "StealthYieldDistribution",
+    "StealthYieldEmitter",
+]

--- a/vaultfire/yield/stealth_emitter.py
+++ b/vaultfire/yield/stealth_emitter.py
@@ -1,0 +1,277 @@
+"""Stealth yield emission utilities with zk arbitration."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence
+from uuid import uuid4
+
+from vaultfire.mission import LedgerMetadata, MissionLedger
+from vaultfire.security.fhe import Ciphertext, FHECipherSuite
+
+
+def _normalize_wallet(wallet_id: str) -> str:
+    if not isinstance(wallet_id, str):
+        raise ValueError("wallet_id must be a string")
+    candidate = wallet_id.strip()
+    if not candidate:
+        raise ValueError("wallet_id cannot be empty")
+    return candidate.lower()
+
+
+def _normalize_event(event: str) -> str:
+    candidate = (event or "").strip()
+    if not candidate:
+        raise ValueError("mission_event must be provided")
+    return candidate
+
+
+def _normalize_chain(chain: str) -> str:
+    candidate = chain.strip().lower()
+    if candidate not in {"base", "ethereum", "zora"}:
+        raise ValueError("chain must be base, ethereum, or zora")
+    return candidate
+
+
+def _hash_wallet(wallet_id: str) -> str:
+    return hashlib.shake_256(wallet_id.encode("utf-8")).hexdigest(64)
+
+
+def _fingerprint_batch(batch_id: str, wallet_commitments: Sequence[str]) -> str:
+    digest_input = batch_id + "::" + "::".join(sorted(wallet_commitments))
+    return hashlib.blake2b(digest_input.encode("utf-8"), digest_size=32).hexdigest()
+
+
+@dataclass(frozen=True)
+class StealthYieldDistribution:
+    """Representation of a single wallet yield distribution."""
+
+    wallet_id: str
+    amount: float
+    loyalty_points: float = 0.0
+    traits: Mapping[str, Any] = field(default_factory=dict)
+
+    def wallet_commitment(self) -> str:
+        return _hash_wallet(_normalize_wallet(self.wallet_id))
+
+
+@dataclass(frozen=True)
+class StealthYieldBatch:
+    """Encrypted batch of stealth yield distributions."""
+
+    batch_id: str
+    mission_event: str
+    chain: str
+    timestamp: str
+    wallet_commitments: Sequence[str]
+    ciphertexts: Sequence[Ciphertext]
+    integrity_attestation: Mapping[str, Any]
+    attestation_context: Mapping[str, Any]
+    alignment_proof: Mapping[str, Any]
+
+    def serialize(self) -> Dict[str, Any]:
+        return {
+            "batch_id": self.batch_id,
+            "mission_event": self.mission_event,
+            "chain": self.chain,
+            "timestamp": self.timestamp,
+            "wallet_commitments": list(self.wallet_commitments),
+            "ciphertexts": [cipher.serialize() for cipher in self.ciphertexts],
+            "integrity_attestation": dict(self.integrity_attestation),
+            "attestation_context": dict(self.attestation_context),
+            "alignment_proof": dict(self.alignment_proof),
+        }
+
+
+class StealthYieldEmitter:
+    """Emit stealth yield with encrypted tracking and zk arbitration."""
+
+    def __init__(
+        self,
+        *,
+        ledger: MissionLedger | None = None,
+        cipher_suite: FHECipherSuite | None = None,
+    ) -> None:
+        self._ledger = ledger or MissionLedger(component="vaultfire.stealth-yield")
+        self._cipher_suite = cipher_suite or FHECipherSuite()
+        self._batches: MutableMapping[str, StealthYieldBatch] = {}
+
+    def build_distribution(
+        self,
+        *,
+        wallet_id: str,
+        amount: float,
+        loyalty_points: float = 0.0,
+        traits: Mapping[str, Any] | None = None,
+    ) -> StealthYieldDistribution:
+        """Create a normalized distribution entry."""
+
+        if amount <= 0:
+            raise ValueError("amount must be positive")
+        if loyalty_points < 0:
+            raise ValueError("loyalty_points cannot be negative")
+        normalized_wallet = _normalize_wallet(wallet_id)
+        return StealthYieldDistribution(
+            wallet_id=normalized_wallet,
+            amount=float(amount),
+            loyalty_points=float(loyalty_points),
+            traits=dict(traits or {}),
+        )
+
+    def emit(
+        self,
+        *,
+        mission_event: str,
+        chain: str,
+        distributions: Sequence[StealthYieldDistribution],
+        attestation_context: Mapping[str, Any],
+    ) -> StealthYieldBatch:
+        """Emit a stealth batch for the provided distributions."""
+
+        normalized_event = _normalize_event(mission_event)
+        normalized_chain = _normalize_chain(chain)
+        if not distributions:
+            raise ValueError("at least one distribution is required")
+
+        batch_id = uuid4().hex
+        timestamp = datetime.now(timezone.utc).isoformat()
+        wallet_commitments = [distribution.wallet_commitment() for distribution in distributions]
+        ciphertexts = [
+            self._cipher_suite.encrypt_record(
+                {
+                    "wallet_commitment": distribution.wallet_commitment(),
+                    "amount": distribution.amount,
+                    "loyalty_points": distribution.loyalty_points,
+                    "traits": dict(distribution.traits),
+                },
+                sensitive_fields=("traits", "wallet_commitment"),
+            )
+            for distribution in distributions
+        ]
+        integrity_attestation = self._cipher_suite.attest_integrity(ciphertexts)
+        alignment_proof = {
+            "batch_fingerprint": _fingerprint_batch(batch_id, wallet_commitments),
+            "context_hash": hashlib.sha3_256(
+                repr(sorted(attestation_context.items())).encode("utf-8")
+            ).hexdigest(),
+        }
+        batch = StealthYieldBatch(
+            batch_id=batch_id,
+            mission_event=normalized_event,
+            chain=normalized_chain,
+            timestamp=timestamp,
+            wallet_commitments=tuple(wallet_commitments),
+            ciphertexts=tuple(ciphertexts),
+            integrity_attestation=dict(integrity_attestation),
+            attestation_context=dict(attestation_context),
+            alignment_proof=alignment_proof,
+        )
+        self._batches[batch_id] = batch
+        self._ledger.append(
+            category="stealth-yield-batch",
+            payload={
+                "batch_id": batch.batch_id,
+                "mission_event": normalized_event,
+                "chain": normalized_chain,
+                "wallet_commitments": wallet_commitments,
+                "integrity_attestation": integrity_attestation,
+                "alignment_proof": alignment_proof,
+            },
+            metadata=LedgerMetadata(
+                partner_id=None,
+                narrative="Stealth yield batch emitted",
+                tags=("stealth-yield", normalized_chain),
+                extra={"batch_id": batch.batch_id},
+            ),
+        )
+        return batch
+
+    def verify_batch(self, batch: StealthYieldBatch) -> bool:
+        """Verify a batch by recomputing the integrity attestation."""
+
+        recomputed = self._cipher_suite.attest_integrity(batch.ciphertexts)
+        return dict(recomputed) == dict(batch.integrity_attestation)
+
+    def request_rollback(self, batch: StealthYieldBatch, *, reason: str) -> str:
+        """Record a rollback request with zk arbitration hints."""
+
+        if batch.batch_id not in self._batches:
+            raise ValueError("batch is not managed by this emitter")
+        arbitration_hash = hashlib.blake2b(
+            (
+                batch.batch_id
+                + "::".join(sorted(batch.wallet_commitments))
+                + reason
+            ).encode("utf-8"),
+            digest_size=32,
+        ).hexdigest()
+        record = self._ledger.append(
+            category="stealth-yield-rollback",
+            payload={
+                "batch_id": batch.batch_id,
+                "reason": reason,
+                "arbitration_hash": arbitration_hash,
+            },
+            metadata=LedgerMetadata(
+                partner_id=None,
+                narrative="Stealth yield rollback requested",
+                tags=("stealth-yield", "rollback"),
+                extra={
+                    "batch_id": batch.batch_id,
+                    "alignment_proof": batch.alignment_proof,
+                },
+            ),
+        )
+        return record.record_id
+
+    def resolve_dispute(
+        self,
+        batch: StealthYieldBatch,
+        *,
+        wallet_commitment: str,
+        evidence: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        """Resolve a dispute using zk arbitration primitives."""
+
+        normalized_commitment = wallet_commitment.strip().lower()
+        if normalized_commitment not in batch.wallet_commitments:
+            raise ValueError("wallet commitment not part of batch")
+        zk_arbitration_proof = hashlib.sha3_256(
+            (
+                batch.batch_id
+                + normalized_commitment
+                + repr(sorted(evidence.items()))
+            ).encode("utf-8")
+        ).hexdigest()
+        self._ledger.append(
+            category="stealth-yield-dispute",
+            payload={
+                "batch_id": batch.batch_id,
+                "wallet_commitment": normalized_commitment,
+                "zk_arbitration_proof": zk_arbitration_proof,
+                "evidence": dict(evidence),
+            },
+            metadata=LedgerMetadata(
+                partner_id=None,
+                narrative="Stealth yield dispute resolved",
+                tags=("stealth-yield", "dispute"),
+                extra={"batch_id": batch.batch_id},
+            ),
+        )
+        return {
+            "batch_id": batch.batch_id,
+            "wallet_commitment": normalized_commitment,
+            "zk_arbitration_proof": zk_arbitration_proof,
+        }
+
+    def get_batch(self, batch_id: str) -> Optional[StealthYieldBatch]:
+        return self._batches.get(batch_id)
+
+
+__all__ = [
+    "StealthYieldEmitter",
+    "StealthYieldBatch",
+    "StealthYieldDistribution",
+]


### PR DESCRIPTION
## Summary
- add the stealth-compatible `vaultfire.partner.sync` handshake service with MPC aggregation and zk attestation mirroring into the mission ledger
- introduce the Vaultfire Token Registry to map cross-chain wallet commitments and drive stealth yield minting through the stealth emitter layer
- deliver a stealth yield emitter with encrypted batch attestations, rollback arbitration, and ledger logging plus updated mission snapshot and changelog entries

## Testing
- pytest tests/test_partner_sync.py
- pytest tests/test_token_registry.py
- pytest tests/test_stealth_yield_emitter.py

------
https://chatgpt.com/codex/tasks/task_e_68e3dbae89c08322a393710bc0bba4cf