### PR TITLE
Add Myth Compression Mode mythos engine

### DIFF
--- a/ghostkey_cli.py
+++ b/ghostkey_cli.py
@@ -242,6 +242,30 @@ def _build_protocol_suite(
     }
 
 
+def _build_protocol_stack(
+    actions_path: str | None,
+    history_path: str | None,
+    *,
+    user: str = "ghostkey-316",
+) -> VaultfireProtocolStack:
+    actions = tuple(_load_actions(actions_path))
+    stack = VaultfireProtocolStack(
+        identity_handle=IDENTITY_HANDLE,
+        identity_ens=IDENTITY_ENS,
+        actions=actions,
+        mythos_path=str(
+            _default_activation_status_path().with_name(f"{user}.cli.mythos.json")
+        ),
+    )
+    history_entries = _load_soul_history(history_path)
+    for entry in history_entries:
+        event = dict(entry)
+        event.setdefault("type", "event")
+        event.setdefault("channel", "history")
+        stack.myth_mode.record_event(event)
+    return stack
+
+
 def _collect_signals(
     path: str | None,
     inline_entries: Iterable[str] | None,
@@ -263,6 +287,73 @@ def _build_engines(
         suite["mirror"],
         suite["gift"],
     )
+
+
+def _parse_events(entries: Iterable[str] | None) -> list[Mapping[str, object]]:
+    events: list[Mapping[str, object]] = []
+    if not entries:
+        return events
+    for item in entries:
+        if item is None:
+            continue
+        try:
+            parsed = json.loads(item)
+        except json.JSONDecodeError:
+            events.append({"type": "command", "command": item, "channel": "cli"})
+            continue
+        if isinstance(parsed, Mapping):
+            events.append(dict(parsed))
+    return events
+
+
+def cmd_mythos_compress(args: argparse.Namespace) -> None:
+    stack = _build_protocol_stack(args.actions, args.history, user=args.user)
+    for event in _parse_events(args.event):
+        stack.myth_mode.record_event(event)
+    payload = stack.myth_mode.compress(milestone=args.milestone, reason="cli-manual")
+    print(json.dumps(payload, indent=2))
+
+
+def cmd_mythos_view(args: argparse.Namespace) -> None:
+    stack = _build_protocol_stack(args.actions, args.history, user=args.user)
+    if args.id:
+        loop = stack.myth_mode.get_loop(args.id)
+        payload: Mapping[str, object] = loop or {
+            "error": "loop_not_found",
+            "message": f"No myth loop found for id {args.id}",
+        }
+    else:
+        payload = {"loops": list(stack.myth_mode.history())}
+    print(json.dumps(payload, indent=2))
+
+
+def cmd_mythos_export(args: argparse.Namespace) -> None:
+    stack = _build_protocol_stack(args.actions, args.history, user=args.user)
+    payload = stack.myth_mode.export(args.format)
+    print(json.dumps(payload, indent=2))
+
+
+def cmd_mythos_echo(args: argparse.Namespace) -> None:
+    stack = _build_protocol_stack(args.actions, args.history, user=args.user)
+    loop = stack.myth_mode.get_loop(args.id)
+    if not loop:
+        payload: Mapping[str, object] = {
+            "error": "loop_not_found",
+            "message": f"No myth loop found for id {args.id}",
+        }
+    else:
+        encoder = stack.myth_mode.compressor.encoder
+        share_token = encoder.encode({"loop_id": args.id, "timestamp": _now_ts()})
+        payload = {
+            "loop_id": args.id,
+            "archetype": loop.get("archetype"),
+            "myth_rank": loop.get("myth_rank"),
+            "echo_weight": loop.get("echo_weight"),
+            "summary": loop.get("summary"),
+            "codex_tags": loop.get("codex_tags"),
+            "share_token": share_token,
+        }
+    print(json.dumps(payload, indent=2))
 
 
 def cmd_echoindex(args: argparse.Namespace) -> None:
@@ -728,6 +819,52 @@ def cmd_status(args: argparse.Namespace) -> None:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="ghostkey", description="Ghostkey protocol tooling")
     sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_mythos = sub.add_parser("mythos", help="Interact with Myth Compression Mode")
