### PR TITLE
Add Vaultfire FOTK engines and CLI integrations

### DIFF
--- a/ghostkey_cli.py
+++ b/ghostkey_cli.py
@@ -12,6 +12,10 @@ from vaultfire.protocol.signal_echo import SignalEchoEngine
 from vaultfire.protocol.timeflare import TimeFlare
 from vaultfire.quantum.hashmirror import QuantumHashMirror
 from vaultfire.modules.ethic_resonant_time_engine import EthicResonantTimeEngine
+from vaultfire.modules.gift_matrix_engine import GiftMatrixEngine
+from vaultfire.modules.living_memory_ledger import LivingMemoryLedger
+from vaultfire.modules.quantum_echo_mirror import QuantumEchoMirror
+from vaultfire.modules.soul_loop_fabric_engine import SoulLoopFabricEngine
 from vaultfire.modules.vaultfire_protocol_stack import (
     ConsciousStateEngine,
     GiftMatrixV1,
@@ -87,6 +91,47 @@ def _parse_update_spec(entries: Iterable[str] | None) -> dict[str, object]:
         else:
             updates[item.strip()] = True
     return updates
+
+
+def _build_engines(
+    actions_path: str | None,
+    history_path: str | None,
+    *,
+    user: str = "ghostkey-316",
+) -> tuple[SoulLoopFabricEngine, QuantumEchoMirror, GiftMatrixEngine]:
+    actions = _load_actions(actions_path)
+    history = _load_soul_history(history_path)
+    time_engine = EthicResonantTimeEngine(
+        user,
+        identity_handle=IDENTITY_HANDLE,
+        identity_ens=IDENTITY_ENS,
+    )
+    for action in actions:
+        time_engine.register_action(action)
+    ledger = LivingMemoryLedger(
+        identity_handle=IDENTITY_HANDLE,
+        identity_ens=IDENTITY_ENS,
+    )
+    fabric = SoulLoopFabricEngine(
+        time_engine=time_engine,
+        ledger=ledger,
+        identity_handle=IDENTITY_HANDLE,
+        identity_ens=IDENTITY_ENS,
+    )
+    for entry in history:
+        fabric.log_intent(
+            str(entry.get("intent", "align")),
+            confidence=float(entry.get("confidence", 0.8)),
+            tags=tuple(entry.get("tags", ())),
+        )
+    mirror = QuantumEchoMirror(time_engine=time_engine, ledger=ledger)
+    gift = GiftMatrixEngine(
+        time_engine=time_engine,
+        ledger=ledger,
+        identity_handle=IDENTITY_HANDLE,
+        identity_ens=IDENTITY_ENS,
+    )
+    return fabric, mirror, gift
 
 
 def cmd_echoindex(args: argparse.Namespace) -> None:
@@ -320,6 +365,84 @@ def cmd_pulsewatch(args: argparse.Namespace) -> None:
     print(json.dumps(payload, indent=2))
 
 
+def cmd_soultrace(args: argparse.Namespace) -> None:
+    fabric, mirror, _ = _build_engines(args.actions, args.history)
+    payload = {
+        "trace": fabric.trace(window=args.window),
+        "metadata": fabric.metadata,
+    }
+    if args.full_history:
+        payload["history"] = list(fabric.history())
+    if args.future:
+        payload["forecast"] = mirror.project_future(
+            steps=args.steps,
+            trust_floor=args.trust_floor,
+        )
+    print(json.dumps(payload, indent=2))
+
+
+def cmd_soulpush(args: argparse.Namespace) -> None:
+    fabric, _, _ = _build_engines(args.actions, args.history)
+    record = fabric.push_signal(args.signal, intent=args.intent)
+    payload = {
+        "record": record.to_payload(),
+        "trace": fabric.trace(window=args.window),
+    }
+    if args.include_history:
+        payload["history"] = list(fabric.history())
+    print(json.dumps(payload, indent=2))
+
+
+def cmd_echo_future(args: argparse.Namespace) -> None:
+    _, mirror, _ = _build_engines(args.actions, args.history)
+    if args.future:
+        payload = mirror.project_future(
+            steps=args.steps,
+            trust_floor=args.trust_floor,
+        )
+    else:
+        payload = mirror.traceback(
+            trust_floor=args.trust_floor,
+            window=args.window,
+        )
+    print(json.dumps(payload, indent=2))
+
+
+def cmd_mirror_traceback(args: argparse.Namespace) -> None:
+    _, mirror, _ = _build_engines(args.actions, args.history)
+    payload = mirror.traceback(
+        trust_floor=args.trust_floor,
+        window=args.window,
+    )
+    print(json.dumps(payload, indent=2))
+
+
+def cmd_giftmatrix_check(args: argparse.Namespace) -> None:
+    _, _, gift = _build_engines(args.actions, args.history)
+    recipients = [_parse_wallet_spec(entry) for entry in args.recipient or ()]
+    payload = gift.preview_allocations(
+        impact=args.impact,
+        ego=args.ego,
+        recipients=recipients,
+    )
+    payload["checked"] = bool(getattr(args, "check", False))
+    print(json.dumps(payload, indent=2))
+
+
+def cmd_claim(args: argparse.Namespace) -> None:
+    _, _, gift = _build_engines(args.actions, args.history)
+    if not args.recipient:
+        raise SystemExit("At least one --recipient value is required for claim")
+    recipients = [_parse_wallet_spec(entry) for entry in args.recipient]
+    payload = gift.prepare_claim(
+        args.id,
+        impact=args.impact,
+        ego=args.ego,
+        recipients=recipients,
+    )
+    print(json.dumps(payload, indent=2))
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="ghostkey", description="Ghostkey protocol tooling")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -424,6 +547,74 @@ def build_parser() -> argparse.ArgumentParser:
         help="Include the entire mission history in the output",
     )
     p_soul.set_defaults(func=cmd_soul)
