### PR TITLE
Add governance token manifest builder

### DIFF
--- a/tests/test_governance_token_spec.py
+++ b/tests/test_governance_token_spec.py
@@ -1,0 +1,64 @@
+import pytest
+
+from vaultfire.token import build_governance_token_spec
+
+
+SPEC_FIXTURE = {
+    "token": {
+        "name": "Vaultfire Governance Token",
+        "symbol": "VLT",
+        "standard": "ERC-20-compatible",
+        "chain_targets": ["Base", "Ethereum", "Base"],
+        "supply_cap": "1_000_000_000",
+        "emissions_curve": "logarithmic_decay",
+    },
+    "governance": {
+        "quorum": "15%",
+        "voting_delay": "1 day",
+        "proposal_threshold": "10_000 VLT",
+    },
+    "ethics": {
+        "proof_of_purpose_required": True,
+        "public_audit_interval_days": 90,
+    },
+}
+
+
+def test_governance_token_manifest_roundtrip():
+    spec = build_governance_token_spec(SPEC_FIXTURE)
+    manifest = spec.to_manifest()
+
+    assert manifest["token"]["name"] == "Vaultfire Governance Token"
+    assert manifest["token"]["symbol"] == "VLT"
+    assert manifest["token"]["chain_targets"] == ["Base", "Ethereum"]
+    assert manifest["token"]["supply_cap"] == 1_000_000_000
+    assert manifest["governance"]["quorum"]["fraction"] == pytest.approx(0.15)
+    assert manifest["governance"]["proposal_threshold"]["amount"] == 10_000
+    assert manifest["governance"]["proposal_threshold"]["denomination"] == "VLT"
+    assert manifest["governance"]["voting_delay"]["seconds"] == 86_400
+    assert manifest["governance"]["voting_delay"]["iso_8601"] == "P1D"
+    assert manifest["ethics"]["proof_of_purpose_required"] is True
+    assert manifest["ethics"]["public_audit_interval_days"] == 90
+    assert len(manifest["checksum"]) == 64
+
+
+def test_governance_token_spec_validates_inputs():
+    invalid_spec = {
+        "token": SPEC_FIXTURE["token"],
+        "governance": {**SPEC_FIXTURE["governance"], "proposal_threshold": "5_000 OTHER"},
+        "ethics": SPEC_FIXTURE["ethics"],
+    }
+
+    with pytest.raises(ValueError):
+        build_governance_token_spec(invalid_spec)
+
+
+def test_governance_token_spec_requires_boolean_ethics():
+    invalid_spec = {
+        "token": SPEC_FIXTURE["token"],
+        "governance": SPEC_FIXTURE["governance"],
+        "ethics": {**SPEC_FIXTURE["ethics"], "proof_of_purpose_required": "yes"},
+    }
+
+    with pytest.raises(TypeError):
+        build_governance_token_spec(invalid_spec)

--- a/vaultfire/token/__init__.py
+++ b/vaultfire/token/__init__.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import json
-from typing import Dict, Iterable, Mapping, Tuple
+from datetime import timedelta
+from typing import Any, Dict, Iterable, Mapping, Sequence, Tuple
 
 
 @dataclass(slots=True, frozen=True)
@@ -128,4 +129,333 @@ def prepare_fire_token_protocol(
     )
 
 
