### PR TITLE
Integrate Vaultfire protocol stack modules and CLI commands

### DIFF
--- a/ghostkey_cli.py
+++ b/ghostkey_cli.py
@@ -5,15 +5,21 @@ from __future__ import annotations
 import argparse
 import json
 from importlib import import_module
-from typing import Any
+from pathlib import Path
+from typing import Any, Iterable, Mapping
 
 from vaultfire.protocol.signal_echo import SignalEchoEngine
 from vaultfire.protocol.timeflare import TimeFlare
 from vaultfire.quantum.hashmirror import QuantumHashMirror
+from vaultfire.modules.ethic_resonant_time_engine import EthicResonantTimeEngine
+from vaultfire.modules.vaultfire_protocol_stack import GiftMatrixV1, VaultfireProtocolStack
 
 _yield_module = import_module("vaultfire.yield")
 PulseSync = getattr(_yield_module, "PulseSync")
 TemporalGiftMatrixEngine = getattr(_yield_module, "TemporalGiftMatrixEngine")
+
+IDENTITY_HANDLE = "bpow20.cb.id"
+IDENTITY_ENS = "ghostkey316.eth"
 
 
 def _load_echo_engine(path: str | None) -> SignalEchoEngine:
@@ -33,6 +39,15 @@ def _parse_wallet_spec(spec: str) -> dict[str, object] | str:
     if len(parts) >= 3 and parts[2]:
         profile["trajectory_bonus"] = float(parts[2])
     return profile
+
+
+def _load_actions(path: str | None) -> list[Mapping[str, object]]:
+    if path is None:
+        return []
+    data = json.loads(Path(path).read_text())
+    if isinstance(data, list):
+        return [dict(item) for item in data if isinstance(item, Mapping)]
+    return []
 
 
 def cmd_echoindex(args: argparse.Namespace) -> None:
@@ -100,6 +115,88 @@ def cmd_yieldclaim(args: argparse.Namespace) -> None:
     print(json.dumps(payload, indent=2))
 
 
+def cmd_timecheck(args: argparse.Namespace) -> None:
+    actions = _load_actions(args.actions)
+    engine = EthicResonantTimeEngine(
+        args.user,
+        identity_handle=IDENTITY_HANDLE,
+        identity_ens=IDENTITY_ENS,
+    )
+    for action in actions:
+        engine.register_action(action)
+    payload = engine.timecheck()
+    print(json.dumps(payload, indent=2))
+
+
+def cmd_pulse(args: argparse.Namespace) -> None:
+    actions = _load_actions(args.actions)
+    engine = EthicResonantTimeEngine(
+        args.user,
+        identity_handle=IDENTITY_HANDLE,
+        identity_ens=IDENTITY_ENS,
+    )
+    for action in actions:
+        engine.register_action(action)
+    payload = engine.pulse()
+    print(json.dumps(payload, indent=2))
+
+
+def _prepare_gift_matrix(
+    *,
+    actions: Iterable[Mapping[str, object]],
+    interaction: str | None,
+    purity: float,
+    branch: str,
+    priority: str,
+    ethic_score: float,
+    alignment_bias: float,
+    wallets: Iterable[str | Mapping[str, object]],
+) -> GiftMatrixV1:
+    stack = VaultfireProtocolStack(actions=tuple(actions))
+    matrix = stack.gift_matrix
+    if interaction:
+        matrix.record_signal(interaction, belief_purity=purity, tags=("cli", "vaultfire"))
+        matrix.register_fork(
+            interaction,
+            branch=branch,
+            priority=priority,
+            ethic_score=ethic_score,
+            alignment_bias=alignment_bias,
+        )
+        matrix.claim(interaction, wallets)
+    return matrix
+
+
+def cmd_unlocknext(args: argparse.Namespace) -> None:
+    actions = _load_actions(args.actions)
+    stack = VaultfireProtocolStack(actions=tuple(actions))
+    payload = stack.unlock_next(args.label)
+    print(json.dumps(payload, indent=2))
+
+
+def cmd_pulsewatch(args: argparse.Namespace) -> None:
+    actions = _load_actions(args.actions)
+    recipients: list[str | Mapping[str, object]] = []
+    if args.wallet:
+        recipients = [_parse_wallet_spec(entry) for entry in args.wallet]
+    elif args.interaction:
+        recipients = [IDENTITY_ENS]
+    matrix = _prepare_gift_matrix(
+        actions=actions,
+        interaction=args.interaction,
+        purity=args.purity,
+        branch=args.branch,
+        priority=args.priority,
+        ethic_score=args.ethic_score,
+        alignment_bias=args.alignment_bias,
+        wallets=recipients,
+    )
+    stack = VaultfireProtocolStack(actions=tuple(actions))
+    stack.gift_matrix = matrix
+    payload = stack.pulsewatch()
+    print(json.dumps(payload, indent=2))
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="ghostkey", description="Ghostkey protocol tooling")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -133,6 +230,37 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional seed for deterministic QuantumHashMirror tags",
     )
     p_yield.set_defaults(func=cmd_yieldclaim)