+
+    p_soultrace = sub.add_parser("soultrace", help="Render Soul Loop Fabric trace output")
+    p_soultrace.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_soultrace.add_argument("--history", help="Optional path to prior intent history", default=None)
+    p_soultrace.add_argument("--window", type=int, default=5, help="Window used for trust averaging")
+    p_soultrace.add_argument("--full-history", action="store_true", help="Include recorded history")
+    p_soultrace.add_argument("--future", action="store_true", help="Include future projection")
+    p_soultrace.add_argument("--steps", type=int, default=3, help="Number of future steps to project")
+    p_soultrace.add_argument("--trust-floor", dest="trust_floor", type=float, default=0.6)
+    p_soultrace.set_defaults(func=cmd_soultrace)
+
+    p_soulpush = sub.add_parser("soulpush", help="Push a signal into the Soul Loop Fabric")
+    p_soulpush.add_argument("--signal", type=float, required=True, help="Signal strength to push")
+    p_soulpush.add_argument("--intent", help="Optional label for the signal", default=None)
+    p_soulpush.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_soulpush.add_argument("--history", help="Optional path to prior intent history", default=None)
+    p_soulpush.add_argument("--window", type=int, default=5, help="Window used for trust averaging")
+    p_soulpush.add_argument(
+        "--include-history",
+        action="store_true",
+        help="Include the recorded history in the response",
+    )
+    p_soulpush.set_defaults(func=cmd_soulpush)
+
+    p_echo_future = sub.add_parser("echo", help="Interact with the Quantum Echo Mirror")
+    p_echo_future.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_echo_future.add_argument("--history", help="Optional path to prior intent history", default=None)
+    p_echo_future.add_argument("--future", action="store_true", help="Return future projection")
+    p_echo_future.add_argument("--steps", type=int, default=3, help="Steps used for future projections")
+    p_echo_future.add_argument("--trust-floor", dest="trust_floor", type=float, default=0.6)
+    p_echo_future.add_argument("--window", type=int, default=None, help="Window for traceback mode")
+    p_echo_future.set_defaults(func=cmd_echo_future)
+
+    p_mirror = sub.add_parser("mirror", help="Traceback using the Quantum Echo Mirror")
+    p_mirror.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_mirror.add_argument("--history", help="Optional path to prior intent history", default=None)
+    p_mirror.add_argument("--traceback", action="store_true", help="Include explicit traceback output")
+    p_mirror.add_argument("--window", type=int, default=None, help="Window limit for timeline entries")
+    p_mirror.add_argument("--trust-floor", dest="trust_floor", type=float, default=0.5)
+    p_mirror.set_defaults(func=cmd_mirror_traceback)
+
+    p_giftmatrix = sub.add_parser("giftmatrix", help="Preview Gift Matrix allocations")
+    p_giftmatrix.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_giftmatrix.add_argument("--history", help="Optional path to prior intent history", default=None)
+    p_giftmatrix.add_argument("--impact", type=float, required=True, help="Impact score")
+    p_giftmatrix.add_argument("--ego", type=float, required=True, help="Ego score")
+    p_giftmatrix.add_argument(
+        "--recipient",
+        action="append",
+        default=None,
+        help="Recipient wallet (optionally wallet:belief_multiplier:trajectory_bonus)",
+    )
+    p_giftmatrix.add_argument("--check", action="store_true", help="Run eligibility check only")
+    p_giftmatrix.set_defaults(func=cmd_giftmatrix_check)
+
+    p_claim = sub.add_parser("claim", help="Prepare a Gift Matrix claim")
+    p_claim.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_claim.add_argument("--history", help="Optional path to prior intent history", default=None)
+    p_claim.add_argument("--id", required=True, help="Claim identifier")
+    p_claim.add_argument("--impact", type=float, required=True, help="Impact score")
+    p_claim.add_argument("--ego", type=float, required=True, help="Ego score")
+    p_claim.add_argument(
+        "--recipient",
+        action="append",
+        required=True,
+        help="Recipient wallet (optionally wallet:belief_multiplier:trajectory_bonus)",
+    )
+    p_claim.set_defaults(func=cmd_claim)
 
     return parser
 

