### PR TITLE
Finalize Vaultfire v6.0 privacy and ethics integration

### DIFF
--- a/tests/enhancements/test_enhancement_confirm_composer.py
+++ b/tests/enhancements/test_enhancement_confirm_composer.py
@@ -1,0 +1,37 @@
+from vaultfire.core import (
+    ConscienceMirrorVerificationLayer,
+    EnhancementConfirmComposer,
+    LoopSingularityDetectorEngine,
+    QuantumDriftSynchronizer,
+    TemporalBehavioralCompressionEngine,
+    VaultfireMythosEngine,
+)
+
+
+def test_enhancement_confirm_composer_sync_and_compose(tmp_path):
+    EnhancementConfirmComposer.sync_with(["PulsewatchMetrics", "EthicsValidationHash"])
+    EnhancementConfirmComposer.annotate(environment="test-suite")
+
+    mythos_path = tmp_path / "mythos.json"
+    mythos = VaultfireMythosEngine(
+        identity_handle="test-handle",
+        identity_ens="test.eth",
+        output_path=str(mythos_path),
+    )
+
+    payload = EnhancementConfirmComposer.compose(
+        TemporalBehavioralCompressionEngine(identity_handle="test-handle", identity_ens="test.eth"),
+        ConscienceMirrorVerificationLayer(identity_handle="test-handle", identity_ens="test.eth"),
+        LoopSingularityDetectorEngine(identity_handle="test-handle", identity_ens="test.eth"),
+        QuantumDriftSynchronizer(identity_handle="test-handle", identity_ens="test.eth"),
+        mythos,
+        extra={"suite": "vaultfire-v6"},
+    )
+
+    sources = payload["confirmation_sources"]
+    assert sources["sources"] == ["PulsewatchMetrics", "EthicsValidationHash"]
+    assert sources["checksum"]
+    assert payload["suite"] == "vaultfire-v6"
+    status = EnhancementConfirmComposer.status()
+    assert status["sources"] == ["PulsewatchMetrics", "EthicsValidationHash"]
+    assert status["checksum"] == sources["checksum"]

--- a/tests/ethics/test_ethics_enforcement.py
+++ b/tests/ethics/test_ethics_enforcement.py
@@ -1,0 +1,21 @@
+from vaultfire.ethics import BehavioralEthicsMonitor, ConsentFirstMirror
+
+
+def test_behavioral_ethics_monitor_and_consent_first_mirror():
+    monitor = BehavioralEthicsMonitor(threshold=0.6)
+    positive = monitor.evaluate({"ethic": "aligned", "alignment": 0.9, "consent": True})
+    assert positive["trusted"]
+
+    negative = monitor.evaluate({"ethic": "betrayal", "alignment": 0.95, "consent": True})
+    assert not negative["trusted"]
+
+    mirror = ConsentFirstMirror(monitor)
+    verified = mirror.verify("user-1", consent=True, review=positive)
+    assert verified["verified"]
+
+    denied = mirror.verify("user-2", consent=False, alignment=0.9, ethic="aligned")
+    assert not denied["verified"]
+
+    lock = mirror.lock_report()
+    assert lock["verifications"]
+    assert not lock["all_verified"]

--- a/tests/legal_disclosure/test_disclosure_shield_trail_engine.py
+++ b/tests/legal_disclosure/test_disclosure_shield_trail_engine.py
@@ -1,0 +1,22 @@
+import pytest
+
+from vaultfire.legal import DisclosureShieldTrailEngine
+
+
+def test_disclosure_trail_engine_records_and_seals():
+    engine = DisclosureShieldTrailEngine()
+    entry = engine.record("ethics", {"status": "aligned", "consent": True})
+    assert entry["digest"]
+    assert entry["payload"]["status"] == "aligned"
+
+    export = engine.export()
+    assert len(export) == 1
+
+    engine.seal()
+    assert engine.sealed()
+    with pytest.raises(RuntimeError):
+        engine.record("ethics", {"status": "update"})
+
+    status = engine.status()
+    assert status["entries"] == 1
+    assert status["latest_digest"] == entry["digest"]