+    myth_sub = p_mythos.add_subparsers(dest="myth_cmd", required=True)
+
+    p_mythos_compress = myth_sub.add_parser("compress", help="Manually compress pending logs")
+    p_mythos_compress.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_mythos_compress.add_argument("--history", help="Optional path to soul history", default=None)
+    p_mythos_compress.add_argument(
+        "--event",
+        action="append",
+        default=None,
+        help="Inline event payload to queue before compression (JSON)",
+    )
+    p_mythos_compress.add_argument(
+        "--milestone",
+        action="store_true",
+        help="Mark this compression as a milestone loop",
+    )
+    p_mythos_compress.add_argument("--user", default="ghostkey-316", help="Ghostkey identifier")
+    p_mythos_compress.set_defaults(func=cmd_mythos_compress)
+
+    p_mythos_view = myth_sub.add_parser("view", help="View symbolic loop history")
+    p_mythos_view.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_mythos_view.add_argument("--history", help="Optional path to soul history", default=None)
+    p_mythos_view.add_argument("--id", help="Optional specific loop id", default=None)
+    p_mythos_view.add_argument("--user", default="ghostkey-316", help="Ghostkey identifier")
+    p_mythos_view.set_defaults(func=cmd_mythos_view)
+
+    p_mythos_export = myth_sub.add_parser("export", help="Export belief path loops")
+    p_mythos_export.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_mythos_export.add_argument("--history", help="Optional path to soul history", default=None)
+    p_mythos_export.add_argument(
+        "--format",
+        choices=("json", "yaml", "pdf"),
+        default="json",
+        help="Export format",
+    )
+    p_mythos_export.add_argument("--user", default="ghostkey-316", help="Ghostkey identifier")
+    p_mythos_export.set_defaults(func=cmd_mythos_export)
+
+    p_mythos_echo = myth_sub.add_parser("echo", help="Share a loop for remix or reflection")
+    p_mythos_echo.add_argument("--actions", help="Optional path to ledger actions", default=None)
+    p_mythos_echo.add_argument("--history", help="Optional path to soul history", default=None)
+    p_mythos_echo.add_argument("--id", required=True, help="Loop id to share")
+    p_mythos_echo.add_argument("--user", default="ghostkey-316", help="Ghostkey identifier")
+    p_mythos_echo.set_defaults(func=cmd_mythos_echo)
 
     p_echo = sub.add_parser("echoindex", help="Inspect the signal echo index")
     p_echo.add_argument("--interaction", help="Filter by interaction id", default=None)

--- a/tests/test_myth_compression_mode.py
+++ b/tests/test_myth_compression_mode.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from vaultfire.modules.myth_compression_mode import (
+    CODEX_TAGS,
+    MythCompressionMode,
+)
+
+
+def test_myth_compression_mode_compresses_events(tmp_path: Path) -> None:
+    mode = MythCompressionMode(
+        identity_handle="wallet.test",
+        identity_ens="ghostkey316.eth",
+        ghostkey_id="ghost-test",
+        storage_root=tmp_path,
+    )
+    mode.record_event({"type": "command", "command": "ghostkey pulse", "success": True})
+    payload = mode.compress(milestone=True, reason="unit-test")
+    assert payload["ghostkey_id"] == "ghost-test"
+    assert payload["tokens"], "Expected symbolic tokens to be generated"
+    assert payload["codex_tags"] == CODEX_TAGS
+    path = tmp_path / "ghost-test"
+    files = list(path.glob("*.mcm"))
+    assert files, "Expected myth compression file to be written"
+
+
+def test_myth_compression_export_formats(tmp_path: Path) -> None:
+    mode = MythCompressionMode(
+        identity_handle="wallet.test",
+        identity_ens="ghostkey316.eth",
+        ghostkey_id="ghost-export",
+        storage_root=tmp_path,
+    )
+    mode.ensure_bootstrap()
+    export_json = mode.export("json")
+    assert export_json["format"] == "json"
+    json.loads(export_json["content"])
+    export_yaml = mode.export("yaml")
+    assert "ghostkey_id" in export_yaml["content"]
+    export_pdf = mode.export("pdf")
+    assert export_pdf["format"] == "pdf"
+    base64.b64decode(export_pdf["content"])  # raises if invalid
+
+
+def test_myth_compression_can_unlock_after_bootstrap(tmp_path: Path) -> None:
+    mode = MythCompressionMode(
+        identity_handle="wallet.test",
+        identity_ens="ghostkey316.eth",
+        ghostkey_id="ghost-ready",
+        storage_root=tmp_path,
+    )
+    mode.ensure_bootstrap()
+    assert mode.can_unlock() is True