--- a/tests/test_gift_matrix_engine.py
+++ b/tests/test_gift_matrix_engine.py
@@ -1,0 +1,36 @@
+import pytest
+
+from vaultfire.modules.ethic_resonant_time_engine import EthicResonantTimeEngine
+from vaultfire.modules.gift_matrix_engine import GiftMatrixEngine
+from vaultfire.modules.living_memory_ledger import LivingMemoryLedger
+
+
+def test_gift_matrix_requires_impact_above_ego() -> None:
+    time_engine = EthicResonantTimeEngine("tester")
+    ledger = LivingMemoryLedger(identity_handle="bpow20.cb.id", identity_ens="ghostkey316.eth")
+    engine = GiftMatrixEngine(time_engine=time_engine, ledger=ledger)
+
+    assert engine.eligible(impact=1.0, ego=0.25) is True
+
+    with pytest.raises(ValueError):
+        engine.prepare_claim(
+            "claim-block",
+            impact=0.3,
+            ego=0.5,
+            recipients=["0xabc"],
+        )
+
+    result = engine.prepare_claim(
+        "claim-ready",
+        impact=1.2,
+        ego=0.4,
+        recipients=["0xabc", {"wallet": "0xdef", "belief_multiplier": 1.5}],
+    )
+
+    assert result["metadata"]["first_of_its_kind"] is True
+    assert len(result["allocations"]) == 2
+    assert sum(item["allocation"] for item in result["allocations"]) > 0
+
+    claim = engine.claim("claim-ready")
+    assert claim is not None
+    assert claim["record"]["impact"] == pytest.approx(1.2)