+
+    p_time = sub.add_parser("timecheck", help="Inspect temporal ethics diagnostics")
+    p_time.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_time.add_argument("--user", default="ghostkey-316", help="Override the user identifier")
+    p_time.set_defaults(func=cmd_timecheck)
+
+    p_pulse = sub.add_parser("pulse", help="Inspect the latest quantum pulse")
+    p_pulse.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_pulse.add_argument("--user", default="ghostkey-316", help="Override the user identifier")
+    p_pulse.set_defaults(func=cmd_pulse)
+
+    p_unlock = sub.add_parser("unlocknext", help="Advance the GiftMatrix protocol layer")
+    p_unlock.add_argument("--label", help="Optional label for the new layer", default=None)
+    p_unlock.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_unlock.set_defaults(func=cmd_unlocknext)
+
+    p_watch = sub.add_parser("pulsewatch", help="Render live pulse and yield insights")
+    p_watch.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_watch.add_argument("--interaction", help="Interaction id to seed GiftMatrix", default=None)
+    p_watch.add_argument("--purity", type=float, default=0.85, help="Belief purity score")
+    p_watch.add_argument("--branch", default="stable", help="Timeline branch label")
+    p_watch.add_argument("--priority", default="low", help="Timeline priority label")
+    p_watch.add_argument("--ethic-score", dest="ethic_score", type=float, default=0.75)
+    p_watch.add_argument("--alignment-bias", dest="alignment_bias", type=float, default=0.2)
+    p_watch.add_argument(
+        "--wallet",
+        action="append",
+        default=None,
+        help="Recipient wallet (optionally wallet:belief_multiplier:trajectory_bonus)",
+    )
+    p_watch.set_defaults(func=cmd_pulsewatch)
 
     return parser
 

--- a/tests/test_conscious_state_engine.py
+++ b/tests/test_conscious_state_engine.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from vaultfire.modules.vaultfire_protocol_stack import ConsciousStateEngine
+
+
+def test_conscious_state_engine_records_actions_and_diagnostics() -> None:
+    engine = ConsciousStateEngine()
+    first = engine.record_action({"ethic": "support", "weight": 2.0, "note": "assist"})
+    second = engine.record_action({"ethic": "betrayal", "weight": 1.5, "note": "conflict"})
+
+    assert first.approved is True
+    assert second.approved is False
+
+    ledger = engine.ledger()
+    assert len(ledger) == 2
+    assert ledger[0].payload["identity"]["ens"] == "ghostkey316.eth"
+
+    health = engine.belief_health()
+    assert 0.0 <= health <= 1.0
+
+    diagnostics = engine.sync_diagnostics()
+    assert diagnostics["actions"] == 2
+    assert diagnostics["identity"]["wallet"] == "bpow20.cb.id"
+    assert diagnostics["last_action"]["note"] == "conflict"

--- a/tests/test_ethic_resonant_time_engine.py
+++ b/tests/test_ethic_resonant_time_engine.py
@@ -24,3 +24,17 @@ def test_time_engine_tracks_history_and_tempo():
     history = engine.review_history()
     assert len(history) == 3
     assert history[0]["type"] == "support"
+
+
+def test_time_engine_timecheck_and_pulse_report_metadata():
+    engine = EthicResonantTimeEngine(user_id="ghostkey316")
+    engine.register_action({"type": "support", "weight": 2})
+    engine.register_action({"type": "betrayal", "weight": 1})
+
+    report = engine.timecheck()
+    assert report["metadata"]["first_of_its_kind"] is True
+    assert report["identity"]["ens"] == "ghostkey316.eth"
+
+    pulse = engine.pulse()
+    assert "pulse" in pulse
+    assert pulse["metadata"]["identity"]["wallet"] == "bpow20.cb.id"