-__all__ = ["FireTokenProtocol", "prepare_fire_token_protocol"]
+@dataclass(slots=True, frozen=True)
+class TokenAmount:
+    """Representation of a token-denominated quantity."""
+
+    amount: int
+    denomination: str
+
+    def export(self) -> Dict[str, object]:
+        return {
+            "amount": self.amount,
+            "denomination": self.denomination,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class TokenDefinition:
+    """Core token metadata for the Vaultfire governance token."""
+
+    name: str
+    symbol: str
+    standard: str
+    chain_targets: Tuple[str, ...]
+    supply_cap: int
+    emissions_curve: str
+
+    def export(self) -> Dict[str, object]:
+        return {
+            "name": self.name,
+            "symbol": self.symbol,
+            "standard": self.standard,
+            "chain_targets": list(self.chain_targets),
+            "supply_cap": self.supply_cap,
+            "emissions_curve": self.emissions_curve,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class GovernanceParameters:
+    """Governance configuration derived from the token specification."""
+
+    quorum_fraction: float
+    voting_delay: timedelta
+    proposal_threshold: TokenAmount
+
+    def export(self) -> Dict[str, object]:
+        delay_seconds = int(self.voting_delay.total_seconds())
+        percentage = round(self.quorum_fraction * 100, 6)
+        iso_8601 = _timedelta_to_iso8601(self.voting_delay)
+        return {
+            "quorum": {
+                "fraction": self.quorum_fraction,
+                "percentage": percentage,
+            },
+            "voting_delay": {
+                "seconds": delay_seconds,
+                "human_readable": _format_timedelta(self.voting_delay),
+                "iso_8601": iso_8601,
+            },
+            "proposal_threshold": self.proposal_threshold.export(),
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class EthicsGuardrails:
+    """Ethics guardrails attached to the governance token."""
+
+    proof_of_purpose_required: bool
+    public_audit_interval_days: int
+
+    def export(self) -> Dict[str, object]:
+        return {
+            "proof_of_purpose_required": self.proof_of_purpose_required,
+            "public_audit_interval_days": self.public_audit_interval_days,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class VaultfireGovernanceTokenSpec:
+    """Complete specification for the Vaultfire governance token."""
+
+    token: TokenDefinition
+    governance: GovernanceParameters
+    ethics: EthicsGuardrails
+
+    def to_manifest(self) -> Dict[str, object]:
+        manifest = {
+            "token": self.token.export(),
+            "governance": self.governance.export(),
+            "ethics": self.ethics.export(),
+        }
+        manifest["checksum"] = _compute_checksum(manifest)
+        return manifest
+
+
+def _require_mapping(value: object, *, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field_name} must be a mapping")
+    return value  # type: ignore[return-value]
+
+
+def _require_non_empty_string(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return stripped
+
+
+def _normalise_chain_targets(chain_targets: Sequence[str]) -> Tuple[str, ...]:
+    if not isinstance(chain_targets, Sequence) or isinstance(chain_targets, (str, bytes)):
+        raise TypeError("chain_targets must be a sequence of strings")
+    ordered_unique: dict[str, None] = {}
+    for index, target in enumerate(chain_targets):
+        if not isinstance(target, str):
+            raise TypeError(f"chain_targets[{index}] must be a string")
+        normalised = target.strip()
+        if not normalised:
+            raise ValueError(f"chain_targets[{index}] must be non-empty")
+        ordered_unique.setdefault(normalised, None)
+    if not ordered_unique:
+        raise ValueError("At least one chain target must be provided")
+    return tuple(ordered_unique.keys())
+
+
+def _parse_positive_int(value: object, *, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise TypeError(f"{field_name} must be an integer")
+    if isinstance(value, int):
+        if value <= 0:
+            raise ValueError(f"{field_name} must be positive")
+        return value
+    if isinstance(value, str):
+        cleaned = value.strip().replace("_", "").replace(",", "")
+        if not cleaned:
+            raise ValueError(f"{field_name} must not be empty")
+        try:
+            parsed = int(cleaned)
+        except ValueError as exc:
+            raise ValueError(f"{field_name} must be an integer value") from exc
+        if parsed <= 0:
+            raise ValueError(f"{field_name} must be positive")
+        return parsed
+    raise TypeError(f"{field_name} must be an integer")
+
+
+def _parse_percentage(value: object, *, field_name: str) -> float:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        numeric = float(value)
+    elif isinstance(value, str):
+        cleaned = value.strip()
+        if cleaned.endswith("%"):
+            cleaned = cleaned[:-1]
+        cleaned = cleaned.replace("_", "").replace(",", "")
+        if not cleaned:
+            raise ValueError(f"{field_name} must not be empty")
+        try:
+            numeric = float(cleaned)
+        except ValueError as exc:
+            raise ValueError(f"{field_name} must be a numeric percentage") from exc
+    else:
+        raise TypeError(f"{field_name} must be numeric or a percentage string")
+
+    if numeric > 1:
+        numeric /= 100
+    if numeric <= 0 or numeric > 1:
+        raise ValueError(f"{field_name} must be between 0 and 100 percent")
+    return round(numeric, 6)
+
+
+def _parse_proposal_threshold(value: object, *, token_symbol: str) -> TokenAmount:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        amount = int(value)
+        denomination = token_symbol
+    elif isinstance(value, str):
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("proposal_threshold must not be empty")
+        parts = cleaned.split()
+        numeric_part = parts[0].replace("_", "").replace(",", "")
+        try:
+            amount = int(numeric_part)
+        except ValueError as exc:
+            raise ValueError("proposal_threshold must start with an integer value") from exc
+        denomination = token_symbol
+        if len(parts) > 1:
+            provided_symbol = parts[1].strip()
+            if provided_symbol and provided_symbol != token_symbol:
+                raise ValueError("proposal_threshold denomination must match the token symbol")
+    else:
+        raise TypeError("proposal_threshold must be numeric or a formatted string")
+
+    if amount <= 0:
+        raise ValueError("proposal_threshold must be greater than zero")
+    return TokenAmount(amount=amount, denomination=token_symbol)
+
+
+def _parse_voting_delay(value: object, *, field_name: str) -> timedelta:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        seconds = float(value)
+        if seconds <= 0:
+            raise ValueError(f"{field_name} must be greater than zero seconds")
+        return timedelta(seconds=seconds)
+    if isinstance(value, str):
+        cleaned = value.strip().lower()
+        if not cleaned:
+            raise ValueError(f"{field_name} must not be empty")
+        parts = cleaned.split()
+        if len(parts) != 2:
+            raise ValueError(f"{field_name} must be in the format '<value> <unit>'")
+        magnitude_raw, unit_raw = parts
+        magnitude_raw = magnitude_raw.replace("_", "")
+        try:
+            magnitude = float(magnitude_raw)
+        except ValueError as exc:
+            raise ValueError(f"{field_name} magnitude must be numeric") from exc
+        if magnitude <= 0:
+            raise ValueError(f"{field_name} magnitude must be greater than zero")
+        unit = unit_raw.rstrip("s")
+        unit_seconds = {
+            "second": 1,
+            "minute": 60,
+            "hour": 60 * 60,
+            "day": 60 * 60 * 24,
+        }.get(unit)
+        if unit_seconds is None:
+            raise ValueError(f"Unsupported unit for {field_name}: {unit_raw}")
+        total_seconds = magnitude * unit_seconds
+        return timedelta(seconds=total_seconds)
+    raise TypeError(f"{field_name} must be numeric seconds or a human readable duration string")
+
+
+def _format_timedelta(value: timedelta) -> str:
+    total_seconds = int(value.total_seconds())
+    if total_seconds % (24 * 3600) == 0:
+        days = total_seconds // (24 * 3600)
+        unit = "day" if days == 1 else "days"
+        return f"{days} {unit}"
+    if total_seconds % 3600 == 0:
+        hours = total_seconds // 3600
+        unit = "hour" if hours == 1 else "hours"
+        return f"{hours} {unit}"
+    if total_seconds % 60 == 0:
+        minutes = total_seconds // 60
+        unit = "minute" if minutes == 1 else "minutes"
+        return f"{minutes} {unit}"
+    return f"{total_seconds} seconds"
+
+
+def _timedelta_to_iso8601(value: timedelta) -> str:
+    total_seconds = int(value.total_seconds())
+    if total_seconds % (24 * 3600) == 0:
+        days = total_seconds // (24 * 3600)
+        return f"P{days}D"
+    if total_seconds % 3600 == 0:
+        hours = total_seconds // 3600
+        return f"PT{hours}H"
+    if total_seconds % 60 == 0:
+        minutes = total_seconds // 60
+        return f"PT{minutes}M"
+    return f"PT{total_seconds}S"
+
+
+def build_governance_token_spec(spec: Mapping[str, Any]) -> VaultfireGovernanceTokenSpec:
+    """Construct a governance token specification from a raw mapping."""
+
+    _require_mapping(spec, field_name="spec")
+    token_section = _require_mapping(spec.get("token"), field_name="token")
+    governance_section = _require_mapping(spec.get("governance"), field_name="governance")
+    ethics_section = _require_mapping(spec.get("ethics"), field_name="ethics")
+
+    token_name = _require_non_empty_string(token_section.get("name"), field_name="token.name")
+    token_symbol = _require_non_empty_string(token_section.get("symbol"), field_name="token.symbol")
+    token_standard = _require_non_empty_string(token_section.get("standard"), field_name="token.standard")
+    chain_targets = _normalise_chain_targets(token_section.get("chain_targets", ()))
+    supply_cap = _parse_positive_int(token_section.get("supply_cap"), field_name="token.supply_cap")
+    emissions_curve = _require_non_empty_string(
+        token_section.get("emissions_curve"), field_name="token.emissions_curve"
+    )
+
+    token_definition = TokenDefinition(
+        name=token_name,
+        symbol=token_symbol,
+        standard=token_standard,
+        chain_targets=chain_targets,
+        supply_cap=supply_cap,
+        emissions_curve=emissions_curve,
+    )
+
+    quorum_fraction = _parse_percentage(governance_section.get("quorum"), field_name="governance.quorum")
+    voting_delay = _parse_voting_delay(governance_section.get("voting_delay"), field_name="governance.voting_delay")
+    proposal_threshold = _parse_proposal_threshold(
+        governance_section.get("proposal_threshold"), token_symbol=token_symbol
+    )
+
+    governance_parameters = GovernanceParameters(
+        quorum_fraction=quorum_fraction,
+        voting_delay=voting_delay,
+        proposal_threshold=proposal_threshold,
+    )
+
+    proof_of_purpose = ethics_section.get("proof_of_purpose_required")
+    if not isinstance(proof_of_purpose, bool):
+        raise TypeError("ethics.proof_of_purpose_required must be a boolean")
+    audit_interval = _parse_positive_int(
+        ethics_section.get("public_audit_interval_days"), field_name="ethics.public_audit_interval_days"
+    )
+
+    ethics_guardrails = EthicsGuardrails(
+        proof_of_purpose_required=proof_of_purpose,
+        public_audit_interval_days=audit_interval,
+    )
+
+    return VaultfireGovernanceTokenSpec(
+        token=token_definition,
+        governance=governance_parameters,
+        ethics=ethics_guardrails,
+    )
+
+
+__all__ = [
+    "FireTokenProtocol",
+    "prepare_fire_token_protocol",
+    "TokenAmount",
+    "TokenDefinition",
+    "GovernanceParameters",
+    "EthicsGuardrails",
+    "VaultfireGovernanceTokenSpec",
+    "build_governance_token_spec",
+]


### PR DESCRIPTION
## Summary
- extend `vaultfire.token` with governance token specification dataclasses and validation helpers
- support manifest generation with checksum, percentage, duration, and threshold parsing
- cover the new manifest builder with dedicated pytest cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3dcb97ad08322ba2487b137949bf2