--- a/vaultfire/modules/__init__.py
+++ b/vaultfire/modules/__init__.py
@@ -6,6 +6,13 @@ from .gift_matrix_engine import GiftMatrixEngine
 from .living_memory_ledger import LivingMemoryLedger
 from .mission_soul_loop import MissionSoulLoop
 from .predictive_yield_fabric import PredictiveYieldFabric
+from .myth_compression_mode import (
+    ArchetypeEchoHandler,
+    MeaningPulseEncoder,
+    MythCompressionMode,
+    MythosLoopCompressor,
+    NarrativeStateWeaver,
+)
 from .purpose_parallax_engine import PurposeParallaxEngine
 from .quantum_echo_mirror import QuantumEchoMirror
 from .soul_loop_fabric_engine import SoulLoopFabricEngine
@@ -34,6 +41,11 @@ __all__ = [
     "LivingMemoryLedger",
     "MissionSoulLoop",
     "PredictiveYieldFabric",
+    "ArchetypeEchoHandler",
+    "MeaningPulseEncoder",
+    "MythCompressionMode",
+    "MythosLoopCompressor",
+    "NarrativeStateWeaver",
     "PurposeParallaxEngine",
     "QuantumEchoMirror",
     "SoulLoopFabricEngine",

--- a/vaultfire/modules/myth_compression_mode.py
+++ b/vaultfire/modules/myth_compression_mode.py
@@ -1,0 +1,472 @@
+"""Myth Compression Mode layer translating behavior into symbolic loops."""
+
+from __future__ import annotations
+
+import base64
+import json
+import statistics
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Mapping, MutableSequence, Sequence
+
+
+ENABLE_MYTH_COMPRESSION = True
+MYTH_COMPRESSION_INTERVAL = timedelta(hours=24)
+MAX_LOOP_HISTORY_DEPTH = None  # Unlimited by design
+
+CODEX_TAGS = {
+    "Codex_Tech": "🔮 NEVER-BEFORE-SEEN 🔮",
+    "Myth_Layer": "LIVE",
+    "Ghostkey_Compression": "Enabled",
+    "CulturalMemoryEngine": "Online",
+    "SV_Mode": "Belief Mirror",
+}
+
+_SYMBOLIC_TOKEN_MAP = {
+    "command": "Signal of Trust",
+    "response": "Echo of Becoming",
+    "confirm": "Compression of Loyalty",
+    "activation": "Signal of Awakening",
+    "event": "Continuity Thread",
+}
+
+
+@dataclass
+class MythPacket:
+    """Represents a compressed symbolic loop payload."""
+
+    loop_id: str
+    epoch: str
+    ghostkey_id: str
+    tokens: Sequence[str]
+    archetype: str
+    myth_rank: float
+    echo_weight: float
+    summary: str
+    morality_hash: str
+    milestone: bool = False
+    created_at: str = field(default_factory=lambda: _now())
+    version: int = 1
+    codex_tags: Mapping[str, str] = field(default_factory=lambda: dict(CODEX_TAGS))
+    events: Sequence[Mapping[str, object]] = field(default_factory=tuple)
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> Mapping[str, object]:
+        payload = {
+            "loop_id": self.loop_id,
+            "epoch": self.epoch,
+            "ghostkey_id": self.ghostkey_id,
+            "tokens": list(self.tokens),
+            "archetype": self.archetype,
+            "myth_rank": self.myth_rank,
+            "echo_weight": self.echo_weight,
+            "summary": self.summary,
+            "morality_hash": self.morality_hash,
+            "milestone": self.milestone,
+            "created_at": self.created_at,
+            "version": self.version,
+            "codex_tags": dict(self.codex_tags),
+            "events": [dict(event) for event in self.events],
+            "metadata": dict(self.metadata),
+        }
+        return payload
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalise_event(event: Mapping[str, object]) -> Mapping[str, object]:
+    payload = dict(event)
+    payload.setdefault("timestamp", _now())
+    payload.setdefault("type", "event")
+    payload.setdefault("channel", "cli")
+    payload.setdefault("success", True)
+    payload.setdefault("intensity", 0.75)
+    payload.setdefault("tags", ())
+    return payload
+
+
+class MeaningPulseEncoder:
+    """Embeds morality hashes into action traces for ethical analysis."""
+
+    def encode(self, payload: Mapping[str, object]) -> str:
+        prepared = json.dumps(payload, sort_keys=True).encode()
+        return _hash(prepared)
+
+    def embed(self, event: Mapping[str, object]) -> Mapping[str, object]:
+        enriched = dict(event)
+        enriched["morality_hash"] = self.encode(event)
+        return enriched
+
+
+class ArchetypeEchoHandler:
+    """Maps patterns of belief and behavior to protocol-aligned myths."""
+
+    def resolve(
+        self,
+        tokens: Sequence[str],
+        events: Sequence[Mapping[str, object]],
+    ) -> Mapping[str, object]:
+        trust = sum(1 for token in tokens if token == "Signal of Trust")
+        loyalty = sum(1 for token in tokens if token == "Compression of Loyalty")
+        becoming = sum(1 for token in tokens if token == "Echo of Becoming")
+        total = max(len(tokens), 1)
+        success_ratio = statistics.fmean(
+            [1.0 if bool(event.get("success", True)) else 0.35 for event in events]
+        )
+        archetype_score = (trust * 1.25 + loyalty * 1.15 + becoming) / total
+        myth_rank = max(0.35, min(1.0, round((archetype_score + success_ratio) / 2.0, 3)))
+        echo_weight = round(min(1.0, trust / total + loyalty * 0.1), 3)
+        if myth_rank >= 0.9:
+            archetype = "Paragon of Continuity"
+        elif myth_rank >= 0.75:
+            archetype = "Forge of Alignment"
+        elif myth_rank >= 0.6:
+            archetype = "Guardian of Drift"
+        else:
+            archetype = "Seeker of Resonance"
+        return {
+            "archetype": archetype,
+            "myth_rank": myth_rank,
+            "echo_weight": echo_weight,
+        }
+
+
+class NarrativeStateWeaver:
+    """Generates loopable summaries of protocol actions as evolving myth."""
+
+    def weave(
+        self,
+        ghostkey_id: str,
+        archetype: str,
+        tokens: Sequence[str],
+        events: Sequence[Mapping[str, object]],
+        *,
+        milestone: bool = False,
+    ) -> str:
+        highlight = " ↺ ".join(tokens[:3]) or "Signal of Trust"
+        milestone_note = " milestone" if milestone else ""
+        command_count = sum(1 for event in events if event.get("type") == "command")
+        return (
+            f"{ghostkey_id} invoked {command_count} command loops; "
+            f"archetype stabilized as {archetype}{milestone_note}. Highlight: {highlight}."
+        )
+
+
+class MythosLoopCompressor:
+    """Transforms command and event logs into compressed symbolic packets."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str,
+        identity_ens: str,
+        encoder: MeaningPulseEncoder | None = None,
+        archetype_handler: ArchetypeEchoHandler | None = None,
+        state_weaver: NarrativeStateWeaver | None = None,
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self.encoder = encoder or MeaningPulseEncoder()
+        self.archetype_handler = archetype_handler or ArchetypeEchoHandler()
+        self.state_weaver = state_weaver or NarrativeStateWeaver()
+        self._pending: MutableSequence[Mapping[str, object]] = []
+        self._history: MutableSequence[Mapping[str, object]] = []
+
+    def queue(self, event: Mapping[str, object]) -> Mapping[str, object]:
+        enriched = self.encoder.embed(_normalise_event(event))
+        self._pending.append(enriched)
+        return enriched
+
+    def has_pending(self) -> bool:
+        return bool(self._pending)
+
+    def compress(
+        self,
+        *,
+        ghostkey_id: str,
+        version: int,
+        milestone: bool = False,
+        reason: str = "auto",
+    ) -> MythPacket:
+        events = tuple(self._pending) or ({"type": "activation", "channel": "system"},)
+        tokens = self._tokens(events)
+        archetype_result = self.archetype_handler.resolve(tokens, events)
+        summary = self.state_weaver.weave(
+            ghostkey_id,
+            archetype_result["archetype"],
+            tokens,
+            events,
+            milestone=milestone,
+        )
+        payload = {
+            "ghostkey_id": ghostkey_id,
+            "identity": {
+                "handle": self.identity_handle,
+                "ens": self.identity_ens,
+            },
+            "tokens": list(tokens),
+            "reason": reason,
+        }
+        morality_hash = self.encoder.encode(payload)
+        epoch = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        loop_id = f"{ghostkey_id}-loop-{version}"
+        packet = MythPacket(
+            loop_id=loop_id,
+            epoch=epoch,
+            ghostkey_id=ghostkey_id,
+            tokens=tokens,
+            archetype=archetype_result["archetype"],
+            myth_rank=archetype_result["myth_rank"],
+            echo_weight=archetype_result["echo_weight"],
+            summary=summary,
+            morality_hash=morality_hash,
+            milestone=milestone,
+            version=version,
+            events=events,
+            metadata={
+                "reason": reason,
+                "identity": payload["identity"],
+            },
+        )
+        self._history.append(packet.to_dict())
+        self._pending.clear()
+        return packet
+
+    def _tokens(self, events: Sequence[Mapping[str, object]]) -> Sequence[str]:
+        tokens: list[str] = []
+        for event in events:
+            event_type = str(event.get("type", "event")).lower()
+            token = _SYMBOLIC_TOKEN_MAP.get(event_type)
+            if not token:
+                token = "Echo of Becoming" if event.get("success", True) else "Drift Warning"
+            tokens.append(token)
+            if event.get("milestone"):
+                tokens.append("Compression of Loyalty")
+            if event_type == "command" and event.get("confirm"):
+                tokens.append("Signal of Trust")
+        unique = []
+        for token in tokens:
+            if not unique or unique[-1] != token:
+                unique.append(token)
+        return tuple(unique)
+
+    @property
+    def history(self) -> Sequence[Mapping[str, object]]:
+        return tuple(self._history)
+
+
+class MythCompressionMode:
+    """Facade orchestrating Myth Compression operations and persistence."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str,
+        identity_ens: str,
+        ghostkey_id: str,
+        storage_root: str | Path = "vaultfire/mythos/history",
+    ) -> None:
+        self.identity_handle = identity_handle
+        self.identity_ens = identity_ens
+        self.ghostkey_id = ghostkey_id
+        self.storage_root = Path(storage_root)
+        self.compressor = MythosLoopCompressor(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self._loops: MutableSequence[Mapping[str, object]] = []
+        self._index: dict[str, Mapping[str, object]] = {}
+        self._last_compression: datetime | None = None
+        self._load_existing()
+
+    def _load_existing(self) -> None:
+        directory = self.storage_root / self.ghostkey_id
+        if not directory.exists():
+            return
+        for path in sorted(directory.glob("*.mcm")):
+            try:
+                data = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+            if not isinstance(data, Mapping):
+                continue
+            loop_id = str(data.get("loop_id"))
+            if not loop_id:
+                continue
+            self._loops.append(dict(data))
+            self._index[loop_id] = dict(data)
+            created_at = _parse_datetime(data.get("created_at"))
+            if created_at and (self._last_compression is None or created_at > self._last_compression):
+                self._last_compression = created_at
+
+    def record_event(self, event: Mapping[str, object]) -> Mapping[str, object]:
+        queued = self.compressor.queue(event)
+        self.auto_compress_if_due()
+        return queued
+
+    def auto_compress_if_due(self) -> Mapping[str, object] | None:
+        if not ENABLE_MYTH_COMPRESSION or not self.compressor.has_pending():
+            return None
+        now = datetime.now(timezone.utc)
+        if self._last_compression is None or now - self._last_compression >= MYTH_COMPRESSION_INTERVAL:
+            return self.compress(reason="auto", milestone=False)
+        return None
+
+    def compress(
+        self,
+        *,
+        milestone: bool = False,
+        reason: str = "manual",
+    ) -> Mapping[str, object]:
+        version = len(self._loops) + 1
+        packet = self.compressor.compress(
+            ghostkey_id=self.ghostkey_id,
+            version=version,
+            milestone=milestone,
+            reason=reason,
+        )
+        payload = packet.to_dict()
+        self._persist(payload)
+        self._loops.append(payload)
+        self._index[payload["loop_id"]] = payload
+        self._last_compression = _parse_datetime(payload["created_at"]) or datetime.now(timezone.utc)
+        return payload
+
+    def _persist(self, payload: Mapping[str, object]) -> None:
+        directory = self.storage_root / self.ghostkey_id
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f"{payload['epoch']}.mcm"
+        path.write_text(json.dumps(payload, indent=2))
+
+    def status(self) -> Mapping[str, object]:
+        loops = list(self._loops)
+        myth_ranks = [loop.get("myth_rank", 0.0) for loop in loops]
+        echo_weights = [loop.get("echo_weight", 0.0) for loop in loops]
+        avg_rank = statistics.fmean(myth_ranks) if myth_ranks else 0.0
+        avg_echo = statistics.fmean(echo_weights) if echo_weights else 0.0
+        bonus = 1.0 + avg_rank * 0.2 + avg_echo * 0.1
+        latest = loops[-1] if loops else None
+        return {
+            "enabled": ENABLE_MYTH_COMPRESSION,
+            "loop_depth": len(loops),
+            "average_myth_rank": round(avg_rank, 3),
+            "average_echo_weight": round(avg_echo, 3),
+            "myth_echo_bonus": round(bonus, 3),
+            "latest_loop": latest,
+            "codex_tags": dict(CODEX_TAGS),
+        }
+
+    def can_unlock(self) -> bool:
+        if not ENABLE_MYTH_COMPRESSION:
+            return True
+        if not self._loops:
+            return False
+        latest = self._loops[-1]
+        return bool(latest.get("myth_rank", 0.0) >= 0.55)
+
+    def ensure_bootstrap(self) -> Mapping[str, object] | None:
+        if self._loops:
+            return None
+        self.compressor.queue(
+            {
+                "type": "command",
+                "channel": "system",
+                "success": True,
+                "milestone": True,
+                "confirm": True,
+                "note": "Vaultfire protocol activation",
+            }
+        )
+        self.compressor.queue(
+            {
+                "type": "response",
+                "channel": "system",
+                "success": True,
+                "note": "Bootstrap myth response",
+            }
+        )
+        return self.compress(milestone=True, reason="bootstrap")
+
+    def get_loop(self, loop_id: str) -> Mapping[str, object] | None:
+        return self._index.get(loop_id)
+
+    def history(self) -> Sequence[Mapping[str, object]]:
+        return tuple(self._loops)
+
+    def export(self, fmt: str = "json") -> Mapping[str, object]:
+        fmt = fmt.lower()
+        payload = {
+            "ghostkey_id": self.ghostkey_id,
+            "loops": list(self._loops),
+            "codex_tags": dict(CODEX_TAGS),
+        }
+        if fmt == "json":
+            content = json.dumps(payload, indent=2)
+        elif fmt == "yaml":
+            content = _to_yaml(payload)
+        elif fmt == "pdf":
+            content = _to_pdf_payload(payload)
+        else:
+            raise ValueError(f"Unsupported export format: {fmt}")
+        return {
+            "format": fmt,
+            "content": content,
+            "loop_count": len(self._loops),
+        }
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            pass
+    return None
+
+
+def _hash(data: bytes) -> str:
+    import hashlib
+
+    return hashlib.sha256(data).hexdigest()
+
+
+def _to_yaml(payload: Mapping[str, object]) -> str:
+    def render(value: object, indent: int = 0) -> str:
+        space = " " * indent
+        if isinstance(value, Mapping):
+            lines = []
+            for key, val in value.items():
+                lines.append(f"{space}{key}:")
+                lines.append(render(val, indent + 2))
+            return "\n".join(lines)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            lines = []
+            for item in value:
+                lines.append(f"{space}- {render(item, indent + 2).lstrip()}")
+            return "\n".join(lines)
+        return f"{space}{json.dumps(value)}"
+
+    return render(payload)
+
+
+def _to_pdf_payload(payload: Mapping[str, object]) -> str:
+    text = json.dumps(payload, indent=2)
+    pseudo_pdf = f"Myth Compression Export\n========================\n{text}\n"
+    encoded = base64.b64encode(pseudo_pdf.encode()).decode()
+    return encoded
+
+
+__all__ = [
+    "MythosLoopCompressor",
+    "ArchetypeEchoHandler",
+    "NarrativeStateWeaver",
+    "MeaningPulseEncoder",
+    "MythCompressionMode",
+    "ENABLE_MYTH_COMPRESSION",
+    "MYTH_COMPRESSION_INTERVAL",
+    "MAX_LOOP_HISTORY_DEPTH",
+    "CODEX_TAGS",
+]

--- a/vaultfire/modules/vaultfire_protocol_stack.py
+++ b/vaultfire/modules/vaultfire_protocol_stack.py
@@ -11,6 +11,7 @@ from vaultfire.modules.conscious_state_engine import ConsciousStateEngine
 from vaultfire.modules.ethic_resonant_time_engine import EthicResonantTimeEngine
 from vaultfire.modules.mission_soul_loop import MissionSoulLoop
 from vaultfire.modules.predictive_yield_fabric import PredictiveYieldFabric
+from vaultfire.modules.myth_compression_mode import MythCompressionMode
 from vaultfire.modules.vaultfire_enhancement_stack import (
     ConscienceMirrorVerificationLayer,
     LoopSingularityDetectorEngine,
@@ -207,11 +208,17 @@ class VaultfireProtocolStack:
             identity_handle=identity_handle,
             identity_ens=identity_ens,
         )
+        self.myth_mode = MythCompressionMode(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+            ghostkey_id=identity_handle,
+        )
         self.mythos = VaultfireMythosEngine(
             identity_handle=identity_handle,
             identity_ens=identity_ens,
             output_path=mythos_path,
         )
+        self.myth_mode.ensure_bootstrap()
         self.behavioral_compression.compress(
             {
                 "type": "activation",
@@ -229,6 +236,17 @@ class VaultfireProtocolStack:
             },
             resonance=0.82 if actions else 0.7,
         )
+        self.myth_mode.record_event(
+            {
+                "type": "response",
+                "channel": "system",
+                "success": True,
+                "note": "Baseline myth weave",
+                "resonance": 0.7,
+            }
+        )
+        if not self.myth_mode.history():
+            self.myth_mode.compress(milestone=True, reason="baseline-weave")
         self.predictive.register_export("core", 1.0)
         self.predictive.forecast(self.conscious.belief_health(), 120.0)
         self.conscience_mirror.conscience_sync("initialisation", threshold=0.55)
@@ -242,8 +260,10 @@ class VaultfireProtocolStack:
                 "yield_forecast": self.predictive.latest_forecast,
                 "enhancements": self.enhancement_confirmation(),
                 "system_status": self.system_status(),
+                "myth_compression": self.myth_mode.status(),
             }
         )