--- a/tests/test_gift_matrix.py
+++ b/tests/test_gift_matrix.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from vaultfire.modules.vaultfire_protocol_stack import GiftMatrixV1, VaultfireProtocolStack
+
+
+def test_gift_matrix_claim_tracks_forks_and_layers() -> None:
+    matrix = GiftMatrixV1()
+    interaction = "mission-1"
+    matrix.record_signal(interaction, belief_purity=0.92, tags=("alpha",))
+    matrix.register_fork(
+        interaction,
+        branch="monitor",
+        priority="medium",
+        ethic_score=0.81,
+        alignment_bias=0.15,
+    )
+    record = matrix.claim(interaction, ["0xabc"])
+
+    assert record.metadata["timeline_branch"] == "monitor"
+    assert record.metadata["priority"] == "medium"
+
+    layer = matrix.unlock_next_layer("Genesis unlock")
+    assert layer["layer"] == 1
+
+    status = matrix.pulse_watch()
+    assert status["metadata"]["first_of_its_kind"] is True
+    assert status["forks_tracked"] == 1
+
+
+def test_protocol_stack_pulsewatch_includes_yield_summary() -> None:
+    stack = VaultfireProtocolStack(actions=({"type": "support", "weight": 3},))
+    summary = stack.pulsewatch()
+
+    assert "belief_health" in summary
+    assert summary["tempo"] == stack.time_engine.current_tempo()

--- a/tests/test_mission_soul_loop.py
+++ b/tests/test_mission_soul_loop.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from vaultfire.modules.vaultfire_protocol_stack import MissionSoulLoop
+
+
+def test_mission_soul_loop_logs_history_and_checkpoints() -> None:
+    loop = MissionSoulLoop()
+    entry = loop.log_intent("Expand Vaultfire outreach", confidence=0.91, tags=("mission",))
+
+    assert entry["intent"] == "Expand Vaultfire outreach"
+    assert entry["confidence"] == 0.91
+
+    profile = loop.update_profile(role="guardian", resonance="high")
+    assert profile["role"] == "guardian"
+
+    history = loop.history()
+    assert history[-1]["tags"] == ("mission",)
+
+    checkpoint = loop.checkpoint()
+    assert checkpoint["profile"]["soul_checkpoint"] == 1
+    assert checkpoint["profile"]["ens"] == "ghostkey316.eth"

--- a/tests/test_predictive_yield_fabric.py
+++ b/tests/test_predictive_yield_fabric.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from vaultfire.modules.vaultfire_protocol_stack import PredictiveYieldFabric
+
+
+def test_predictive_yield_fabric_forecast_and_optimize() -> None:
+    fabric = PredictiveYieldFabric()
+    fabric.register_export("core", 0.7)
+    fabric.register_export("ally", 0.3)
+
+    captured: list[dict[str, float]] = []
+
+    def _hook(distribution):
+        captured.append(dict(distribution))
+
+    fabric.register_hook("capture", _hook)
+    forecast = fabric.forecast(signal_purity=0.82, base_yield=200.0)
+
+    assert forecast["identity"]["ens"] == "ghostkey316.eth"
+    assert "distribution" in forecast
+    assert captured
+
+    optimisation = fabric.auto_optimize()
+    weights = optimisation["normalized_weights"]
+    assert abs(sum(weights.values()) - 1.0) < 1e-12

--- a/vaultfire/modules/__init__.py
+++ b/vaultfire/modules/__init__.py
@@ -1,5 +1,27 @@
 """Utility modules for the Vaultfire package."""
 
+from .ethic_resonant_time_engine import EthicResonantTimeEngine
+from .vaultfire_protocol_stack import (
+    AdaptiveRelicStore,
+    ConsciousStateEngine,
+    GiftMatrixV1,
+    GhostMemoryArchive,
+    MissionSoulLoop,
+    PredictiveYieldFabric,
+    SignalForge,
+    VaultfireDNASyncer,
+    VaultfireProtocolStack,
+)
+
 __all__ = [
-    "ethic_resonant_time_engine",
+    "EthicResonantTimeEngine",
+    "AdaptiveRelicStore",
+    "ConsciousStateEngine",
+    "GiftMatrixV1",
+    "GhostMemoryArchive",
+    "MissionSoulLoop",
+    "PredictiveYieldFabric",
+    "SignalForge",
+    "VaultfireDNASyncer",
+    "VaultfireProtocolStack",
 ]