--- a/tests/mythos/test_protocol_integration_manifest.py
+++ b/tests/mythos/test_protocol_integration_manifest.py
@@ -1,0 +1,26 @@
+from vaultfire.core import (
+    EnhancementConfirmComposer,
+    GhostkeyCLI,
+    TemporalBehavioralCompressionEngine,
+    VaultfireProtocolStack,
+)
+
+
+def test_protocol_integration_manifest_and_architect(tmp_path):
+    GhostkeyCLI.reset()
+    EnhancementConfirmComposer.sync_with([])
+    manifest = VaultfireProtocolStack.integrate([TemporalBehavioralCompressionEngine])
+    assert manifest
+    assert manifest[0]["module"] == "TemporalBehavioralCompressionEngine"
+
+    stack = VaultfireProtocolStack(mythos_path=str(tmp_path / "mythos.json"))
+    modules = {entry["module"] for entry in stack.integration_manifest}
+    assert "TemporalBehavioralCompressionEngine" in modules
+
+    assignment = VaultfireProtocolStack.assign_architect("ghostkey316.eth")
+    assert assignment["architect"] == "ghostkey316.eth"
+    assert VaultfireProtocolStack.architect() == "ghostkey316.eth"
+    assert VaultfireProtocolStack.architect_history()
+
+    status = EnhancementConfirmComposer.status()
+    assert status["sources"] is not None

--- a/tests/privacy/test_privacy_integration.py
+++ b/tests/privacy/test_privacy_integration.py
@@ -1,0 +1,26 @@
+from vaultfire.core import GhostkeyCLI, VaultfireProtocolStack
+from vaultfire.privacy import (
+    ConsentGuardianLayer,
+    EchoAnonymizerEngine,
+    GhostkeyPrivacyHalo,
+    VaultTraceEraser,
+)
+
+
+def test_privacy_modules_are_integrated_and_cli_extended():
+    GhostkeyCLI.reset()
+    stack = VaultfireProtocolStack()
+
+    shield = stack.privacy_shield
+    assert isinstance(shield.guardian, ConsentGuardianLayer)
+    assert isinstance(shield.anonymizer, EchoAnonymizerEngine)
+    assert isinstance(shield.eraser, VaultTraceEraser)
+    assert isinstance(shield.halo, GhostkeyPrivacyHalo)
+
+    manifest_modules = {entry["module"] for entry in stack.integration_manifest}
+    assert {"ConsentGuardianLayer", "EchoAnonymizerEngine", "VaultTraceEraser", "GhostkeyPrivacyHalo"}.issubset(
+        manifest_modules
+    )
+
+    privacy_commands = stack.cli_manifest["categories"]["privacy"]
+    assert {"compress", "anonymize", "consent-verify"}.issubset(set(privacy_commands))

--- a/vaultfire/core/__init__.py
+++ b/vaultfire/core/__init__.py
@@ -17,6 +17,17 @@ from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
 
 from engine.proof_of_loyalty import record_belief_action
 from vaultfire.mission import LedgerMetadata, MissionLedger
+from vaultfire.core.cli import GhostkeyCLI
+from vaultfire.modules import (
+    ConscienceMirrorVerificationLayer,
+    EnhancementConfirmComposer,
+    LoopSingularityDetectorEngine,
+    MythCompressionMode,
+    QuantumDriftSynchronizer,
+    TemporalBehavioralCompressionEngine,
+    VaultfireMythosEngine,
+    VaultfireProtocolStack,
+)
 
 logger = logging.getLogger("vaultfire.core")
 