--- a/tests/test_quantum_echo_mirror.py
+++ b/tests/test_quantum_echo_mirror.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta, timezone
+
+from vaultfire.modules.ethic_resonant_time_engine import EthicResonantTimeEngine
+from vaultfire.modules.living_memory_ledger import LivingMemoryLedger
+from vaultfire.modules.quantum_echo_mirror import QuantumEchoMirror
+from vaultfire.modules.soul_loop_fabric_engine import SoulLoopFabricEngine
+
+
+def test_quantum_echo_respects_temporal_bounds_and_trust() -> None:
+    time_engine = EthicResonantTimeEngine("tester")
+    ledger = LivingMemoryLedger(identity_handle="bpow20.cb.id", identity_ens="ghostkey316.eth")
+    fabric = SoulLoopFabricEngine(time_engine=time_engine, ledger=ledger)
+
+    old_timestamp = datetime.now(timezone.utc) - timedelta(hours=10)
+    ledger.record({"intent": "archive", "confidence": 0.9}, timestamp=old_timestamp, trust=0.9)
+    fabric.log_intent("align", confidence=0.9)
+    recent = fabric.log_intent("uplift", confidence=0.85)
+    mirror = QuantumEchoMirror(time_engine=time_engine, ledger=ledger)
+
+    projection = mirror.project_future(steps=3, trust_floor=0.7)
+    assert projection["metadata"]["first_of_its_kind"] is True
+    assert projection["forecast"], "expected at least one forecast entry"
+    record_ids = [entry["record_id"] for entry in projection["forecast"]]
+    assert recent.record_id in record_ids
+    assert "memory-0001" not in record_ids
+
+    timeline = mirror.traceback(trust_floor=0.5)
+    assert len(timeline["timeline"]) == 2
+    assert timeline["timeline"][-1]["record_id"] == recent.record_id

--- a/tests/test_soul_loop_fabric_engine.py
+++ b/tests/test_soul_loop_fabric_engine.py
@@ -1,0 +1,24 @@
+from vaultfire.modules.ethic_resonant_time_engine import EthicResonantTimeEngine
+from vaultfire.modules.living_memory_ledger import LivingMemoryLedger
+from vaultfire.modules.soul_loop_fabric_engine import SoulLoopFabricEngine
+
+
+def test_soul_loop_trace_includes_trust_and_moral_score() -> None:
+    time_engine = EthicResonantTimeEngine("tester")
+    ledger = LivingMemoryLedger(identity_handle="bpow20.cb.id", identity_ens="ghostkey316.eth")
+    fabric = SoulLoopFabricEngine(time_engine=time_engine, ledger=ledger)
+
+    fabric.log_intent("align", confidence=0.9, tags=("ally",))
+    fabric.log_intent("uplift", confidence=0.8, tags=("mission",))
+    push_record = fabric.push_signal(0.7, intent="harmonize")
+
+    assert push_record.trust >= 0.6
+
+    trace = fabric.trace(window=2)
+    assert trace["metadata"]["first_of_its_kind"] is True
+    assert trace["tempo"] in {"slow", "normal", "fast", "ultrafast"}
+    assert trace["moral_score"] == time_engine.mmi.get_score()
+    assert trace["trust_window"] >= 0.6
+    history = fabric.history()
+    assert len(history) == 3
+    assert history[-1]["payload"]["signal"] == 0.7

--- a/vaultfire/modules/__init__.py
+++ b/vaultfire/modules/__init__.py
@@ -1,6 +1,10 @@
 """Utility modules for the Vaultfire package."""
 
 from .ethic_resonant_time_engine import EthicResonantTimeEngine