--- a/vaultfire/modules/ethic_resonant_time_engine.py
+++ b/vaultfire/modules/ethic_resonant_time_engine.py
@@ -1,9 +1,21 @@
-"""Ethics-aware tempo engine for Vaultfire Ghostkey synchronization."""
+"""Ethics-aware tempo engine for Vaultfire Ghostkey synchronization.
+
+This module predates the new Vaultfire Protocol Stack but has now been
+extended so the :class:`EthicResonantTimeEngine` can act as the temporal
+anchor for the end-to-end integration requested by Ghostkey-316.  The
+engine now keeps lightweight metadata describing its *First-of-its-Kind*
+status, emits diagnostic payloads for the Ghostkey CLI, and mirrors quantum
+hash pulses so the GiftMatrix and other modules can validate temporal
+integrity.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Dict, Iterable, List, Mapping, MutableSequence, Tuple
+
+from vaultfire.quantum.hashmirror import QuantumHashMirror
 
 
 @dataclass(frozen=True)
@@ -94,18 +106,83 @@ class GhostkeySyncEngine:
 
 
 class EthicResonantTimeEngine:
-    """Coordinates moral scoring with Ghostkey synchronization."""
+    """Coordinates moral scoring with Ghostkey synchronization.
 
-    def __init__(self, user_id: str) -> None:
+    The engine acts as the canonical source of temporal ethics telemetry for
+    the Vaultfire stack.  Each action updates the rolling moral momentum
+    score and imprints a *quantum pulse* string so downstream modules can
+    validate that the timeline has not been tampered with.  The metadata flag
+    ``first_of_its_kind`` is surfaced to the CLI so the user can confirm the
+    protocol uniqueness requirement from the prompt.
+    """
+
+    def __init__(
+        self,
+        user_id: str,
+        *,
+        identity_handle: str = "bpow20.cb.id",
+        identity_ens: str = "ghostkey316.eth",
+    ) -> None:
         self.mmi = MoralMomentumIndex()
         self.ttg = TemporalTrustGate(self.mmi)
         self.ghostkey = GhostkeySyncEngine(user_id)
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self.metadata: Mapping[str, object] = {
+            "module": "EthicResonantTimeEngine",
+            "first_of_its_kind": True,
+            "identity": {
+                "wallet": identity_handle,
+                "ens": identity_ens,
+                "user_id": user_id,
+            },
+        }
+        self._quantum_mirror = QuantumHashMirror(
+            seed=f"ethic-resonant-time::{user_id}"
+        )
+        self._pulse_log: MutableSequence[Mapping[str, object]] = []
 
     def register_action(self, action: Mapping[str, object]) -> None:
         """Register an action with both Ghostkey sync and moral index."""
 
-        self.ghostkey.log_event(action)
-        self.mmi.update(action)
+        timestamp = datetime.now(timezone.utc)
+        payload = dict(action)
+        payload.setdefault("timestamp", timestamp.isoformat())
+        self.ghostkey.log_event(payload)
+        self.mmi.update(payload)
+        tempo = self.ttg.access_window()
+        integrity = self._integrity_from_action(payload)
+        interaction_ref = str(
+            payload.get("interaction_id") or payload.get("timestamp") or f"tempo::{len(self._pulse_log)+1}"
+        )
+        pulse = self._quantum_mirror.imprint(
+            self.identity_ens,
+            interaction_id=interaction_ref,
+            branch=tempo,
+            payload={
+                "integrity": integrity,
+                "timestamp": payload.get("timestamp"),
+                "action": payload.get("type"),
+                "weight": payload.get("weight", 0),
+            },
+        )
+        self._pulse_log.append(
+            {
+                "tempo": tempo,
+                "integrity": integrity,
+                "timestamp": payload.get("timestamp"),
+                "pulse": pulse,
+            }
+        )
+
+    def _integrity_from_action(self, action: Mapping[str, object]) -> float:
+        action_type = str(action.get("type", "")).lower()
+        weight = float(action.get("weight", 1.0))
+        if action_type in {"support", "sacrifice", "uplift"}:
+            return min(1.0, 0.8 + abs(weight) * 0.05)
+        if action_type in {"selfish", "betrayal"}:
+            return max(0.0, 0.6 - abs(weight) * 0.05)
+        return 0.7
 
     def current_tempo(self) -> str:
         """Return the current access tempo."""
@@ -116,6 +193,42 @@ class EthicResonantTimeEngine:
         """Provide a tuple view of the recorded action history."""
 
         return tuple(self.ghostkey.replay_history())
+
+    def timecheck(self) -> Mapping[str, object]:
+        """Return a diagnostic payload consumed by the CLI."""
+
+        return {
+            "identity": self.metadata["identity"],
+            "tempo": self.current_tempo(),
+            "moral_score": self.mmi.get_score(),
+            "history": list(self.review_history()),
+            "pulse_integrity": self._pulse_log[-1]["integrity"] if self._pulse_log else 0.0,
+            "metadata": self.metadata,
+        }
+
+    def pulse(self) -> Mapping[str, object]:
+        """Expose the latest quantum pulse and tempo status."""
+
+        latest = self._pulse_log[-1] if self._pulse_log else {}
+        if latest:
+            tempo = latest.get("tempo", self.current_tempo())
+            pulse_value = latest.get("pulse")
+            integrity = latest.get("integrity", 0.0)
+        else:
+            tempo = self.current_tempo()
+            pulse_value = self._quantum_mirror.imprint(
+                self.identity_ens,
+                interaction_id="initial",
+                branch=tempo,
+                payload={"generated": True},
+            )
+            integrity = 0.0
+        return {
+            "tempo": tempo,
+            "pulse": pulse_value,
+            "integrity": integrity,
+            "metadata": self.metadata,
+        }
 
 
 if __name__ == "__main__":

--- a/vaultfire/modules/vaultfire_protocol_stack.py
+++ b/vaultfire/modules/vaultfire_protocol_stack.py
@@ -1,0 +1,491 @@
+"""Integrated Vaultfire protocol stack for the Ghostkey CLI.
+
+The module exposes lightweight Python implementations of the systems
+described in the Vaultfire activation brief.  Each class focuses on providing
+deterministic, testable behaviour so the surrounding tooling (CLI commands
+and pytest suites) can exercise the protocol without depending on external
+infrastructure.  The real production counterparts would speak to distributed
+ledgers and quantum mirrors; here we provide auditable facsimiles.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from importlib import import_module
+from typing import Callable, Iterable, List, Mapping, MutableMapping, Sequence
+
+from vaultfire.modules.ethic_resonant_time_engine import EthicResonantTimeEngine
+from vaultfire.protocol.signal_echo import SignalEchoEngine
+from vaultfire.quantum.hashmirror import QuantumHashMirror
+
+_yield_module = import_module("vaultfire.yield")
+PulseSync = getattr(_yield_module, "PulseSync")
+TemporalGiftMatrixEngine = getattr(_yield_module, "TemporalGiftMatrixEngine")
+
+IDENTITY_HANDLE = "bpow20.cb.id"
+IDENTITY_ENS = "ghostkey316.eth"
+
+
+def _now_ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class LedgerAction:
+    """Internal representation of a ledger action."""
+
+    payload: Mapping[str, object]
+    approved: bool
+    belief_delta: float
+    recorded_at: str = field(default_factory=_now_ts)
+
+
+class ConsciousStateEngine:
+    """Record ethics-checked ledger actions and compute belief health."""
+
+    POSITIVE_ETHICS = {"aligned", "support", "sacrifice", "uplift"}
+    NEGATIVE_ETHICS = {"betrayal", "selfish", "drain"}
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str = IDENTITY_HANDLE,
+        identity_ens: str = IDENTITY_ENS,
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self._ledger: List[LedgerAction] = []
+        self.metadata: Mapping[str, object] = {
+            "module": "ConsciousStateEngine",
+            "identity": {
+                "wallet": identity_handle,
+                "ens": identity_ens,
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # action tracking
+    # ------------------------------------------------------------------
+    def record_action(self, action: Mapping[str, object]) -> LedgerAction:
+        """Store an ethics filtered ledger action."""
+
+        ethic = str(action.get("ethic", "aligned")).lower()
+        weight = float(action.get("weight", 1.0))
+        belief_delta = self._resolve_belief_delta(ethic, weight)
+        if "approved" in action:
+            approved = bool(action.get("approved"))
+        else:
+            approved = ethic in self.POSITIVE_ETHICS
+        record = LedgerAction(payload=dict(action), approved=approved, belief_delta=belief_delta)
+        record.payload.setdefault(
+            "identity",
+            {"wallet": self.identity_handle, "ens": self.identity_ens},
+        )
+        record.payload.setdefault("ethic", ethic)
+        self._ledger.append(record)
+        return record
+
+    def _resolve_belief_delta(self, ethic: str, weight: float) -> float:
+        if ethic in self.POSITIVE_ETHICS:
+            return min(1.0, 0.5 + abs(weight) * 0.1)
+        if ethic in self.NEGATIVE_ETHICS:
+            return max(-1.0, -0.5 - abs(weight) * 0.1)
+        return 0.0
+
+    # ------------------------------------------------------------------
+    # analytics
+    # ------------------------------------------------------------------
+    def belief_health(self) -> float:
+        """Return the average belief delta constrained to ``[0, 1]``."""
+
+        if not self._ledger:
+            return 1.0
+        raw = sum(entry.belief_delta for entry in self._ledger) / len(self._ledger)
+        return max(0.0, min((raw + 1.0) / 2.0, 1.0))
+
+    def sync_diagnostics(self) -> Mapping[str, object]:
+        """Expose Ghostkey CLI friendly diagnostics."""
+
+        last = self._ledger[-1] if self._ledger else None
+        return {
+            "identity": self.metadata["identity"],
+            "actions": len(self._ledger),
+            "belief_health": self.belief_health(),
+            "last_action": dict(last.payload) if last else None,
+        }
+
+    def ledger(self) -> Sequence[LedgerAction]:
+        """Return a snapshot of the ledger."""
+
+        return tuple(self._ledger)
+
+
+class PredictiveYieldFabric:
+    """Weighted forecasting and auto-optimisation helper."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str = IDENTITY_HANDLE,
+        identity_ens: str = IDENTITY_ENS,
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self._exports: MutableMapping[str, float] = {}
+        self._hooks: MutableMapping[str, Callable[[Mapping[str, float]], None]] = {}
+        self._latest_forecast: Mapping[str, object] | None = None
+        self.metadata: Mapping[str, object] = {
+            "module": "PredictiveYieldFabric",
+            "identity": {
+                "wallet": identity_handle,
+                "ens": identity_ens,
+            },
+        }
+
+    def register_export(self, name: str, weight: float) -> None:
+        weight = max(weight, 0.0)
+        self._exports[name] = weight
+
+    def register_hook(self, name: str, callback: Callable[[Mapping[str, float]], None]) -> None:
+        self._hooks[name] = callback
+
+    def forecast(self, signal_purity: float, base_yield: float, *, horizon: int = 3) -> Mapping[str, object]:
+        """Compute a weighted yield forecast and notify registered hooks."""
+
+        if not self._exports:
+            self.register_export("core", 1.0)
+        normalized_total = sum(self._exports.values()) or 1.0
+        composite = base_yield * (0.5 + max(signal_purity, 0.0) * 0.5)
+        distribution = {
+            name: composite * (weight / normalized_total)
+            for name, weight in self._exports.items()
+        }
+        for callback in self._hooks.values():
+            callback(distribution)
+        self._latest_forecast = {
+            "identity": self.metadata["identity"],
+            "horizon": horizon,
+            "composite_yield": composite,
+            "distribution": distribution,
+            "timestamp": _now_ts(),
+        }
+        return self._latest_forecast
+
+    def auto_optimize(self) -> Mapping[str, object]:
+        """Return normalised export weights."""
+
+        total = sum(self._exports.values()) or 1.0
+        normalised = {name: (weight / total) for name, weight in self._exports.items()}
+        return {
+            "identity": self.metadata["identity"],
+            "normalized_weights": normalised,
+        }
+
+    @property
+    def latest_forecast(self) -> Mapping[str, object] | None:
+        return self._latest_forecast
+
+
+class MissionSoulLoop:
+    """Track intent evolution and profile state for Ghostkey identity."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str = IDENTITY_HANDLE,
+        identity_ens: str = IDENTITY_ENS,
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self._history: List[Mapping[str, object]] = []
+        self._profile: MutableMapping[str, object] = {
+            "ens": identity_ens,
+            "wallet": identity_handle,
+            "soul_checkpoint": 0,
+        }
+
+    def log_intent(
+        self,
+        intent: str,
+        *,
+        confidence: float,
+        tags: Sequence[str] = (),
+    ) -> Mapping[str, object]:
+        record = {
+            "intent": intent,
+            "confidence": float(confidence),
+            "tags": tuple(tags),
+            "recorded_at": _now_ts(),
+        }
+        self._history.append(record)
+        self._profile["soul_checkpoint"] = len(self._history)
+        return record
+
+    def update_profile(self, **fields: object) -> Mapping[str, object]:
+        self._profile.update(fields)
+        return dict(self._profile)
+
+    def history(self) -> Sequence[Mapping[str, object]]:
+        return tuple(self._history)
+
+    def checkpoint(self) -> Mapping[str, object]:
+        return {
+            "profile": dict(self._profile),
+            "history": list(self._history[-3:]),
+        }
+
+
+class _EphemeralTimeFlare:
+    """Minimal TimeFlare compatible helper used for tests and CLI."""
+
+    def __init__(self) -> None:
+        self._ledger: List[Mapping[str, object]] = []
+
+    def register(self, entry: Mapping[str, object]) -> None:
+        self._ledger.append(dict(entry))
+
+    def load(self) -> List[Mapping[str, object]]:
+        return [dict(entry) for entry in self._ledger]
+
+
+class GiftMatrixV1:
+    """Belief signal reward distribution orchestrator."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str = IDENTITY_HANDLE,
+        identity_ens: str = IDENTITY_ENS,
+        timeflare: _EphemeralTimeFlare | None = None,
+        signal_engine: SignalEchoEngine | None = None,
+        pulse_sync: PulseSync | None = None,
+        hash_mirror: QuantumHashMirror | None = None,
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self._timeflare = timeflare or _EphemeralTimeFlare()
+        self.signal_engine = signal_engine or SignalEchoEngine()
+        self.pulse_sync = pulse_sync or PulseSync()
+        self.hash_mirror = hash_mirror or QuantumHashMirror(
+            seed=f"gift-matrix::{identity_ens}"
+        )
+        self.engine = TemporalGiftMatrixEngine(
+            timeflare=self._timeflare,
+            signal_engine=self.signal_engine,
+            pulse_sync=self.pulse_sync,
+            hash_mirror=self.hash_mirror,
+            base_reward=180.0,
+        )
+        self.metadata: Mapping[str, object] = {
+            "module": "GiftMatrix_v1",
+            "first_of_its_kind": True,
+            "identity": {
+                "wallet": identity_handle,
+                "ens": identity_ens,
+            },
+        }
+        self._fork_log: List[Mapping[str, object]] = []
+        self._unlocked_layers: List[Mapping[str, object]] = []
+        self._last_signal_purity: float = 0.0
+        self._last_record: Mapping[str, object] | None = None
+
+    def record_signal(
+        self,
+        interaction_id: str,
+        *,
+        belief_purity: float,
+        emotion: str = "focus",
+        ethic: str = "aligned",
+        tags: Sequence[str] = (),
+    ) -> None:
+        self._last_signal_purity = float(belief_purity)
+        self.signal_engine.record_frame(
+            interaction_id,
+            emotion=emotion,
+            ethic=ethic,
+            intensity=belief_purity,
+            tags=tags,
+        )
+
+    def register_fork(
+        self,
+        interaction_id: str,
+        *,
+        branch: str,
+        priority: str,
+        ethic_score: float,
+        alignment_bias: float,
+    ) -> Mapping[str, object]:
+        entry = {
+            "interaction_id": interaction_id,
+            "branch": branch,
+            "priority": priority,
+            "ethic_score": float(ethic_score),
+            "alignment_bias": float(alignment_bias),
+            "created_at": _now_ts(),
+        }
+        self._fork_log.append(entry)
+        self._timeflare.register(entry)
+        return entry
+
+    def claim(self, interaction_id: str, recipients: Iterable[str | Mapping[str, object]]):
+        record = self.engine.generate_matrix(interaction_id, recipients)
+        self._last_record = {
+            "record_id": record.record_id,
+            "metadata": dict(record.metadata),
+            "allocations": [allocation.__dict__ for allocation in record.allocations],
+        }
+        return record
+
+    def unlock_next_layer(self, label: str | None = None) -> Mapping[str, object]:
+        layer_index = len(self._unlocked_layers) + 1
+        entry = {
+            "layer": layer_index,
+            "label": label or f"Layer-{layer_index}",
+            "unlocked_at": _now_ts(),
+        }
+        self._unlocked_layers.append(entry)
+        return entry
+
+    def pulse_watch(self) -> Mapping[str, object]:
+        return {
+            "identity": self.metadata["identity"],
+            "active_layers": len(self._unlocked_layers),
+            "forks_tracked": len(self._fork_log),
+            "last_signal_purity": self._last_signal_purity,
+            "last_record": self._last_record,
+            "metadata": self.metadata,
+        }
+
+
+class VaultfireProtocolStack:
+    """Convenience wrapper bundling the protocol systems."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str = IDENTITY_HANDLE,
+        identity_ens: str = IDENTITY_ENS,
+        actions: Sequence[Mapping[str, object]] = (),
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self.conscious = ConsciousStateEngine(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self.predictive = PredictiveYieldFabric(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self.soul = MissionSoulLoop(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self.time_engine = EthicResonantTimeEngine(
+            "ghostkey-316",
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self.gift_matrix = GiftMatrixV1(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        for action in actions:
+            self.conscious.record_action(action)
+            self.time_engine.register_action(action)
+        self.predictive.register_export("core", 1.0)
+        self.predictive.forecast(self.conscious.belief_health(), 120.0)
+
+    def unlock_next(self, label: str | None = None) -> Mapping[str, object]:
+        return self.gift_matrix.unlock_next_layer(label)
+
+    def pulsewatch(self) -> Mapping[str, object]:
+        summary = self.gift_matrix.pulse_watch()
+        summary.update(
+            {
+                "belief_health": self.conscious.belief_health(),
+                "tempo": self.time_engine.current_tempo(),
+                "yield_forecast": self.predictive.latest_forecast,
+            }
+        )
+        return summary
+
+
+# ---------------------------------------------------------------------------
+# Future module scaffolding
+# ---------------------------------------------------------------------------
+
+
+class AdaptiveRelicStore:
+    """Placeholder scaffold for the Adaptive Relic Store module."""
+
+    def __init__(self) -> None:
+        self.backlog: List[str] = []
+
+    def blueprint(self, relic_name: str) -> Mapping[str, object]:
+        self.backlog.append(relic_name)
+        return {
+            "relic": relic_name,
+            "status": "planned",
+            "created_at": _now_ts(),
+        }
+
+
+class GhostMemoryArchive:
+    """Placeholder scaffold for time-locked memory unlocks."""
+
+    def __init__(self) -> None:
+        self._anchors: List[Mapping[str, object]] = []
+
+    def plan_anchor(self, label: str, unlock_at: str) -> Mapping[str, object]:
+        entry = {"label": label, "unlock_at": unlock_at}
+        self._anchors.append(entry)
+        return entry
+
+
+class SignalForge:
+    """Placeholder scaffold for the belief-to-energy converter."""
+
+    def __init__(self) -> None:
+        self._designs: List[Mapping[str, object]] = []
+
+    def draft_conversion(self, signal: str, efficiency: float) -> Mapping[str, object]:
+        plan = {
+            "signal": signal,
+            "efficiency": efficiency,
+            "created_at": _now_ts(),
+        }
+        self._designs.append(plan)
+        return plan
+
+
+class VaultfireDNASyncer:
+    """Placeholder scaffold for legacy moral imprint technology."""
+
+    def __init__(self) -> None:
+        self._imprints: List[Mapping[str, object]] = []
+
+    def schedule_imprint(self, reference: str, integrity: float) -> Mapping[str, object]:
+        imprint = {
+            "reference": reference,
+            "integrity": integrity,
+            "scheduled_at": _now_ts(),
+        }
+        self._imprints.append(imprint)
+        return imprint
+
+
+__all__ = [
+    "ConsciousStateEngine",
+    "PredictiveYieldFabric",
+    "MissionSoulLoop",
+    "GiftMatrixV1",
+    "VaultfireProtocolStack",
+    "AdaptiveRelicStore",
+    "GhostMemoryArchive",
+    "SignalForge",
+    "VaultfireDNASyncer",
+]
+


### PR DESCRIPTION
## Summary
- create a vaultfire_protocol_stack module that implements the ConsciousStateEngine, PredictiveYieldFabric, MissionSoulLoop, GiftMatrixV1, and scaffolding for upcoming systems
- enhance the EthicResonantTimeEngine and Ghostkey CLI so temporal diagnostics, pulse telemetry, and layer unlocking flows are wired to the Ghostkey-316 identity
- add focused pytest coverage for the new protocol components and GiftMatrix orchestration

## Testing
- pytest tests/test_conscious_state_engine.py tests/test_predictive_yield_fabric.py tests/test_mission_soul_loop.py tests/test_ethic_resonant_time_engine.py tests/test_gift_matrix.py

------
https://chatgpt.com/codex/tasks/task_e_68e40a00fc988322891be7cf78836623