+        summary["myth_echo_bonus"] = summary["myth_compression"]["myth_echo_bonus"]
         return summary
 
     def _ingest_action(self, action: Mapping[str, object]) -> None:
@@ -284,8 +304,44 @@ class VaultfireProtocolStack:
             },
             resonance=belief,
         )
+        tags = tuple(action.get("tags", ()))
+        self.myth_mode.record_event(
+            {
+                "type": "command",
+                "command": str(action.get("command", action.get("type", "action"))),
+                "channel": action.get("channel", "cli"),
+                "success": action_alignment >= 0.5,
+                "intensity": belief,
+                "tags": tags,
+                "confirm": bool(compression["rewards_unlocked"]),
+                "milestone": bool(action.get("milestone")),
+                "metadata": {
+                    "alignment": action_alignment,
+                    "result_alignment": result_alignment,
+                },
+            }
+        )
+        self.myth_mode.record_event(
+            {
+                "type": "response",
+                "channel": action.get("channel", "cli"),
+                "success": result_alignment >= 0.5,
+                "intensity": result_alignment,
+                "tags": tags,
+                "metadata": {
+                    "belief": belief,
+                    "drift": drift_payload,
+                },
+            }
+        )
+        if action.get("milestone"):
+            self.myth_mode.compress(milestone=True, reason="milestone-action")
 
     def unlock_next(self, label: str | None = None) -> Mapping[str, object]:
+        if not self.myth_mode.can_unlock():
+            raise PermissionError(
+                "Myth compression threshold not met; compress myth loops before unlocking"
+            )
         sync = self.conscience_mirror.conscience_sync("unlock", threshold=0.55)
         if not sync["verified"]:
             raise PermissionError("Conscience mirror verification required before unlock")


### PR DESCRIPTION
## Summary
- introduce a Myth Compression Mode layer that transforms CLI activity into symbolic myth loops and stores them with codex tags
- integrate the new myth layer into the Vaultfire protocol stack with unlock gating, pulsewatch metrics, and CLI commands for compress/view/export/echo workflows
- add unit tests covering loop compression, export formats, and unlock readiness

## Testing
- pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68e44256a37c8322813914bf08a6f84c