@@ -413,6 +424,7 @@ __all__ = [
     "CoreConfig",
     "PurposeStore",
     "VaultfireConfig",
+    "GhostkeyCLI",
     "cli_belief",
     "get_purpose_store",
     "get_recent_purpose_records",
@@ -421,4 +433,12 @@ __all__ = [
     "protocol_notify",
     "reset_vaultfire_state",
     "sync_purpose",
+    "VaultfireProtocolStack",
+    "EnhancementConfirmComposer",
+    "MythCompressionMode",
+    "TemporalBehavioralCompressionEngine",
+    "ConscienceMirrorVerificationLayer",
+    "LoopSingularityDetectorEngine",
+    "QuantumDriftSynchronizer",
+    "VaultfireMythosEngine",
 ]

--- a/vaultfire/core/cli.py
+++ b/vaultfire/core/cli.py
@@ -1,0 +1,66 @@
+"""Ghostkey CLI orchestration utilities."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Sequence
+
+__all__ = ["GhostkeyCLI"]
+
+
+def _now_ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class GhostkeyCLI:
+    """Registry for Ghostkey CLI subcommands and capabilities."""
+
+    _subcommands: MutableMapping[str, set[str]] = {}
+    _last_updated: str | None = None
+
+    @classmethod
+    def add_subcommands(cls, descriptors: Iterable[str]) -> Mapping[str, object]:
+        for descriptor in descriptors:
+            if descriptor is None:
+                continue
+            text = str(descriptor).strip()
+            if not text:
+                continue
+            head, *rest = text.split(maxsplit=1)
+            category = head.lower()
+            remainder = rest[0] if rest else ""
+            if "/" in remainder:
+                actions = [segment.strip() for segment in remainder.split("/") if segment.strip()]
+            elif remainder:
+                actions = [remainder.strip()]
+            else:
+                actions = [""]
+            bucket = cls._subcommands.setdefault(category, set())
+            for action in actions:
+                bucket.add(action)
+        cls._last_updated = _now_ts()
+        return cls.manifest()
+
+    @classmethod
+    def manifest(cls) -> Mapping[str, object]:
+        categories: Dict[str, Sequence[str]] = {}
+        commands: List[str] = []
+        for category, actions in cls._subcommands.items():
+            sorted_actions = sorted(actions)
+            categories[category] = sorted_actions
+            for action in sorted_actions:
+                command = f"{category} {action}".strip()
+                commands.append(command)
+        commands.sort()
+        return {
+            "commands": commands,
+            "categories": categories,
+            "updated_at": cls._last_updated,
+            "count": len(commands),
+        }
+
+    @classmethod
+    def reset(cls) -> None:
+        cls._subcommands.clear()
+        cls._last_updated = None
+

--- a/vaultfire/ethics/__init__.py
+++ b/vaultfire/ethics/__init__.py
@@ -1,0 +1,124 @@
+"""Human-AI ethics enforcement utilities for Vaultfire deployments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping, MutableSequence, Sequence
+
+__all__ = ["BehavioralEthicsMonitor", "ConsentFirstMirror"]
+
+
+def _now_ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _clamp(value: float, minimum: float = 0.0, maximum: float = 1.0) -> float:
+    return max(minimum, min(maximum, value))
+
+
+@dataclass
+class _EthicEvent:
+    timestamp: str
+    ethic: str
+    alignment_score: float
+    consent: bool
+    trusted: bool
+    metadata: Mapping[str, object]
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {
+            "timestamp": self.timestamp,
+            "ethic": self.ethic,
+            "alignment_score": self.alignment_score,
+            "consent": self.consent,
+            "trusted": self.trusted,
+            "metadata": dict(self.metadata),
+        }
+
+
+class BehavioralEthicsMonitor:
+    """Evaluates alignment signals against minimum ethical thresholds."""
+
+    NEGATIVE_ETHICS = {"betrayal", "selfish", "abuse", "drain"}
+
+    def __init__(self, *, threshold: float = 0.72) -> None:
+        self.threshold = _clamp(threshold)
+        self._events: MutableSequence[_EthicEvent] = []
+
+    def evaluate(self, payload: Mapping[str, object]) -> Mapping[str, object]:
+        ethic = str(payload.get("ethic", "aligned")).lower()
+        alignment = _clamp(float(payload.get("alignment", payload.get("belief", 0.0))))
+        consent = bool(payload.get("consent", True))
+        trusted = consent and alignment >= self.threshold and ethic not in self.NEGATIVE_ETHICS
+        event = _EthicEvent(
+            timestamp=_now_ts(),
+            ethic=ethic,
+            alignment_score=alignment,
+            consent=consent,
+            trusted=trusted,
+            metadata={
+                "source": payload.get("source", "action"),
+                "result_alignment": _clamp(float(payload.get("result_alignment", alignment))),
+            },
+        )
+        self._events.append(event)
+        return event.to_payload()
+
+    def history(self) -> Sequence[Mapping[str, object]]:
+        return tuple(event.to_payload() for event in self._events)
+
+    def status(self) -> Mapping[str, object]:
+        return {
+            "threshold": self.threshold,
+            "events_recorded": len(self._events),
+            "last_event": self._events[-1].to_payload() if self._events else None,
+        }
+
+
+class ConsentFirstMirror:
+    """Mirrors ethics decisions through a consent-first verification lens."""
+
+    def __init__(self, monitor: BehavioralEthicsMonitor | None = None) -> None:
+        self.monitor = monitor or BehavioralEthicsMonitor()
+        self._verifications: MutableSequence[Mapping[str, object]] = []
+
+    def verify(
+        self,
+        subject: str,
+        *,
+        consent: bool,
+        review: Mapping[str, object] | None = None,
+        alignment: float | None = None,
+        ethic: str | None = None,
+    ) -> Mapping[str, object]:
+        payload = dict(review) if review else {
+            "ethic": ethic or "aligned",
+            "alignment": alignment if alignment is not None else self.monitor.threshold,
+            "consent": consent,
+        }
+        if review is None:
+            payload = self.monitor.evaluate(payload)
+        verified = bool(consent and payload.get("trusted", False))
+        record = {
+            "subject": subject,
+            "verified": verified,
+            "ethic": payload.get("ethic", "aligned"),
+            "alignment_score": payload.get("alignment_score", payload.get("alignment", 0.0)),
+            "timestamp": _now_ts(),
+        }
+        self._verifications.append(record)
+        return dict(record)
+
+    def lock_report(self) -> Mapping[str, object]:
+        return {
+            "verifications": list(self._verifications),
+            "all_verified": all(item["verified"] for item in self._verifications) if self._verifications else False,
+        }
+
+    def status(self) -> Mapping[str, object]:
+        return {
+            "verifications_recorded": len(self._verifications),
+            "last_verification": self._verifications[-1] if self._verifications else None,
+        }
+

--- a/vaultfire/legal/__init__.py
+++ b/vaultfire/legal/__init__.py
@@ -1,0 +1,81 @@
+"""Legal disclosure utilities for Vaultfire v6.0 deployments."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping, MutableSequence, Sequence
+
+__all__ = ["DisclosureShieldTrailEngine"]
+
+
+def _now_ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _fingerprint(payload: Mapping[str, object]) -> str:
+    digest = hashlib.sha256()
+    digest.update(json.dumps(payload, sort_keys=True).encode("utf-8"))
+    return digest.hexdigest()
+
+
+@dataclass
+class _TrailEntry:
+    label: str
+    payload: Mapping[str, object]
+    recorded_at: str
+    digest: str
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {
+            "label": self.label,
+            "payload": dict(self.payload),
+            "recorded_at": self.recorded_at,
+            "digest": self.digest,
+        }
+
+
+class DisclosureShieldTrailEngine:
+    """Maintains a cryptographically anchored disclosure audit trail."""
+
+    def __init__(self) -> None:
+        self._trail: MutableSequence[_TrailEntry] = []
+        self._sealed = False
+
+    def record(self, label: str, payload: Mapping[str, object]) -> Mapping[str, object]:
+        if self._sealed:
+            raise RuntimeError("disclosure trail is sealed")
+        normalised = {key: payload[key] for key in payload}
+        entry = _TrailEntry(
+            label=str(label),
+            payload=normalised,
+            recorded_at=_now_ts(),
+            digest=_fingerprint({"label": label, **normalised}),
+        )
+        self._trail.append(entry)
+        return entry.to_payload()
+
+    def export(self) -> Sequence[Mapping[str, object]]:
+        return tuple(entry.to_payload() for entry in self._trail)
+
+    def seal(self) -> None:
+        self._sealed = True
+
+    def sealed(self) -> bool:
+        return self._sealed
+
+    def status(self) -> Mapping[str, object]:
+        return {
+            "entries": len(self._trail),
+            "sealed": self._sealed,
+            "latest_digest": self._trail[-1].digest if self._trail else None,
+        }
+
+    def summary(self) -> Mapping[str, object]:
+        return {
+            "trail": list(self.export()),
+            "status": self.status(),
+        }
+

--- a/vaultfire/modules/__init__.py
+++ b/vaultfire/modules/__init__.py
@@ -19,6 +19,7 @@ from .soul_loop_fabric_engine import SoulLoopFabricEngine
 from .temporal_dreamcatcher_engine import TemporalDreamcatcherEngine
 from .vaultfire_enhancement_stack import (
     ConscienceMirrorVerificationLayer,
+    EnhancementConfirmComposer,
     LoopSingularityDetectorEngine,
     QuantumDriftSynchronizer,
     TemporalBehavioralCompressionEngine,
@@ -52,6 +53,7 @@ __all__ = [
     "TemporalDreamcatcherEngine",
     "TemporalBehavioralCompressionEngine",
     "ConscienceMirrorVerificationLayer",
+    "EnhancementConfirmComposer",
     "LoopSingularityDetectorEngine",
     "QuantumDriftSynchronizer",
     "VaultfireMythosEngine",

--- a/vaultfire/modules/vaultfire_enhancement_stack.py
+++ b/vaultfire/modules/vaultfire_enhancement_stack.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 import hashlib
 import json
 from pathlib import Path
-from typing import Iterable, Mapping, MutableSequence, Sequence
+from typing import Iterable, Mapping, MutableMapping, MutableSequence, Sequence
 
 from vaultfire.quantum.hashmirror import QuantumHashMirror
 
@@ -475,6 +475,87 @@ class VaultfireMythosEngine:
         return bool(self._fragments)
 
 
+class EnhancementConfirmComposer:
+    """Orchestrates the final confirmation payload for enhancement unlocks."""
+
+    _synced_sources: tuple[str, ...] = ()
+    _synced_at: str | None = None
+    _sync_checksum: str | None = None
+    _annotations: MutableMapping[str, object] = {}
+
+    @classmethod
+    def sync_with(cls, sources: Iterable[str]) -> Mapping[str, object]:
+        """Register telemetry sources that participate in the confirmation."""
+
+        normalised: list[str] = []
+        seen: set[str] = set()
+        for source in sources:
+            label = str(source).strip()
+            if not label:
+                continue
+            if label in seen:
+                continue
+            seen.add(label)
+            normalised.append(label)
+        cls._synced_sources = tuple(normalised)
+        cls._synced_at = _now_ts()
+        digest = hashlib.sha256()
+        for label in cls._synced_sources:
+            digest.update(label.encode("utf-8"))
+        digest.update(cls._synced_at.encode("utf-8"))
+        cls._sync_checksum = digest.hexdigest()
+        cls._annotations = {
+            "sources": list(cls._synced_sources),
+            "synced_at": cls._synced_at,
+            "checksum": cls._sync_checksum,
+        }
+        return dict(cls._annotations)
+
+    @classmethod
+    def annotate(cls, **metadata: object) -> Mapping[str, object]:
+        """Attach additional metadata for downstream confirmations."""
+
+        if not cls._annotations:
+            cls.sync_with(())
+        cls._annotations.update({key: metadata[key] for key in metadata})
+        return dict(cls._annotations)
+
+    @classmethod
+    def compose(
+        cls,
+        tbc: TemporalBehavioralCompressionEngine,
+        cmv: ConscienceMirrorVerificationLayer,
+        lsd: LoopSingularityDetectorEngine,
+        qds: QuantumDriftSynchronizer,
+        mythos: VaultfireMythosEngine,
+        *,
+        include_logs: bool = False,
+        extra: Mapping[str, object] | None = None,
+    ) -> Mapping[str, object]:
+        base = compose_enhancement_confirmation(
+            tbc,
+            cmv,
+            lsd,
+            qds,
+            mythos,
+            include_logs=include_logs,
+        )
+        annotations = dict(cls._annotations) if cls._annotations else {}
+        if annotations:
+            base.setdefault("confirmation_sources", annotations)
+        if extra:
+            base.update({key: extra[key] for key in extra})
+        return base
+
+    @classmethod
+    def status(cls) -> Mapping[str, object]:
+        return {
+            "sources": list(cls._synced_sources),
+            "synced_at": cls._synced_at,
+            "checksum": cls._sync_checksum,
+        }
+
+
 def compose_enhancement_confirmation(
     tbc: TemporalBehavioralCompressionEngine,
     cmv: ConscienceMirrorVerificationLayer,
@@ -521,5 +602,6 @@ __all__ = [
     "QuantumDriftSynchronizer",
     "VaultfireMythosEngine",
     "compose_enhancement_confirmation",
+    "EnhancementConfirmComposer",
 ]
 

--- a/vaultfire/modules/vaultfire_protocol_stack.py
+++ b/vaultfire/modules/vaultfire_protocol_stack.py
@@ -14,15 +14,23 @@ from vaultfire.modules.predictive_yield_fabric import PredictiveYieldFabric
 from vaultfire.modules.myth_compression_mode import MythCompressionMode
 from vaultfire.modules.vaultfire_enhancement_stack import (
     ConscienceMirrorVerificationLayer,
+    EnhancementConfirmComposer,
     LoopSingularityDetectorEngine,
     QuantumDriftSynchronizer,
     TemporalBehavioralCompressionEngine,
     VaultfireMythosEngine,
-    compose_enhancement_confirmation,
 )
 from vaultfire.protocol.signal_echo import SignalEchoEngine
 from vaultfire.quantum.hashmirror import QuantumHashMirror
 from vaultfire.privacy_integrity import PrivacyIntegrityShield, get_privacy_shield
+from vaultfire.privacy import (
+    ConsentGuardianLayer,
+    EchoAnonymizerEngine,
+    GhostkeyPrivacyHalo,
+    VaultTraceEraser,
+)
+from vaultfire.legal import DisclosureShieldTrailEngine
+from vaultfire.ethics import BehavioralEthicsMonitor, ConsentFirstMirror
 
 _yield_module = import_module("vaultfire.yield")
 PulseSync = getattr(_yield_module, "PulseSync")
@@ -30,6 +38,14 @@ TemporalGiftMatrixEngine = getattr(_yield_module, "TemporalGiftMatrixEngine")
 
 IDENTITY_HANDLE = "bpow20.cb.id"
 IDENTITY_ENS = "ghostkey316.eth"
+
+_DEFAULT_CONFIRMATION_SOURCES = (
+    "PulsewatchMetrics",
+    "LoopCompressionLogs",
+    "AnonymizationProof",
+    "EthicsValidationHash",
+    "DisclosureAuditTrail",
+)
 
 
 def _now_ts() -> str:
@@ -188,6 +204,11 @@ class GiftMatrixV1:
 class VaultfireProtocolStack:
     """Convenience wrapper bundling the protocol systems."""
 
+    _architect_handle: str = IDENTITY_ENS
+    _architect_history: List[Mapping[str, object]] = [
+        {"architect": IDENTITY_ENS, "assigned_at": _now_ts()}
+    ]
+
     def __init__(
         self,
         *,
@@ -226,6 +247,7 @@ class VaultfireProtocolStack:
             identity_ens=identity_ens,
             privacy_shield=self.privacy_shield,
         )
+        self.privacy_shield.toggle_tracking(True)
         self.behavioral_compression = TemporalBehavioralCompressionEngine(
             identity_handle=identity_handle,
             identity_ens=identity_ens,
@@ -251,6 +273,37 @@ class VaultfireProtocolStack:
             identity_handle=identity_handle,
             identity_ens=identity_ens,
             output_path=mythos_path,
+        )
+        self.ethics_monitor = BehavioralEthicsMonitor()
+        self.consent_first_mirror = ConsentFirstMirror(self.ethics_monitor)
+        self.disclosure_trail = DisclosureShieldTrailEngine()
+        self.integration_manifest = self.integrate(
+            [
+                TemporalBehavioralCompressionEngine,
+                ConscienceMirrorVerificationLayer,
+                LoopSingularityDetectorEngine,
+                QuantumDriftSynchronizer,
+                VaultfireMythosEngine,
+                MythCompressionMode,
+                ConsentGuardianLayer,
+                EchoAnonymizerEngine,
+                VaultTraceEraser,
+                GhostkeyPrivacyHalo,
+                DisclosureShieldTrailEngine,
+                BehavioralEthicsMonitor,
+                ConsentFirstMirror,
+            ]
+        )
+        from vaultfire.core.cli import GhostkeyCLI
+
+        self.cli_manifest = GhostkeyCLI.add_subcommands(
+            [
+                "mythos compress/view/export/share",
+                "privacy compress/anonymize/consent-verify",
+                "audit trail export",
+                "ethics check/lock-report",
+                "unlock verify --ethics --consent",
+            ]
         )
         self.myth_mode.ensure_bootstrap()
         self.behavioral_compression.compress(
@@ -284,6 +337,7 @@ class VaultfireProtocolStack:
         self.predictive.register_export("core", 1.0)
         self.predictive.forecast(self.conscious.belief_health(), 120.0)
         self.conscience_mirror.conscience_sync("initialisation", threshold=0.55)
+        self.architect_ens = self.architect()
 
     def pulsewatch(self) -> Mapping[str, object]:
         summary = dict(self.gift_matrix.pulse_watch())
@@ -343,6 +397,20 @@ class VaultfireProtocolStack:
                 "external_signal": signal_value,
             }
         )
+        ethics_review = self.ethics_monitor.evaluate(
+            {
+                "ethic": action.get("ethic", action.get("intent", "aligned")),
+                "alignment": action_alignment,
+                "result_alignment": result_alignment,
+                "consent": bool(action.get("consent", True)),
+                "source": action.get("type", "action"),
+            }
+        )
+        consent_report = self.consent_first_mirror.verify(
+            str(action.get("actor", self.identity_handle)),
+            consent=bool(action.get("consent", True)),
+            review=ethics_review,
+        )
         self.loop_detector.observe(
             belief=belief,
             action_alignment=action_alignment,
@@ -350,6 +418,15 @@ class VaultfireProtocolStack:
             context={
                 "thresholds": compression["thresholds_triggered"],
                 "nudge": drift_payload["nudge"],
+            },
+        )
+        self.disclosure_trail.record(
+            "vaultfire.action",
+            {
+                "interaction": str(action.get("interaction_id", action.get("id", "unknown"))),
+                "ethic": ethics_review["ethic"],
+                "trusted": ethics_review["trusted"],
+                "consent_verified": consent_report["verified"],
             },
         )
         self.mythos.weave(
@@ -408,17 +485,23 @@ class VaultfireProtocolStack:
         return payload
 
     def enhancement_confirmation(self, *, include_logs: bool = False) -> Mapping[str, object]:
-        return compose_enhancement_confirmation(
+        extra = {
+            "ethics": self.ethics_monitor.status(),
+            "consent_mirror": self.consent_first_mirror.status(),
+            "disclosure_trail": self.disclosure_trail.status(),
+        }
+        return EnhancementConfirmComposer.compose(
             self.behavioral_compression,
             self.conscience_mirror,
             self.loop_detector,
             self.quantum_drift,
             self.mythos,
             include_logs=include_logs,
+            extra=extra,
         )
 
     def system_status(self) -> Mapping[str, object]:
-        return {
+        status = {
             "Codex_Status": "🔥 READY 🔥",
             "Ghostkey_CLI": "Activated & Trusted",
             "Engine_Stack": "Synced",
@@ -426,6 +509,44 @@ class VaultfireProtocolStack:
             "Telemetry": "CLI + enhancement unlock telemetry live",
             "metadata": self.metadata,
         }
+        status["Enhancement_Confirmation"] = EnhancementConfirmComposer.status()
+        status["Integration_Manifest"] = list(self.integration_manifest)
+        status["CLI_Manifest"] = self.cli_manifest
+        status["Architect"] = {"ens": self.architect_ens, "history": list(self.architect_history())}
+        return status
+
+    @classmethod
+    def integrate(cls, modules: Iterable[type]) -> Sequence[Mapping[str, object]]:
+        manifest = []
+        timestamp = _now_ts()
+        for module in modules:
+            label = getattr(module, "__name__", str(module))
+            manifest.append(
+                {
+                    "module": label,
+                    "namespace": getattr(module, "__module__", ""),
+                    "integrated_at": timestamp,
+                }
+            )
+        EnhancementConfirmComposer.sync_with(_DEFAULT_CONFIRMATION_SOURCES)
+        EnhancementConfirmComposer.annotate(integration_manifest=list(manifest))
+        return tuple(manifest)
+
+    @classmethod
+    def assign_architect(cls, ens: str) -> Mapping[str, object]:
+        entry = {"architect": str(ens), "assigned_at": _now_ts()}
+        cls._architect_handle = str(ens)
+        cls._architect_history.append(entry)
+        EnhancementConfirmComposer.annotate(architect=str(ens))
+        return dict(entry)
+
+    @classmethod
+    def architect(cls) -> str:
+        return cls._architect_handle
+
+    @classmethod
+    def architect_history(cls) -> Sequence[Mapping[str, object]]:
+        return tuple(cls._architect_history)
 
 
 # ---------------------------------------------------------------------------

--- a/vaultfire/privacy.py
+++ b/vaultfire/privacy.py
@@ -223,8 +223,29 @@ class _SecureSession:
         self._closed = True
 
 
+_INTEGRATION_EXPORTS = {
+    "ConsentGuardianLayer",
+    "EchoAnonymizerEngine",
+    "VaultTraceEraser",
+    "GhostkeyPrivacyHalo",
+    "PrivacyIntegrityShield",
+    "get_privacy_shield",
+}
+
+
+def __getattr__(name: str):  # pragma: no cover - exercised via import semantics
+    if name in _INTEGRATION_EXPORTS:
+        from vaultfire import privacy_integrity as _privacy_integrity
+
+        value = getattr(_privacy_integrity, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     "PrivacyError",
     "QuantumSecureCipherSuite",
     "StructuredCiphertext",
+    *_INTEGRATION_EXPORTS,
 ]


### PR DESCRIPTION
## Summary
- add legal, privacy, and ethics orchestration modules with CLI registration utilities
- extend VaultfireProtocolStack to record ethics, disclosure, and architect metadata while re-exporting v6.0 components
- introduce targeted pytest suites validating enhancement composer, privacy bridging, ethics monitor, legal trail, and integration manifest flows

## Testing
- pytest tests/enhancements tests/privacy tests/ethics tests/legal_disclosure tests/mythos

------
https://chatgpt.com/codex/tasks/task_e_68e46512a0fc8322b38dbdbb6924bcfa