+from .gift_matrix_engine import GiftMatrixEngine
+from .living_memory_ledger import LivingMemoryLedger
+from .quantum_echo_mirror import QuantumEchoMirror
+from .soul_loop_fabric_engine import SoulLoopFabricEngine
 from .vaultfire_protocol_stack import (
     AdaptiveRelicStore,
     ConsciousStateEngine,
@@ -15,6 +19,10 @@ from .vaultfire_protocol_stack import (
 
 __all__ = [
     "EthicResonantTimeEngine",
+    "GiftMatrixEngine",
+    "LivingMemoryLedger",
+    "QuantumEchoMirror",
+    "SoulLoopFabricEngine",
     "AdaptiveRelicStore",
     "ConsciousStateEngine",
     "GiftMatrixV1",

--- a/vaultfire/modules/gift_matrix_engine.py
+++ b/vaultfire/modules/gift_matrix_engine.py
@@ -1,0 +1,179 @@
+"""Gift Matrix orchestration aligned with the Living Memory Ledger."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, MutableMapping
+
+from vaultfire.modules.ethic_resonant_time_engine import EthicResonantTimeEngine
+from vaultfire.modules.living_memory_ledger import LivingMemoryLedger
+
+
+@dataclass(frozen=True)
+class Allocation:
+    wallet: str
+    allocation: float
+    belief_score: float
+    signal_weight: float
+    identity_tag: str
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {
+            "wallet": self.wallet,
+            "allocation": self.allocation,
+            "belief_score": self.belief_score,
+            "signal_weight": self.signal_weight,
+            "identity_tag": self.identity_tag,
+        }
+
+
+class GiftMatrixEngine:
+    """Simplified Gift Matrix with impact/ego gating."""
+
+    def __init__(
+        self,
+        *,
+        time_engine: EthicResonantTimeEngine,
+        ledger: LivingMemoryLedger,
+        identity_handle: str = "bpow20.cb.id",
+        identity_ens: str = "ghostkey316.eth",
+    ) -> None:
+        self.time_engine = time_engine
+        self.ledger = ledger
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self.metadata: Mapping[str, object] = {
+            "module": "GiftMatrixEngine",
+            "identity": {"wallet": identity_handle, "ens": identity_ens},
+            "first_of_its_kind": True,
+            "tags": ("FOTK",),
+        }
+        self._claims: MutableMapping[str, Mapping[str, object]] = {}
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def eligible(self, impact: float, ego: float) -> bool:
+        return float(impact) > float(ego)
+
+    def _resolve_recipients(
+        self, recipients: Iterable[str | Mapping[str, object]]
+    ) -> list[tuple[str, float]]:
+        resolved: list[tuple[str, float]] = []
+        for entry in recipients:
+            if isinstance(entry, Mapping):
+                wallet = str(entry.get("wallet"))
+                belief = float(entry.get("belief_multiplier", 1.0))
+                trajectory = float(entry.get("trajectory_bonus", 0.0))
+            else:
+                wallet = str(entry)
+                belief = 1.0
+                trajectory = 0.0
+            weight = max(0.0, belief + trajectory)
+            resolved.append((wallet, weight or 1.0))
+        return resolved
+
+    def _build_allocations(
+        self,
+        recipients: Iterable[str | Mapping[str, object]],
+        *,
+        impact: float,
+    ) -> list[Allocation]:
+        resolved = self._resolve_recipients(recipients)
+        if not resolved:
+            return []
+        total = sum(weight for _, weight in resolved) or 1.0
+        base = max(impact, 1.0)
+        allocations: list[Allocation] = []
+        for index, (wallet, weight) in enumerate(resolved, 1):
+            fraction = weight / total
+            allocations.append(
+                Allocation(
+                    wallet=wallet,
+                    allocation=round(base * fraction, 6),
+                    belief_score=round(weight, 4),
+                    signal_weight=round(fraction, 4),
+                    identity_tag=f"{wallet}::gift::{index}",
+                )
+            )
+        return allocations
+
+    def preview_allocations(
+        self,
+        *,
+        impact: float,
+        ego: float,
+        recipients: Iterable[str | Mapping[str, object]],
+    ) -> Mapping[str, object]:
+        return {
+            "eligible": self.eligible(impact, ego),
+            "tempo": self.time_engine.current_tempo(),
+            "allocations": [
+                allocation.to_payload()
+                for allocation in self._build_allocations(recipients, impact=impact)
+            ],
+            "metadata": self.metadata,
+        }
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    def prepare_claim(
+        self,
+        claim_id: str,
+        *,
+        impact: float,
+        ego: float,
+        recipients: Iterable[str | Mapping[str, object]],
+    ) -> Mapping[str, object]:
+        if not self.eligible(impact, ego):
+            raise ValueError("impact must be greater than ego to invoke GiftMatrix")
+
+        delta = float(impact) - float(ego)
+        self.time_engine.register_action(
+            {
+                "type": "support",
+                "interaction_id": claim_id,
+                "weight": max(delta, 0.1) * 10,
+            }
+        )
+
+        allocations = [
+            allocation.to_payload()
+            for allocation in self._build_allocations(recipients, impact=impact)
+        ]
+
+        record = self.ledger.record(
+            {
+                "claim_id": claim_id,
+                "allocations": allocations,
+            },
+            trust=min(1.0, 0.55 + delta * 0.1),
+            impact=impact,
+            ego=ego,
+        )
+
+        payload = {
+            "claim_id": claim_id,
+            "tempo": self.time_engine.current_tempo(),
+            "allocations": allocations,
+            "record": record.to_payload(),
+            "metadata": self.metadata,
+        }
+        self._claims[claim_id] = payload
+        return payload
+
+    def claim(self, claim_id: str) -> Mapping[str, object] | None:
+        cached = self._claims.get(claim_id)
+        if cached:
+            return cached
+        for record in self.ledger.records():
+            if record.payload.get("claim_id") == claim_id:
+                return {
+                    "claim_id": claim_id,
+                    "record": record.to_payload(),
+                    "tempo": self.time_engine.current_tempo(),
+                    "metadata": self.metadata,
+                }
+        return None
+

--- a/vaultfire/modules/living_memory_ledger.py
+++ b/vaultfire/modules/living_memory_ledger.py
@@ -1,0 +1,137 @@
+"""Living Memory Ledger utilities for Vaultfire engines.
+
+The ledger acts as a lightweight in-memory journal that mirrors the
+behaviour described in the Vaultfire protocol notes.  Entries are recorded
+with an associated trust score as well as ``impact`` and ``ego`` signals so
+engines can reason about proportionality.  The implementation deliberately
+keeps the API surface small and deterministic which keeps the surrounding
+tests fast and reliable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, MutableSequence, Sequence
+
+
+@dataclass(frozen=True)
+class MemoryRecord:
+    """Immutable representation of a living memory entry."""
+
+    record_id: str
+    timestamp: datetime
+    payload: Mapping[str, object]
+    trust: float
+    impact: float
+    ego: float
+
+    def to_payload(self) -> Mapping[str, object]:
+        """Return a JSON serialisable payload."""
+
+        return {
+            "record_id": self.record_id,
+            "timestamp": self.timestamp.isoformat(),
+            "payload": dict(self.payload),
+            "trust": self.trust,
+            "impact": self.impact,
+            "ego": self.ego,
+        }
+
+
+class LivingMemoryLedger:
+    """Minimal ledger that maintains trust aware memory entries."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str,
+        identity_ens: str,
+        base_trust: float = 0.6,
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self.base_trust = max(0.0, min(base_trust, 1.0))
+        self._records: MutableSequence[MemoryRecord] = []
+        self._counter: int = 0
+        self.metadata: Mapping[str, object] = {
+            "module": "LivingMemoryLedger",
+            "identity": {"wallet": identity_handle, "ens": identity_ens},
+        }
+
+    # ------------------------------------------------------------------
+    # recording helpers
+    # ------------------------------------------------------------------
+    def _next_id(self) -> str:
+        self._counter += 1
+        return f"memory-{self._counter:04d}"
+
+    def record(
+        self,
+        payload: Mapping[str, object],
+        *,
+        trust: float | None = None,
+        impact: float = 0.0,
+        ego: float = 0.0,
+        timestamp: datetime | None = None,
+    ) -> MemoryRecord:
+        """Record a new memory entry and return the stored record."""
+
+        trust_value = self._resolve_trust(payload, trust)
+        timestamp = timestamp or datetime.now(timezone.utc)
+        record = MemoryRecord(
+            record_id=self._next_id(),
+            timestamp=timestamp,
+            payload=dict(payload),
+            trust=trust_value,
+            impact=float(impact),
+            ego=float(ego),
+        )
+        self._records.append(record)
+        return record
+
+    def _resolve_trust(
+        self, payload: Mapping[str, object], override: float | None
+    ) -> float:
+        if override is not None:
+            value = float(override)
+        else:
+            confidence = float(payload.get("confidence", self.base_trust))
+            value = 0.5 * self.base_trust + 0.5 * max(0.0, min(confidence, 1.0))
+        return max(0.0, min(value, 1.0))
+
+    # ------------------------------------------------------------------
+    # inspection utilities
+    # ------------------------------------------------------------------
+    def records(self) -> Sequence[MemoryRecord]:
+        return tuple(self._records)
+
+    def tail(self, limit: int | None = None) -> Sequence[MemoryRecord]:
+        if limit is None:
+            return self.records()
+        if limit <= 0:
+            return tuple()
+        return tuple(self._records[-limit:])
+
+    def average_trust(self, window: int | None = None) -> float:
+        records: Iterable[MemoryRecord]
+        if window is None:
+            records = self._records
+        else:
+            records = self.tail(window)
+        values = [entry.trust for entry in records]
+        if not values:
+            return self.base_trust
+        return sum(values) / len(values)
+
+    def timeline_bounds(self) -> tuple[datetime, datetime] | None:
+        if not self._records:
+            return None
+        return self._records[0].timestamp, self._records[-1].timestamp
+
+    def find(self, record_id: str) -> MemoryRecord | None:
+        for record in self._records:
+            if record.record_id == record_id:
+                return record
+        return None
+

--- a/vaultfire/modules/quantum_echo_mirror.py
+++ b/vaultfire/modules/quantum_echo_mirror.py
@@ -1,0 +1,101 @@
+"""Quantum Echo Mirror built on top of the Living Memory Ledger."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Mapping, Sequence
+
+from vaultfire.modules.ethic_resonant_time_engine import EthicResonantTimeEngine
+from vaultfire.modules.living_memory_ledger import LivingMemoryLedger, MemoryRecord
+
+
+class QuantumEchoMirror:
+    """Project timelines while respecting trust floors and tempo bounds."""
+
+    _TEMPO_BOUNDS = {
+        "slow": 60 * 60,  # 1 hour
+        "normal": 60 * 60 * 4,  # 4 hours
+        "fast": 60 * 60 * 8,  # 8 hours
+        "ultrafast": 60 * 60 * 12,  # 12 hours
+    }
+
+    def __init__(
+        self,
+        *,
+        time_engine: EthicResonantTimeEngine,
+        ledger: LivingMemoryLedger,
+    ) -> None:
+        self.time_engine = time_engine
+        self.ledger = ledger
+        self.metadata: Mapping[str, object] = {
+            "module": "QuantumEchoMirror",
+            "first_of_its_kind": True,
+            "tags": ("FOTK",),
+        }
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _bound_seconds(self) -> int:
+        tempo = self.time_engine.current_tempo()
+        return int(self._TEMPO_BOUNDS.get(tempo, 60 * 60))
+
+    def _eligible_records(
+        self, *, trust_floor: float, limit: int | None = None
+    ) -> Sequence[MemoryRecord]:
+        now = datetime.now(timezone.utc)
+        bound = self._bound_seconds()
+        records = []
+        for record in reversed(self.ledger.records()):
+            if record.trust < trust_floor:
+                continue
+            delta = now - record.timestamp
+            if delta.total_seconds() > bound:
+                continue
+            records.append(record)
+            if limit is not None and len(records) >= limit:
+                break
+        return tuple(reversed(records))
+
+    # ------------------------------------------------------------------
+    # public interface
+    # ------------------------------------------------------------------
+    def project_future(
+        self,
+        *,
+        steps: int = 3,
+        trust_floor: float = 0.6,
+    ) -> Mapping[str, object]:
+        candidates = self._eligible_records(trust_floor=trust_floor, limit=steps)
+        pulse = self.time_engine.pulse()
+        return {
+            "tempo": self.time_engine.current_tempo(),
+            "bound_seconds": self._bound_seconds(),
+            "forecast": [
+                {
+                    "record_id": record.record_id,
+                    "timestamp": record.timestamp.isoformat(),
+                    "intent": record.payload.get("intent") or record.payload.get("signal"),
+                    "trust": record.trust,
+                    "projected_pulse": pulse.get("pulse"),
+                }
+                for record in candidates
+            ],
+            "metadata": self.metadata,
+        }
+
+    def traceback(
+        self,
+        *,
+        trust_floor: float = 0.5,
+        window: int | None = None,
+    ) -> Mapping[str, object]:
+        limit = window if window and window > 0 else None
+        candidates = self._eligible_records(trust_floor=trust_floor, limit=limit)
+        return {
+            "tempo": self.time_engine.current_tempo(),
+            "bound_seconds": self._bound_seconds(),
+            "timeline": [record.to_payload() for record in candidates],
+            "metadata": self.metadata,
+        }
+

--- a/vaultfire/modules/soul_loop_fabric_engine.py
+++ b/vaultfire/modules/soul_loop_fabric_engine.py
@@ -1,0 +1,110 @@
+"""Soul Loop Fabric engine that bridges ethics tempo and living memory."""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from vaultfire.modules.ethic_resonant_time_engine import EthicResonantTimeEngine
+from vaultfire.modules.living_memory_ledger import LivingMemoryLedger, MemoryRecord
+
+
+class SoulLoopFabricEngine:
+    """Synchronise intent history with the ethic resonant tempo engine."""
+
+    def __init__(
+        self,
+        *,
+        time_engine: EthicResonantTimeEngine | None = None,
+        ledger: LivingMemoryLedger | None = None,
+        identity_handle: str = "bpow20.cb.id",
+        identity_ens: str = "ghostkey316.eth",
+    ) -> None:
+        self.time_engine = time_engine or EthicResonantTimeEngine(
+            "ghostkey-316",
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self.ledger = ledger or LivingMemoryLedger(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self.metadata: Mapping[str, object] = {
+            "module": "SoulLoopFabricEngine",
+            "identity": {"wallet": identity_handle, "ens": identity_ens},
+            "first_of_its_kind": True,
+            "tags": ("FOTK",),
+        }
+
+    # ------------------------------------------------------------------
+    # intent management
+    # ------------------------------------------------------------------
+    def log_intent(
+        self,
+        intent: str,
+        *,
+        confidence: float = 0.85,
+        tags: Sequence[str] | None = None,
+    ) -> MemoryRecord:
+        tags = tuple(tags or ())
+        action = {
+            "type": "support",
+            "intent": intent,
+            "weight": max(confidence, 0.1) * 10,
+            "tags": tags,
+        }
+        self.time_engine.register_action(action)
+        payload = {
+            "intent": intent,
+            "confidence": confidence,
+            "tags": list(tags),
+        }
+        return self.ledger.record(
+            payload,
+            trust=confidence,
+            impact=max(confidence, 0.0),
+            ego=0.0,
+        )
+
+    def push_signal(self, value: float, *, intent: str | None = None) -> MemoryRecord:
+        label = intent or "signal"
+        action_type = "support" if value >= 0 else "selfish"
+        self.time_engine.register_action(
+            {
+                "type": action_type,
+                "intent": label,
+                "weight": abs(value) * 10,
+            }
+        )
+        trust = 0.6 + max(value, 0.0) * 0.25
+        trust = max(0.0, min(trust, 1.0))
+        return self.ledger.record(
+            {"signal": value, "intent": label},
+            trust=trust,
+            impact=max(value, 0.0),
+            ego=max(-value, 0.0),
+        )
+
+    # ------------------------------------------------------------------
+    # analytics
+    # ------------------------------------------------------------------
+    def trace(self, *, window: int = 5) -> Mapping[str, object]:
+        pulse_snapshot = self.time_engine.pulse()
+        return {
+            "tempo": self.time_engine.current_tempo(),
+            "moral_score": self.time_engine.mmi.get_score(),
+            "trust_window": self.ledger.average_trust(window),
+            "history_size": len(self.ledger.records()),
+            "latest_pulse": pulse_snapshot.get("pulse"),
+            "metadata": self.metadata,
+        }
+
+    def history(self) -> Sequence[Mapping[str, object]]:
+        return tuple(record.to_payload() for record in self.ledger.records())
+
+    def export(self) -> Mapping[str, object]:
+        return {
+            "metadata": self.metadata,
+            "trace": self.trace(),
+            "history": list(self.history()),
+        }
+


### PR DESCRIPTION
## Summary
- add a living memory ledger and three first-of-its-kind engines for soul loop, quantum mirror, and gift matrix coordination
- extend the Ghostkey CLI with soultrace, soulpush, echo, mirror, giftmatrix, and claim subcommands built on the new engines
- cover the new engines with targeted pytest suites validating trust gating, temporal bounds, and gift eligibility

## Testing
- pytest tests/test_soul_loop_fabric_engine.py
- pytest tests/test_quantum_echo_mirror.py
- pytest tests/test_gift_matrix_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68e423d1e51c8322942419170f28bd15