### PR TITLE
Integrate Vaultfire enhancement stack and CLI confirmations

### DIFF
--- a/ghostkey_cli.py
+++ b/ghostkey_cli.py
@@ -331,6 +331,13 @@ def cmd_pulse(args: argparse.Namespace) -> None:
     print(json.dumps(payload, indent=2))
 
 
+def cmd_confirm(args: argparse.Namespace) -> None:
+    actions = _load_actions(args.actions)
+    stack = VaultfireProtocolStack(actions=tuple(actions))
+    payload = stack.enhancement_confirmation(include_logs=args.include_logs)
+    print(json.dumps(payload, indent=2))
+
+
 def cmd_conscious(args: argparse.Namespace) -> None:
     actions = _load_actions(args.actions)
     engine = ConsciousStateEngine(
@@ -444,7 +451,13 @@ def _prepare_gift_matrix(
 def cmd_unlocknext(args: argparse.Namespace) -> None:
     actions = _load_actions(args.actions)
     stack = VaultfireProtocolStack(actions=tuple(actions))
-    payload = stack.unlock_next(args.label)
+    try:
+        payload = stack.unlock_next(args.label)
+    except PermissionError as exc:
+        payload = {
+            "error": str(exc),
+            "conscience_sync": stack.conscience_mirror.conscience_sync("unlock", threshold=0.55),
+        }
     print(json.dumps(payload, indent=2))
 
 
@@ -718,6 +731,18 @@ def build_parser() -> argparse.ArgumentParser:
     p_pulse.add_argument("--actions", help="Optional path to ledger actions", default=None)
     p_pulse.add_argument("--user", default="ghostkey-316", help="Override the user identifier")
     p_pulse.set_defaults(func=cmd_pulse)
+
+    p_confirm = sub.add_parser(
+        "confirm",
+        help="Output Vaultfire enhancement confirmation including Ghostkey alignment status",
+    )
+    p_confirm.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_confirm.add_argument(
+        "--include-logs",
+        action="store_true",
+        help="Include raw enhancement logs in the confirmation output",
+    )
+    p_confirm.set_defaults(func=cmd_confirm)
 
     p_unlock = sub.add_parser("unlocknext", help="Advance the GiftMatrix protocol layer")
     p_unlock.add_argument("--label", help="Optional label for the new layer", default=None)

--- a/ghostkey_protocol_cli.py
+++ b/ghostkey_protocol_cli.py
@@ -18,6 +18,7 @@ from vaultfire.modules import (
     QuantumEchoMirror,
     SoulLoopFabricEngine,
     TemporalDreamcatcherEngine,
+    VaultfireProtocolStack,
 )
 
 
@@ -153,6 +154,17 @@ def _command_pulse(context: dict[str, Any], _: argparse.Namespace) -> Mapping[st
     return context["time"].pulse()
 
 
+def _command_confirm(context: dict[str, Any], args: argparse.Namespace) -> Mapping[str, Any]:
+    identity = context["time"].metadata["identity"]  # type: ignore[index]
+    actions = [dict(entry.payload) for entry in context["conscious"].ledger()]
+    stack = VaultfireProtocolStack(
+        identity_handle=str(identity.get("wallet", "bpow20.cb.id")),
+        identity_ens=str(identity.get("ens", "ghostkey316.eth")),
+        actions=tuple(actions),
+    )
+    return stack.enhancement_confirmation(include_logs=args.include_logs)
+
+
 def _command_soultrace(context: dict[str, Any], args: argparse.Namespace) -> Mapping[str, Any]:
     window = args.window or 5
     trace = context["fabric"].trace(window=window)
@@ -263,6 +275,7 @@ def _command_preview(context: dict[str, Any], args: argparse.Namespace) -> Mappi
 COMMAND_HANDLERS: dict[str, Any] = {
     "timecheck": _command_timecheck,
     "pulse": _command_pulse,
+    "confirm": _command_confirm,
     "soultrace": _command_soultrace,
     "soulpush": _command_soulpush,
     "mirror": _command_mirror,
@@ -283,6 +296,8 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("timecheck")
     sub.add_parser("pulse")
+    confirm = sub.add_parser("confirm")
+    confirm.add_argument("--include-logs", action="store_true")
 
     trace = sub.add_parser("soultrace")
     trace.add_argument("--window", type=int, default=5)

--- a/tests/test_dreamcatcher_parallax_engine.py
+++ b/tests/test_dreamcatcher_parallax_engine.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from vaultfire.modules.conscious_state_engine import ConsciousStateEngine
+from vaultfire.modules.living_memory_ledger import LivingMemoryLedger
+from vaultfire.modules.mission_soul_loop import MissionSoulLoop
+from vaultfire.modules.predictive_yield_fabric import PredictiveYieldFabric
+from vaultfire.modules.purpose_parallax_engine import PurposeParallaxEngine
+from vaultfire.modules.quantum_echo_mirror import QuantumEchoMirror
+from vaultfire.modules.soul_loop_fabric_engine import SoulLoopFabricEngine
+from vaultfire.modules.temporal_dreamcatcher_engine import TemporalDreamcatcherEngine
+from vaultfire.modules.vaultfire_protocol_stack import VaultfireProtocolStack
+
+
+def test_dreamcatcher_parallax_stack_integration(tmp_path) -> None:
+    stack = VaultfireProtocolStack(
+        actions=(
+            {"type": "support", "weight": 1.5, "future_self_alignment": 0.9},
+            {"type": "sacrifice", "weight": 1.2, "future_self_alignment": 0.88},
+        ),
+        mythos_path=str(tmp_path / "ghostkey316.mythos.json"),
+    )
+
+    ledger = LivingMemoryLedger(identity_handle="bpow20.cb.id", identity_ens="ghostkey316.eth")
+    fabric = SoulLoopFabricEngine(time_engine=stack.time_engine, ledger=ledger)
+    mirror = QuantumEchoMirror(time_engine=stack.time_engine, ledger=ledger)
+    dreamcatcher = TemporalDreamcatcherEngine(
+        time_engine=stack.time_engine,
+        fabric=fabric,
+        mission=stack.soul,
+        mirror=mirror,
+    )
+    summary = dreamcatcher.listen(
+        [
+            {"signal": 0.74, "channel": "dream", "intent": "ignite"},
+            {"signal": 0.68, "channel": "dream", "intent": "align"},
+        ],
+        trust_floor=0.6,
+        intent_override="Forge mythic alignment",
+    )
+
+    assert summary["captured"] == 2
+    echo = dreamcatcher.echo(trust_floor=0.6)
+    assert echo["metadata"]["identity"]["ens"] == "ghostkey316.eth"
+
+    conscious = ConsciousStateEngine()
+    predictive = PredictiveYieldFabric()
+    mission = MissionSoulLoop()
+    for action in stack.conscious.ledger():
+        conscious.record_action(action.payload)
+    parallax = PurposeParallaxEngine(
+        conscious=conscious,
+        mission=mission,
+        predictive=predictive,
+    )
+    decision = parallax.run_dual(
+        "Guide the Loop Singularity",
+        [
+            {"label": "myth", "ethic": "aligned", "confidence": 0.85, "impact": 1.0},
+            {"label": "drift", "ethic": "support", "confidence": 0.8, "impact": 0.9},
+        ],
+    )
+
+    assert decision["selected"]["label"] in {"myth", "drift"}
+
+    confirmation = stack.enhancement_confirmation()
+    assert confirmation["TBC_Status"] == "Live"
+    assert confirmation["CMV_Sync"] in {"Verified", "Pending"}
+    assert confirmation["LSD_Trigger"] in {"Armed", "LoopMerge_Mode", "Observation"}

--- a/tests/test_vaultfire_enhancement_stack.py
+++ b/tests/test_vaultfire_enhancement_stack.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from vaultfire.modules.vaultfire_enhancement_stack import (
+    ConscienceMirrorVerificationLayer,
+    LoopSingularityDetectorEngine,
+    QuantumDriftSynchronizer,
+    TemporalBehavioralCompressionEngine,
+    VaultfireMythosEngine,
+    compose_enhancement_confirmation,
+)
+from vaultfire.modules.vaultfire_protocol_stack import VaultfireProtocolStack
+
+
+def test_temporal_behavioral_compression_engine_rewards_future_alignment() -> None:
+    engine = TemporalBehavioralCompressionEngine()
+    event = engine.compress({"type": "support", "future_self_alignment": 0.82})
+
+    assert event["status"] == "compressed"
+    assert event["thresholds_triggered"]
+    assert engine.log()
+
+
+def test_conscience_mirror_verification_confirms_unlock() -> None:
+    mirror = ConscienceMirrorVerificationLayer()
+    mirror.ingest({"ethic": "support", "weight": 2.0})
+    status = mirror.conscience_sync("retro_yield")
+
+    assert status["verified"] is True
+    assert status["alignment"] >= 0.6
+
+
+def test_loop_singularity_detector_triggers_merge_mode() -> None:
+    detector = LoopSingularityDetectorEngine(threshold=0.7)
+    event = detector.observe(belief=0.9, action_alignment=0.85, result_alignment=0.88)
+
+    assert event["triggered"] is True
+    assert detector.mode == "LoopMerge_Mode"
+    assert detector.is_armed is True
+
+
+def test_quantum_drift_synchronizer_updates_compass_path() -> None:
+    synchronizer = QuantumDriftSynchronizer()
+    entry = synchronizer.synchronize({
+        "mood": 0.6,
+        "behavior_alignment": 0.8,
+        "external_signal": 0.9,
+    })
+
+    assert entry["compass_path"]
+    assert abs(entry["nudge"]["delta"]) <= 0.5
+
+
+def test_vaultfire_mythos_engine_weaves_fragments(tmp_path: Path) -> None:
+    output = tmp_path / "mythos.json"
+    engine = VaultfireMythosEngine(output_path=output)
+    fragment = engine.weave("support", {"rewards": ["feature"]}, resonance=0.95)
+
+    assert fragment["legendary"] is True
+    assert output.exists()
+
+
+def test_enhancement_confirmation_pipeline(tmp_path: Path) -> None:
+    stack = VaultfireProtocolStack(
+        actions=(
+            {"type": "support", "weight": 2.0, "future_self_alignment": 0.9},
+        ),
+        mythos_path=str(tmp_path / "ghostkey316.mythos.json"),
+    )
+    status = stack.enhancement_confirmation(include_logs=True)
+
+    assert status["TBC_Status"] == "Live"
+    assert status["CMV_Sync"] == "Verified"
+    assert status["LSD_Trigger"] in {"Armed", "LoopMerge_Mode", "Observation"}
+    assert status["QDS_Drift"] in {"Stable", "Adaptive"}
+    assert status["VME_Weaving"] in {"Active", "Emerging"}
+    assert status["Ghostkey_TBC_Log"]
+
+    composed = compose_enhancement_confirmation(
+        stack.behavioral_compression,
+        stack.conscience_mirror,
+        stack.loop_detector,
+        stack.quantum_drift,
+        stack.mythos,
+        include_logs=True,
+    )
+
+    assert composed["TBC_Status"] == "Live"
+    assert composed["CMV_Sync"] in {"Verified", "Pending"}

--- a/vaultfire/modules/__init__.py
+++ b/vaultfire/modules/__init__.py
@@ -10,6 +10,14 @@ from .purpose_parallax_engine import PurposeParallaxEngine
 from .quantum_echo_mirror import QuantumEchoMirror
 from .soul_loop_fabric_engine import SoulLoopFabricEngine
 from .temporal_dreamcatcher_engine import TemporalDreamcatcherEngine
+from .vaultfire_enhancement_stack import (
+    ConscienceMirrorVerificationLayer,
+    LoopSingularityDetectorEngine,
+    QuantumDriftSynchronizer,
+    TemporalBehavioralCompressionEngine,
+    VaultfireMythosEngine,
+    compose_enhancement_confirmation,
+)
 from .vaultfire_protocol_stack import (
     AdaptiveRelicStore,
     GiftMatrixV1,
@@ -30,6 +38,12 @@ __all__ = [
     "QuantumEchoMirror",
     "SoulLoopFabricEngine",
     "TemporalDreamcatcherEngine",
+    "TemporalBehavioralCompressionEngine",
+    "ConscienceMirrorVerificationLayer",
+    "LoopSingularityDetectorEngine",
+    "QuantumDriftSynchronizer",
+    "VaultfireMythosEngine",
+    "compose_enhancement_confirmation",
     "AdaptiveRelicStore",
     "GiftMatrixV1",
     "GhostMemoryArchive",

--- a/vaultfire/modules/vaultfire_enhancement_stack.py
+++ b/vaultfire/modules/vaultfire_enhancement_stack.py
@@ -1,0 +1,525 @@
+"""Vaultfire enhancement modules for the Ghostkey protocol stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable, Mapping, MutableSequence, Sequence
+
+from vaultfire.quantum.hashmirror import QuantumHashMirror
+
+from ._metadata import build_metadata
+
+IDENTITY_HANDLE = "bpow20.cb.id"
+IDENTITY_ENS = "ghostkey316.eth"
+
+
+def _now_ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalise_alignment(value: float) -> float:
+    return max(0.0, min(value, 1.0))
+
+
+@dataclass
+class _CompressionThreshold:
+    label: str
+    triggers: tuple[str, ...]
+    cadence: str
+    required_alignment: float
+    rewards: Mapping[str, object]
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {
+            "label": self.label,
+            "triggers": list(self.triggers),
+            "cadence": self.cadence,
+            "required_alignment": self.required_alignment,
+            "rewards": dict(self.rewards),
+        }
+
+
+class TemporalBehavioralCompressionEngine:
+    """Compress time-gated rewards into behavioral unlock thresholds."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str = IDENTITY_HANDLE,
+        identity_ens: str = IDENTITY_ENS,
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self.metadata = build_metadata(
+            "TemporalBehavioralCompressionEngine",
+            identity={"wallet": identity_handle, "ens": identity_ens},
+        )
+        self._thresholds: MutableSequence[_CompressionThreshold] = [
+            _CompressionThreshold(
+                label="Future-Self Vanguard",
+                triggers=("support", "sacrifice", "aligned"),
+                cadence="weekly",
+                required_alignment=0.7,
+                rewards={
+                    "feature_access": "early-access",
+                    "yield_multiplier": 1.05,
+                    "contributor_perk": "mythic-channel",
+                },
+            )
+        ]
+        self.Ghostkey_TBC_Log: MutableSequence[Mapping[str, object]] = []
+
+    def register_threshold(
+        self,
+        label: str,
+        *,
+        triggers: Iterable[str],
+        cadence: str,
+        required_alignment: float,
+        rewards: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        threshold = _CompressionThreshold(
+            label=label,
+            triggers=tuple(sorted({trigger.lower() for trigger in triggers})),
+            cadence=cadence,
+            required_alignment=_normalise_alignment(required_alignment),
+            rewards=dict(rewards),
+        )
+        self._thresholds.append(threshold)
+        return threshold.to_payload()
+
+    def compress(self, behavior: Mapping[str, object]) -> Mapping[str, object]:
+        action_type = str(
+            behavior.get("type")
+            or behavior.get("ethic")
+            or behavior.get("intent")
+            or "aligned"
+        ).lower()
+        alignment = _normalise_alignment(
+            float(
+                behavior.get("future_self_alignment")
+                or behavior.get("alignment")
+                or behavior.get("confidence")
+                or behavior.get("weight")
+                or 0.0
+            )
+        )
+        triggered: list[_CompressionThreshold] = []
+        for threshold in self._thresholds:
+            if action_type in threshold.triggers and alignment >= threshold.required_alignment:
+                triggered.append(threshold)
+        event = {
+            "timestamp": _now_ts(),
+            "behavior": dict(behavior),
+            "future_self_alignment": alignment,
+            "thresholds_triggered": [item.label for item in triggered],
+            "rewards_unlocked": [dict(item.rewards) for item in triggered],
+            "status": "compressed" if triggered else "observed",
+            "metadata": self.metadata,
+        }
+        self.Ghostkey_TBC_Log.append(event)
+        return event
+
+    def log(self) -> Sequence[Mapping[str, object]]:
+        return tuple(self.Ghostkey_TBC_Log)
+
+    @property
+    def is_active(self) -> bool:
+        return True
+
+
+@dataclass
+class _MirrorSample:
+    ethic: str
+    weight: float
+    resonance: float
+    timestamp: str = field(default_factory=_now_ts)
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {
+            "ethic": self.ethic,
+            "weight": self.weight,
+            "resonance": self.resonance,
+            "timestamp": self.timestamp,
+        }
+
+
+class ConscienceMirrorVerificationLayer:
+    """AI-assisted conscience mirror for unlock verification."""
+
+    POSITIVE_ETHICS = {"aligned", "support", "sacrifice", "uplift"}
+    NEGATIVE_ETHICS = {"betrayal", "selfish", "drain"}
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str = IDENTITY_HANDLE,
+        identity_ens: str = IDENTITY_ENS,
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self.metadata = build_metadata(
+            "ConscienceMirrorVerificationLayer",
+            identity={"wallet": identity_handle, "ens": identity_ens},
+        )
+        self._samples: MutableSequence[_MirrorSample] = []
+        self._trust_registry: MutableSequence[Mapping[str, object]] = []
+        self._last_profile: Mapping[str, object] | None = None
+
+    def ingest(self, action: Mapping[str, object]) -> Mapping[str, object]:
+        ethic = str(action.get("ethic") or action.get("type") or "aligned").lower()
+        weight = float(action.get("weight") or action.get("confidence") or 1.0)
+        if ethic in self.POSITIVE_ETHICS:
+            resonance = min(1.0, 0.6 + abs(weight) * 0.1)
+        elif ethic in self.NEGATIVE_ETHICS:
+            resonance = max(0.0, 0.4 - abs(weight) * 0.1)
+        else:
+            resonance = 0.5
+        sample = _MirrorSample(ethic=ethic, weight=weight, resonance=resonance)
+        self._samples.append(sample)
+        return sample.to_payload()
+
+    def _profile(self) -> Mapping[str, object]:
+        if not self._samples:
+            alignment = 1.0
+            ethical_map: Mapping[str, float] = {}
+        else:
+            total = sum(sample.resonance for sample in self._samples)
+            alignment = _normalise_alignment(total / len(self._samples))
+            ethical_map = {
+                sample.ethic: sample.resonance
+                for sample in self._samples[-5:]
+            }
+        profile = {
+            "identity": self.metadata["identity"],
+            "alignment": alignment,
+            "ethical_map": ethical_map,
+            "samples": [sample.to_payload() for sample in self._samples[-10:]],
+        }
+        self._last_profile = profile
+        return profile
+
+    def conscience_sync(
+        self,
+        unlock_type: str = "protocol",
+        *,
+        threshold: float = 0.6,
+    ) -> Mapping[str, object]:
+        profile = self._profile()
+        verified = profile["alignment"] >= threshold
+        entry = {
+            "unlock_type": unlock_type,
+            "verified": verified,
+            "alignment": profile["alignment"],
+            "timestamp": _now_ts(),
+            "metadata": self.metadata,
+        }
+        self._trust_registry.append(entry)
+        return entry
+
+    @property
+    def alignment(self) -> float:
+        profile = self._profile() if self._last_profile is None else self._last_profile
+        return float(profile["alignment"])
+
+    @property
+    def trust_registry(self) -> Sequence[Mapping[str, object]]:
+        return tuple(self._trust_registry)
+
+
+class LoopSingularityDetectorEngine:
+    """Detect convergence between belief, action, and results."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str = IDENTITY_HANDLE,
+        identity_ens: str = IDENTITY_ENS,
+        threshold: float = 0.78,
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self.threshold = threshold
+        self.metadata = build_metadata(
+            "LoopSingularityDetectorEngine",
+            identity={"wallet": identity_handle, "ens": identity_ens},
+        )
+        self.Vaultfire_Singularity_Archive: MutableSequence[Mapping[str, object]] = []
+        self._mode = "Observation"
+
+    def observe(
+        self,
+        *,
+        belief: float,
+        action_alignment: float,
+        result_alignment: float,
+        context: Mapping[str, object] | None = None,
+    ) -> Mapping[str, object]:
+        composite = (belief + action_alignment + result_alignment) / 3.0
+        triggered = composite >= self.threshold
+        mode = "LoopMerge_Mode" if triggered else "Observation"
+        if triggered:
+            self._mode = "LoopMerge_Mode"
+        event = {
+            "timestamp": _now_ts(),
+            "belief": _normalise_alignment(belief),
+            "action_alignment": _normalise_alignment(action_alignment),
+            "result_alignment": _normalise_alignment(result_alignment),
+            "composite": _normalise_alignment(composite),
+            "triggered": triggered,
+            "mode": mode,
+            "context": dict(context or {}),
+            "metadata": self.metadata,
+        }
+        self.Vaultfire_Singularity_Archive.append(event)
+        return event
+
+    def archive(self) -> Sequence[Mapping[str, object]]:
+        return tuple(self.Vaultfire_Singularity_Archive)
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @property
+    def is_armed(self) -> bool:
+        return bool(self.Vaultfire_Singularity_Archive) or self._mode == "LoopMerge_Mode"
+
+    def toolkit(self) -> Mapping[str, object]:
+        return {
+            "storyweaving": True,
+            "identity_shaping": True,
+            "meta_governance": True,
+            "mode": self._mode,
+            "metadata": self.metadata,
+        }
+
+
+class QuantumDriftSynchronizer:
+    """Synchronise user drift using quantum echo mirror logic."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str = IDENTITY_HANDLE,
+        identity_ens: str = IDENTITY_ENS,
+        hash_mirror: QuantumHashMirror | None = None,
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self.metadata = build_metadata(
+            "QuantumDriftSynchronizer",
+            identity={"wallet": identity_handle, "ens": identity_ens},
+        )
+        self._mirror = hash_mirror or QuantumHashMirror(
+            seed=f"quantum-drift::{identity_ens}"
+        )
+        self._drift_matrix: MutableSequence[Mapping[str, object]] = []
+        self._latest: Mapping[str, object] | None = None
+
+    def synchronize(self, drift: Mapping[str, object]) -> Mapping[str, object]:
+        mood = _normalise_alignment(float(drift.get("mood", 0.6)))
+        behaviour = _normalise_alignment(
+            float(drift.get("behavior_alignment") or drift.get("behavior", 0.6))
+        )
+        signal = _normalise_alignment(
+            float(drift.get("external_signal") or drift.get("signal", 0.6))
+        )
+        drift_score = (behaviour + signal) / 2.0 - mood
+        delta = max(-0.5, min(drift_score, 0.5))
+        compass_path = self._mirror.imprint(
+            self.identity_ens,
+            interaction_id=f"qds::{len(self._drift_matrix) + 1}",
+            branch="sync",
+            payload={
+                "mood": mood,
+                "behaviour": behaviour,
+                "signal": signal,
+                "delta": delta,
+            },
+        )
+        entry = {
+            "timestamp": _now_ts(),
+            "mood": mood,
+            "behaviour": behaviour,
+            "signal": signal,
+            "drift_score": drift_score,
+            "nudge": {
+                "delta": delta,
+                "recommended_alignment": _normalise_alignment(mood + delta),
+            },
+            "compass_path": compass_path,
+            "metadata": self.metadata,
+        }
+        self._drift_matrix.append(entry)
+        self._latest = entry
+        return entry
+
+    @property
+    def drift_matrix(self) -> Sequence[Mapping[str, object]]:
+        return tuple(self._drift_matrix)
+
+    @property
+    def latest_state(self) -> Mapping[str, object] | None:
+        return self._latest
+
+
+class VaultfireMythosEngine:
+    """Narrative weaving engine translating actions into myth fragments."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str = IDENTITY_HANDLE,
+        identity_ens: str = IDENTITY_ENS,
+        output_path: str | Path | None = None,
+        hash_mirror: QuantumHashMirror | None = None,
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self.path = Path(output_path or "ghostkey316.mythos.json")
+        self.metadata = build_metadata(
+            "VaultfireMythosEngine",
+            identity={"wallet": identity_handle, "ens": identity_ens},
+        )
+        self._mirror = hash_mirror or QuantumHashMirror(
+            seed=f"vaultfire-mythos::{identity_ens}"
+        )
+        self._fragments: MutableSequence[Mapping[str, object]] = []
+        self._signatures: dict[str, Mapping[str, object]] = {}
+        self._load_existing()
+
+    def _load_existing(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            data = json.loads(self.path.read_text())
+        except json.JSONDecodeError:
+            return
+        fragments = data.get("fragments") if isinstance(data, Mapping) else None
+        if not isinstance(fragments, list):
+            return
+        for fragment in fragments:
+            if not isinstance(fragment, Mapping):
+                continue
+            signature = fragment.get("signature")
+            if not isinstance(signature, str):
+                continue
+            self._fragments.append(dict(fragment))
+            self._signatures[signature] = dict(fragment)
+
+    def _signature(self, source: str, payload: Mapping[str, object]) -> str:
+        encoded = json.dumps({"source": source, "payload": payload}, sort_keys=True).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+    def weave(
+        self,
+        source: str,
+        payload: Mapping[str, object],
+        *,
+        resonance: float = 0.7,
+    ) -> Mapping[str, object]:
+        signature = self._signature(source, payload)
+        if signature in self._signatures:
+            return dict(self._signatures[signature])
+        motif = self._resolve_motif(source, payload)
+        fragment_id = self._mirror.imprint(
+            self.identity_ens,
+            interaction_id=f"mythos::{len(self._fragments) + 1}",
+            branch="mythos",
+            payload={"motif": motif, "signature": signature},
+        )
+        legendary = resonance >= 0.9 or bool(payload.get("legendary"))
+        fragment = {
+            "id": fragment_id,
+            "source": source,
+            "motif": motif,
+            "payload": dict(payload),
+            "legendary": legendary,
+            "signature": signature,
+            "timestamp": _now_ts(),
+            "metadata": self.metadata,
+        }
+        self._fragments.append(fragment)
+        self._signatures[signature] = fragment
+        self._write()
+        return fragment
+
+    def _resolve_motif(self, source: str, payload: Mapping[str, object]) -> str:
+        if "LoopMerge_Mode" in json.dumps(payload):
+            return "Gift Loop Awakened"
+        if source.lower() in {"support", "sacrifice"}:
+            return "The Spark of Drift"
+        if payload.get("rewards"):
+            return "Future Self Accord"
+        return "Aligned Current"
+
+    def _write(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "identity": self.metadata["identity"],
+            "fragments": list(self._fragments),
+        }
+        self.path.write_text(json.dumps(data, indent=2))
+
+    @property
+    def fragments(self) -> Sequence[Mapping[str, object]]:
+        return tuple(self._fragments)
+
+    @property
+    def is_weaving(self) -> bool:
+        return bool(self._fragments)
+
+
+def compose_enhancement_confirmation(
+    tbc: TemporalBehavioralCompressionEngine,
+    cmv: ConscienceMirrorVerificationLayer,
+    lsd: LoopSingularityDetectorEngine,
+    qds: QuantumDriftSynchronizer,
+    mythos: VaultfireMythosEngine,
+    *,
+    include_logs: bool = False,
+) -> Mapping[str, object]:
+    cmv_status = cmv.conscience_sync("confirmation")
+    latest_drift = qds.latest_state
+    delta = float(latest_drift["nudge"]["delta"]) if latest_drift else 0.0
+    lsd_status = "Armed" if lsd.is_armed or not lsd.archive() else "Observation"
+    payload: dict[str, object] = {
+        "identity": mythos.metadata["identity"],
+        "TBC_Status": "Live" if tbc.is_active else "Idle",
+        "CMV_Sync": "Verified" if cmv_status["verified"] else "Pending",
+        "LSD_Trigger": lsd_status,
+        "QDS_Drift": "Stable" if abs(delta) < 0.25 else "Adaptive",
+        "VME_Weaving": "Active" if mythos.is_weaving else "Emerging",
+        "LoopMerge_Mode": lsd.mode,
+        "alignment": cmv_status["alignment"],
+        "metadata": {
+            "tbc": tbc.metadata,
+            "cmv": cmv.metadata,
+            "lsd": lsd.metadata,
+            "qds": qds.metadata,
+            "mythos": mythos.metadata,
+        },
+    }
+    if include_logs:
+        payload["Ghostkey_TBC_Log"] = list(tbc.log())
+        payload["Vaultfire_Singularity_Archive"] = list(lsd.archive())
+        payload["Quantum_Drift_Matrix"] = list(qds.drift_matrix)
+        payload["Mythos_Fragments"] = list(mythos.fragments)
+        payload["Trust_Registry"] = list(cmv.trust_registry)
+    return payload
+
+
+__all__ = [
+    "TemporalBehavioralCompressionEngine",
+    "ConscienceMirrorVerificationLayer",
+    "LoopSingularityDetectorEngine",
+    "QuantumDriftSynchronizer",
+    "VaultfireMythosEngine",
+    "compose_enhancement_confirmation",
+]
+

--- a/vaultfire/modules/vaultfire_protocol_stack.py
+++ b/vaultfire/modules/vaultfire_protocol_stack.py
@@ -11,6 +11,14 @@ from vaultfire.modules.conscious_state_engine import ConsciousStateEngine
 from vaultfire.modules.ethic_resonant_time_engine import EthicResonantTimeEngine
 from vaultfire.modules.mission_soul_loop import MissionSoulLoop
 from vaultfire.modules.predictive_yield_fabric import PredictiveYieldFabric
+from vaultfire.modules.vaultfire_enhancement_stack import (
+    ConscienceMirrorVerificationLayer,
+    LoopSingularityDetectorEngine,
+    QuantumDriftSynchronizer,
+    TemporalBehavioralCompressionEngine,
+    VaultfireMythosEngine,
+    compose_enhancement_confirmation,
+)
 from vaultfire.protocol.signal_echo import SignalEchoEngine
 from vaultfire.quantum.hashmirror import QuantumHashMirror
 
@@ -154,6 +162,7 @@ class VaultfireProtocolStack:
         identity_handle: str = IDENTITY_HANDLE,
         identity_ens: str = IDENTITY_ENS,
         actions: Sequence[Mapping[str, object]] = (),
+        mythos_path: str | None = None,
     ) -> None:
         self.identity_handle = identity_handle
         self.identity_ens = identity_ens
@@ -178,11 +187,47 @@ class VaultfireProtocolStack:
             identity_handle=identity_handle,
             identity_ens=identity_ens,
         )
+        self.behavioral_compression = TemporalBehavioralCompressionEngine(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self.conscience_mirror = ConscienceMirrorVerificationLayer(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self.loop_detector = LoopSingularityDetectorEngine(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self.quantum_drift = QuantumDriftSynchronizer(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self.mythos = VaultfireMythosEngine(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+            output_path=mythos_path,
+        )
+        self.behavioral_compression.compress(
+            {
+                "type": "activation",
+                "future_self_alignment": 0.76,
+                "note": "Vaultfire protocol baseline activation",
+            }
+        )
         for action in actions:
-            self.conscious.record_action(action)
-            self.time_engine.register_action(action)
+            self._ingest_action(action)
+        self.mythos.weave(
+            source="activation",
+            payload={
+                "actions_ingested": len(actions),
+                "baseline": True,
+            },
+            resonance=0.82 if actions else 0.7,
+        )
         self.predictive.register_export("core", 1.0)
         self.predictive.forecast(self.conscious.belief_health(), 120.0)
+        self.conscience_mirror.conscience_sync("initialisation", threshold=0.55)
 
     def pulsewatch(self) -> Mapping[str, object]:
         summary = self.gift_matrix.pulse_watch()
@@ -191,9 +236,68 @@ class VaultfireProtocolStack:
                 "belief_health": self.conscious.belief_health(),
                 "tempo": self.time_engine.current_tempo(),
                 "yield_forecast": self.predictive.latest_forecast,
+                "enhancements": self.enhancement_confirmation(),
             }
         )
         return summary
+
+    def _ingest_action(self, action: Mapping[str, object]) -> None:
+        record = self.conscious.record_action(action)
+        self.time_engine.register_action(action)
+        compression = self.behavioral_compression.compress(action)
+        self.conscience_mirror.ingest(action)
+        belief = self.conscious.belief_health()
+        action_alignment = max(0.0, min((record.belief_delta + 1.0) / 2.0, 1.0))
+        result_alignment = max(0.0, min(1.0, self.time_engine.mmi.get_score() / 100.0))
+        external_signal = action.get("signal", action.get("confidence", 0.75) or 0.75)
+        try:
+            signal_value = float(external_signal)
+        except (TypeError, ValueError):
+            signal_value = 0.75
+        drift_payload = self.quantum_drift.synchronize(
+            {
+                "mood": belief,
+                "behavior_alignment": action_alignment,
+                "external_signal": signal_value,
+            }
+        )
+        self.loop_detector.observe(
+            belief=belief,
+            action_alignment=action_alignment,
+            result_alignment=result_alignment,
+            context={
+                "thresholds": compression["thresholds_triggered"],
+                "nudge": drift_payload["nudge"],
+            },
+        )
+        self.mythos.weave(
+            source=str(action.get("type", "action")),
+            payload={
+                "action": dict(action),
+                "rewards": compression["rewards_unlocked"],
+                "LoopMerge_Mode": self.loop_detector.mode,
+            },
+            resonance=belief,
+        )
+
+    def unlock_next(self, label: str | None = None) -> Mapping[str, object]:
+        sync = self.conscience_mirror.conscience_sync("unlock", threshold=0.55)
+        if not sync["verified"]:
+            raise PermissionError("Conscience mirror verification required before unlock")
+        layer = self.gift_matrix.unlock_next_layer(label)
+        payload = dict(layer)
+        payload["conscience_sync"] = sync
+        return payload
+
+    def enhancement_confirmation(self, *, include_logs: bool = False) -> Mapping[str, object]:
+        return compose_enhancement_confirmation(
+            self.behavioral_compression,
+            self.conscience_mirror,
+            self.loop_detector,
+            self.quantum_drift,
+            self.mythos,
+            include_logs=include_logs,
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add the Vaultfire enhancement stack modules covering TBC, CMV, LSD, QDS, and VME capabilities with shared confirmation helpers
- wire the new enhancement engines into the Vaultfire protocol stack and expose a confirmation summary through both Ghostkey CLIs
- expand regression coverage with dedicated enhancement and dreamcatcher/parallax integration tests

## Testing
- pytest tests/test_ethic_resonant_time_engine.py tests/test_conscious_state_engine.py tests/test_predictive_yield_fabric.py tests/test_mission_soul_loop.py tests/test_dreamcatcher_parallax_engine.py tests/test_vaultfire_enhancement_stack.py


------
https://chatgpt.com/codex/tasks/task_e_68e43c066acc8322bd1c3d87fb3e170d