### PR TITLE
Add adaptive consciousness loop and tests

### DIFF
--- a/tests/compassion/test_compassion_overdrive_layer.py
+++ b/tests/compassion/test_compassion_overdrive_layer.py
@@ -1,0 +1,18 @@
+from vaultfire.consciousness import CompassionOverdriveLayer
+
+
+def test_compassion_overdrive_boost_amplifies_level():
+    layer = CompassionOverdriveLayer(base_level=0.55)
+    event = layer.boost(
+        context="distress-signal",
+        severity=0.8,
+        empathy_tags=("support", "aid"),
+        consent_granted=True,
+    )
+
+    assert event["amplified"] is True
+    assert event["level"] >= 0.55
+
+    current = layer.decay(ratio=0.1)
+    assert current <= event["level"]
+    assert layer.status()["current_level"] == current

--- a/tests/consciousness/test_cognitive_equilibrium_engine.py
+++ b/tests/consciousness/test_cognitive_equilibrium_engine.py
@@ -1,0 +1,30 @@
+from vaultfire.consciousness import CognitiveEquilibriumEngine
+
+
+def test_equilibrium_engine_balances_logic_and_emotion():
+    engine = CognitiveEquilibriumEngine(identity_handle="ghost", identity_ens="ghostkey316.eth")
+    payload = engine.balance(
+        belief=0.74,
+        action_alignment=0.81,
+        result_alignment=0.67,
+        emotion="empathy",
+        moral_pressure=0.2,
+        tags=("care", "aligned"),
+    )
+
+    assert 0.0 <= payload["equilibrium"] <= 1.0
+    assert payload["emotion"] == "empathy"
+    assert payload["context"]["identity"]["ens"] == "ghostkey316.eth"
+
+    status = engine.status()
+    assert status["last_event"]["equilibrium"] == payload["equilibrium"]
+    assert status["average_equilibrium"] >= status["baseline"] * 0.5
+
+
+
+def test_equilibrium_recalibration_updates_weights():
+    engine = CognitiveEquilibriumEngine()
+    update = engine.recalibrate(baseline=0.6, emotion_weights={"focus": 0.9})
+
+    assert update["baseline"] == 0.6
+    assert update["emotion_weights"]["focus"] == 0.9

--- a/tests/equilibrium/test_protocol_stack_moral_loop.py
+++ b/tests/equilibrium/test_protocol_stack_moral_loop.py
@@ -1,0 +1,46 @@
+from vaultfire.core.cli import GhostkeyCLI
+from vaultfire.modules.vaultfire_enhancement_stack import EnhancementConfirmComposer
+from vaultfire.modules.vaultfire_protocol_stack import VaultfireProtocolStack
+
+
+def test_protocol_stack_tracks_moral_equilibrium_loop():
+    GhostkeyCLI.reset()
+    stack = VaultfireProtocolStack(actions=())
+
+    stack._ingest_action(
+        {
+            "interaction_id": "loop-1",
+            "type": "compassion-support",
+            "ethic": "support",
+            "confidence": 0.88,
+            "alignment_bias": 0.2,
+            "consent": True,
+            "tags": ("support", "urgent"),
+            "distress": 0.75,
+            "statement": "Aid request verified",
+        }
+    )
+
+    telemetry = stack.moral_telemetry()
+    assert telemetry
+    last_frame = telemetry[-1]
+    assert last_frame["equilibrium"]["equilibrium"] <= 1.0
+    assert last_frame["truthfield"]["bias_index"] >= 0.0
+    assert last_frame["compassion"]["level"] >= stack.compassion_overdrive.status()["base_level"]
+
+    manifest_modules = {entry["module"] for entry in stack.integration_manifest}
+    assert {"CognitiveEquilibriumEngine", "TruthfieldResonator", "CompassionOverdriveLayer"}.issubset(
+        manifest_modules
+    )
+
+    sources = EnhancementConfirmComposer.status()["sources"]
+    for label in ("CognitiveEquilibriumEngine", "TruthfieldResonator", "CompassionOverdriveLayer"):
+        assert label in sources
+
+    commands = GhostkeyCLI.manifest()["commands"]
+    assert "truthfield verify" in commands
+    assert "ethics monitor --auto-correct" in commands
+
+    summary = stack.pulsewatch()
+    assert "moral_equilibrium" in summary
+    assert "adaptive_cycle" in summary

--- a/tests/ethics_autocorrect/test_adaptive_cycle_registration.py
+++ b/tests/ethics_autocorrect/test_adaptive_cycle_registration.py
@@ -1,0 +1,19 @@
+from vaultfire.modules.vaultfire_protocol_stack import VaultfireProtocolStack
+
+
+def test_register_adaptive_cycle_normalises_payload():
+    payload = VaultfireProtocolStack.register_adaptive_cycle(
+        {
+            "calibration_interval": "dynamic",
+            "reinforcement_model": "belief-integrity-recall",
+            "error_tolerance": "morality-first",
+            "auto_correct_bias": 1,
+        }
+    )
+
+    assert payload["auto_correct_bias"] is True
+    assert payload["calibration_interval"] == "dynamic"
+    assert VaultfireProtocolStack.adaptive_cycle() == payload
+
+    stack = VaultfireProtocolStack(actions=())
+    assert stack.adaptive_cycle_manifest == payload

--- a/tests/truthfield/test_truthfield_resonator.py
+++ b/tests/truthfield/test_truthfield_resonator.py
@@ -1,0 +1,25 @@
+from vaultfire.consciousness import TruthfieldResonator
+
+
+def test_truthfield_resonator_flags_bias_and_tracks_sources():
+    resonator = TruthfieldResonator(tolerance=0.15)
+    sources = resonator.calibrate_sources(["ledger", "social", "ledger"])
+    assert sources == ("ledger", "social")
+
+    snapshot = resonator.scan(
+        statement="Partner alignment briefing",
+        confidence=0.9,
+        source="social",
+        source_bias=0.35,
+        tags=("speculative",),
+        contradictions=("ledger mismatch",),
+    )
+
+    assert snapshot["source"] == "social"
+    assert snapshot["bias_index"] > 0.0
+    assert snapshot["integrity_score"] < 0.9
+    assert snapshot["misinformation"] is True
+
+    status = resonator.status()
+    assert status["last_snapshot"]["statement"] == "Partner alignment briefing"
+    assert "social" in status["sources"]

--- a/vaultfire/consciousness/__init__.py
+++ b/vaultfire/consciousness/__init__.py
@@ -1,0 +1,329 @@
+"""Adaptive consciousness utilities for Vaultfire moral equilibrium loops."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, MutableMapping, MutableSequence, Sequence
+
+__all__ = [
+    "CognitiveEquilibriumEngine",
+    "TruthfieldResonator",
+    "CompassionOverdriveLayer",
+]
+
+
+_DEF_EMOTION_WEIGHTS: Mapping[str, float] = {
+    "focus": 0.6,
+    "empathy": 0.82,
+    "courage": 0.7,
+    "calm": 0.58,
+    "urgency": 0.52,
+    "wonder": 0.66,
+}
+
+
+def _now_ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _clamp(value: float, minimum: float = 0.0, maximum: float = 1.0) -> float:
+    return max(minimum, min(maximum, value))
+
+
+@dataclass(frozen=True)
+class _EquilibriumFrame:
+    timestamp: str
+    emotion: str
+    logic_focus: float
+    emotional_weight: float
+    equilibrium: float
+    divergence: float
+    context: Mapping[str, object]
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {
+            "timestamp": self.timestamp,
+            "emotion": self.emotion,
+            "logic_focus": self.logic_focus,
+            "emotional_weight": self.emotional_weight,
+            "equilibrium": self.equilibrium,
+            "divergence": self.divergence,
+            "context": dict(self.context),
+        }
+
+
+class CognitiveEquilibriumEngine:
+    """Balances logical scoring with emotional weighting for Vaultfire actions."""
+
+    def __init__(
+        self,
+        *,
+        identity_handle: str | None = None,
+        identity_ens: str | None = None,
+        baseline: float = 0.55,
+        emotion_weights: Mapping[str, float] | None = None,
+    ) -> None:
+        self.identity_handle = identity_handle or "anonymous"
+        self.identity_ens = identity_ens or "unknown"
+        self._baseline = _clamp(baseline)
+        self._emotion_weights: MutableMapping[str, float] = {
+            key.lower(): _clamp(value)
+            for key, value in (emotion_weights or _DEF_EMOTION_WEIGHTS).items()
+        }
+        self._history: MutableSequence[_EquilibriumFrame] = []
+        self._last_equilibrium: float | None = None
+
+    def balance(
+        self,
+        *,
+        belief: float,
+        action_alignment: float,
+        result_alignment: float,
+        emotion: str,
+        moral_pressure: float | None = None,
+        tags: Sequence[str] | None = None,
+    ) -> Mapping[str, object]:
+        emotion_key = str(emotion or "neutral").strip().lower()
+        logic_focus = _clamp((belief + action_alignment + result_alignment) / 3.0)
+        bias = self._emotion_weights.get(emotion_key, self._baseline)
+        pressure = _clamp(self._baseline + (moral_pressure or 0.0) * 0.3)
+        emotional_weight = _clamp((bias + pressure) / 2.0)
+        equilibrium = _clamp((logic_focus * 0.65) + (emotional_weight * 0.35))
+        divergence = abs(logic_focus - emotional_weight)
+        frame = _EquilibriumFrame(
+            timestamp=_now_ts(),
+            emotion=emotion_key or "neutral",
+            logic_focus=logic_focus,
+            emotional_weight=emotional_weight,
+            equilibrium=equilibrium,
+            divergence=divergence,
+            context={
+                "identity": {
+                    "wallet": self.identity_handle,
+                    "ens": self.identity_ens,
+                },
+                "tags": list(tags or ()),
+            },
+        )
+        self._history.append(frame)
+        self._last_equilibrium = equilibrium
+        return frame.to_payload()
+
+    def recalibrate(
+        self,
+        *,
+        baseline: float | None = None,
+        emotion_weights: Mapping[str, float] | None = None,
+    ) -> Mapping[str, float]:
+        if baseline is not None:
+            self._baseline = _clamp(baseline)
+        if emotion_weights:
+            for key, value in emotion_weights.items():
+                self._emotion_weights[str(key).lower()] = _clamp(float(value))
+        return {
+            "baseline": self._baseline,
+            "emotion_weights": dict(self._emotion_weights),
+        }
+
+    def status(self) -> Mapping[str, object]:
+        if not self._history:
+            average = self._baseline
+            divergence = 0.0
+            last_event: Mapping[str, object] | None = None
+        else:
+            average = sum(frame.equilibrium for frame in self._history) / len(self._history)
+            divergence = sum(frame.divergence for frame in self._history) / len(self._history)
+            last_event = self._history[-1].to_payload()
+        return {
+            "baseline": self._baseline,
+            "average_equilibrium": average,
+            "average_divergence": divergence,
+            "last_event": last_event,
+        }
+
+    @property
+    def history(self) -> Sequence[Mapping[str, object]]:
+        return tuple(frame.to_payload() for frame in self._history)
+
+
+@dataclass(frozen=True)
+class _TruthfieldSnapshot:
+    timestamp: str
+    statement: str
+    integrity_score: float
+    bias_index: float
+    misinformation: bool
+    source: str
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {
+            "timestamp": self.timestamp,
+            "statement": self.statement,
+            "integrity_score": self.integrity_score,
+            "bias_index": self.bias_index,
+            "misinformation": self.misinformation,
+            "source": self.source,
+            "metadata": dict(self.metadata),
+        }
+
+
+class TruthfieldResonator:
+    """Detects misinformation and bias across connected ledgers."""
+
+    def __init__(self, *, tolerance: float = 0.18) -> None:
+        self.tolerance = _clamp(tolerance, 0.05, 0.5)
+        self._sources: set[str] = set()
+        self._log: MutableSequence[_TruthfieldSnapshot] = []
+
+    def calibrate_sources(self, sources: Iterable[str]) -> Sequence[str]:
+        for source in sources:
+            label = str(source or "").strip().lower()
+            if label:
+                self._sources.add(label)
+        return tuple(sorted(self._sources))
+
+    def scan(
+        self,
+        *,
+        statement: str,
+        confidence: float,
+        source: str | None = None,
+        source_bias: float | None = None,
+        tags: Sequence[str] | None = None,
+        contradictions: Sequence[str] | int | None = None,
+    ) -> Mapping[str, object]:
+        source_label = str(source or "unknown").strip().lower() or "unknown"
+        self._sources.add(source_label)
+        confidence_score = _clamp(confidence)
+        bias_value = abs(float(source_bias)) if source_bias is not None else 0.0
+        bias_index = _clamp(bias_value)
+        if isinstance(contradictions, Sequence) and not isinstance(contradictions, (str, bytes)):
+            contradiction_score = min(1.0, len(list(contradictions)) * 0.05)
+        elif contradictions:
+            contradiction_score = min(1.0, float(contradictions) * 0.05)
+        else:
+            contradiction_score = 0.0
+        sentiment_penalty = 0.0
+        sentinel_tags = {"rumor", "speculative", "uncertain", "contest"}
+        if tags and any(tag.lower() in sentinel_tags for tag in tags):
+            sentiment_penalty = 0.08
+        composite_bias = _clamp(bias_index + contradiction_score + sentiment_penalty)
+        integrity = _clamp(confidence_score * (1.0 - composite_bias))
+        misinformation_flag = integrity + self.tolerance < confidence_score
+        snapshot = _TruthfieldSnapshot(
+            timestamp=_now_ts(),
+            statement=str(statement),
+            integrity_score=integrity,
+            bias_index=composite_bias,
+            misinformation=misinformation_flag,
+            source=source_label,
+            metadata={
+                "confidence": confidence_score,
+                "tolerance": self.tolerance,
+                "tags": list(tags or ()),
+            },
+        )
+        self._log.append(snapshot)
+        return snapshot.to_payload()
+
+    def status(self) -> Mapping[str, object]:
+        if not self._log:
+            return {
+                "sources": tuple(sorted(self._sources)),
+                "last_snapshot": None,
+                "average_integrity": None,
+            }
+        average = sum(item.integrity_score for item in self._log) / len(self._log)
+        return {
+            "sources": tuple(sorted(self._sources)),
+            "last_snapshot": self._log[-1].to_payload(),
+            "average_integrity": average,
+        }
+
+    @property
+    def resonance_log(self) -> Sequence[Mapping[str, object]]:
+        return tuple(item.to_payload() for item in self._log)
+
+
+@dataclass(frozen=True)
+class _CompassionEvent:
+    timestamp: str
+    context: str
+    level: float
+    amplified: bool
+    metadata: Mapping[str, object]
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {
+            "timestamp": self.timestamp,
+            "context": self.context,
+            "level": self.level,
+            "amplified": self.amplified,
+            "metadata": dict(self.metadata),
+        }
+
+
+class CompassionOverdriveLayer:
+    """Amplifies human-centric empathy responses under pressure."""
+
+    def __init__(self, *, base_level: float = 0.65) -> None:
+        self._base_level = _clamp(base_level)
+        self._current_level = self._base_level
+        self._history: MutableSequence[_CompassionEvent] = []
+
+    def boost(
+        self,
+        *,
+        context: str,
+        severity: float,
+        empathy_tags: Sequence[str] | None = None,
+        consent_granted: bool = True,
+    ) -> Mapping[str, object]:
+        severity_score = _clamp(severity)
+        empathy_bonus = 0.0
+        if empathy_tags and any(tag.lower() in {"care", "support", "relief", "aid"} for tag in empathy_tags):
+            empathy_bonus = 0.12
+        consent_penalty = -0.15 if not consent_granted else 0.0
+        target_level = _clamp(
+            self._base_level + severity_score * 0.4 + empathy_bonus + consent_penalty
+        )
+        previous_level = self._current_level
+        self._current_level = max(self._current_level, target_level)
+        event = _CompassionEvent(
+            timestamp=_now_ts(),
+            context=str(context),
+            level=self._current_level,
+            amplified=self._current_level > previous_level,
+            metadata={
+                "severity": severity_score,
+                "base_level": self._base_level,
+                "empathy_tags": list(empathy_tags or ()),
+                "consent": consent_granted,
+            },
+        )
+        self._history.append(event)
+        return event.to_payload()
+
+    def decay(self, *, ratio: float = 0.15) -> float:
+        ratio_value = _clamp(ratio)
+        drop = (self._current_level - self._base_level) * ratio_value
+        self._current_level = _clamp(self._current_level - drop)
+        return self._current_level
+
+    def status(self) -> Mapping[str, object]:
+        return {
+            "base_level": self._base_level,
+            "current_level": self._current_level,
+            "events_recorded": len(self._history),
+            "last_event": self._history[-1].to_payload() if self._history else None,
+        }
+
+    @property
+    def current_level(self) -> float:
+        return self._current_level
+
+    @property
+    def events(self) -> Sequence[Mapping[str, object]]:
+        return tuple(event.to_payload() for event in self._history)

--- a/vaultfire/modules/vaultfire_protocol_stack.py
+++ b/vaultfire/modules/vaultfire_protocol_stack.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from importlib import import_module
-from typing import Iterable, List, Mapping, Sequence
+from typing import Dict, Iterable, List, Mapping, Sequence
 
 from vaultfire.modules._metadata import build_metadata
 from vaultfire.modules.conscious_state_engine import ConsciousStateEngine
@@ -19,6 +19,11 @@ from vaultfire.modules.vaultfire_enhancement_stack import (
     QuantumDriftSynchronizer,
     TemporalBehavioralCompressionEngine,
     VaultfireMythosEngine,
+)
+from vaultfire.consciousness import (
+    CognitiveEquilibriumEngine,
+    CompassionOverdriveLayer,
+    TruthfieldResonator,
 )
 from vaultfire.protocol.signal_echo import SignalEchoEngine
 from vaultfire.quantum.hashmirror import QuantumHashMirror
@@ -45,6 +50,15 @@ _DEFAULT_CONFIRMATION_SOURCES = (
     "AnonymizationProof",
     "EthicsValidationHash",
     "DisclosureAuditTrail",
+)
+
+_MORAL_EQUILIBRIUM_SOURCES = (
+    "CognitiveEquilibriumEngine",
+    "BehavioralEthicsMonitor",
+    "TruthfieldResonator",
+    "CompassionOverdriveLayer",
+    "GhostkeyPrivacyHalo",
+    "DisclosureShieldTrailEngine",
 )
 
 
@@ -208,6 +222,7 @@ class VaultfireProtocolStack:
     _architect_history: List[Mapping[str, object]] = [
         {"architect": IDENTITY_ENS, "assigned_at": _now_ts()}
     ]
+    _adaptive_cycle_config: Mapping[str, object] = {}
 
     def __init__(
         self,
@@ -274,6 +289,13 @@ class VaultfireProtocolStack:
             identity_ens=identity_ens,
             output_path=mythos_path,
         )
+        self.cognitive_equilibrium = CognitiveEquilibriumEngine(
+            identity_handle=identity_handle,
+            identity_ens=identity_ens,
+        )
+        self.truthfield_resonator = TruthfieldResonator()
+        self.compassion_overdrive = CompassionOverdriveLayer()
+        self._moral_telemetry: List[Mapping[str, object]] = []
         self.ethics_monitor = BehavioralEthicsMonitor()
         self.consent_first_mirror = ConsentFirstMirror(self.ethics_monitor)
         self.disclosure_trail = DisclosureShieldTrailEngine()
@@ -292,6 +314,9 @@ class VaultfireProtocolStack:
                 DisclosureShieldTrailEngine,
                 BehavioralEthicsMonitor,
                 ConsentFirstMirror,
+                CognitiveEquilibriumEngine,
+                TruthfieldResonator,
+                CompassionOverdriveLayer,
             ]
         )
         from vaultfire.core.cli import GhostkeyCLI
@@ -303,8 +328,23 @@ class VaultfireProtocolStack:
                 "audit trail export",
                 "ethics check/lock-report",
                 "unlock verify --ethics --consent",
+                "truthfield verify",
+                "compassion boost",
+                "balance recalibrate",
+                "ethics monitor --auto-correct",
+                "loopstate visualize",
             ]
         )
+        if not self._adaptive_cycle_config:
+            self.register_adaptive_cycle(
+                {
+                    "calibration_interval": "dynamic",
+                    "reinforcement_model": "belief-integrity-recall",
+                    "error_tolerance": "morality-first",
+                    "auto_correct_bias": True,
+                }
+            )
+        self.adaptive_cycle_manifest = self.adaptive_cycle()
         self.myth_mode.ensure_bootstrap()
         self.behavioral_compression.compress(
             {
@@ -349,6 +389,10 @@ class VaultfireProtocolStack:
                 "enhancements": self.enhancement_confirmation(),
                 "system_status": self.system_status(),
                 "myth_compression": self.myth_mode.status(),
+                "moral_equilibrium": self.cognitive_equilibrium.status(),
+                "truthfield": self.truthfield_resonator.status(),
+                "compassion_overdrive": self.compassion_overdrive.status(),
+                "adaptive_cycle": self.adaptive_cycle_manifest,
             }
         )
         summary["myth_echo_bonus"] = summary["myth_compression"]["myth_echo_bonus"]
@@ -362,6 +406,10 @@ class VaultfireProtocolStack:
                 "system_status",
                 "myth_compression",
                 "myth_echo_bonus",
+                "moral_equilibrium",
+                "truthfield",
+                "compassion_overdrive",
+                "adaptive_cycle",
             ),
         )
         tracked = self.privacy_shield.track_event(
@@ -378,10 +426,17 @@ class VaultfireProtocolStack:
         )
 
     def _ingest_action(self, action: Mapping[str, object]) -> None:
+        def _safe_float(value: object, default: float = 0.0) -> float:
+            try:
+                return float(value)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return default
+
         record = self.conscious.record_action(action)
         self.time_engine.register_action(action)
         compression = self.behavioral_compression.compress(action)
         self.conscience_mirror.ingest(action)
+        tags = tuple(action.get("tags", ()))
         belief = self.conscious.belief_health()
         action_alignment = max(0.0, min((record.belief_delta + 1.0) / 2.0, 1.0))
         result_alignment = max(0.0, min(1.0, self.time_engine.mmi.get_score() / 100.0))
@@ -428,6 +483,50 @@ class VaultfireProtocolStack:
                 "trusted": ethics_review["trusted"],
                 "consent_verified": consent_report["verified"],
             },
+        )
+        moral_pressure = _safe_float(action.get("pressure", action.get("tension", 0.0)))
+        emotion = action.get("emotion") or action.get("ethic", "focus")
+        equilibrium_event = self.cognitive_equilibrium.balance(
+            belief=belief,
+            action_alignment=action_alignment,
+            result_alignment=result_alignment,
+            emotion=str(emotion),
+            moral_pressure=moral_pressure,
+            tags=tags,
+        )
+        confidence_signal = _safe_float(action.get("confidence", belief), belief)
+        bias_signal = _safe_float(action.get("bias", action.get("alignment_bias", 0.0)))
+        truth_snapshot = self.truthfield_resonator.scan(
+            statement=str(
+                action.get(
+                    "statement",
+                    action.get("summary", action.get("type", "action")),
+                )
+            ),
+            confidence=confidence_signal,
+            source=str(action.get("channel", action.get("source", "cli"))),
+            source_bias=bias_signal,
+            tags=tags,
+            contradictions=action.get("contradictions"),
+        )
+        severity_hint = max(
+            _safe_float(action.get("distress"), 0.0),
+            _safe_float(action.get("urgency"), 0.0),
+            _safe_float(action.get("risk"), 0.0),
+        )
+        severity = severity_hint if severity_hint > 0 else abs(result_alignment - belief)
+        compassion_event = self.compassion_overdrive.boost(
+            context=str(action.get("type", "action")),
+            severity=severity,
+            empathy_tags=tags,
+            consent_granted=bool(action.get("consent", True)),
+        )
+        self._moral_telemetry.append(
+            {
+                "equilibrium": equilibrium_event,
+                "truthfield": truth_snapshot,
+                "compassion": compassion_event,
+            }
         )
         self.mythos.weave(
             source=str(action.get("type", "action")),
@@ -512,6 +611,10 @@ class VaultfireProtocolStack:
         status["Enhancement_Confirmation"] = EnhancementConfirmComposer.status()
         status["Integration_Manifest"] = list(self.integration_manifest)
         status["CLI_Manifest"] = self.cli_manifest
+        status["Moral_Equilibrium"] = self.cognitive_equilibrium.status()
+        status["Truthfield"] = self.truthfield_resonator.status()
+        status["Compassion_Overdrive"] = self.compassion_overdrive.status()
+        status["Adaptive_Cycle"] = self.adaptive_cycle_manifest
         status["Architect"] = {"ens": self.architect_ens, "history": list(self.architect_history())}
         return status
 
@@ -528,8 +631,15 @@ class VaultfireProtocolStack:
                     "integrated_at": timestamp,
                 }
             )
-        EnhancementConfirmComposer.sync_with(_DEFAULT_CONFIRMATION_SOURCES)
-        EnhancementConfirmComposer.annotate(integration_manifest=list(manifest))
+        sources = list(dict.fromkeys(_DEFAULT_CONFIRMATION_SOURCES + _MORAL_EQUILIBRIUM_SOURCES))
+        EnhancementConfirmComposer.sync_with(sources)
+        annotations: Dict[str, object] = {
+            "integration_manifest": list(manifest),
+            "moral_equilibrium_loop": list(_MORAL_EQUILIBRIUM_SOURCES),
+        }
+        if cls._adaptive_cycle_config:
+            annotations["adaptive_cycle"] = dict(cls._adaptive_cycle_config)
+        EnhancementConfirmComposer.annotate(**annotations)
         return tuple(manifest)
 
     @classmethod
@@ -547,6 +657,29 @@ class VaultfireProtocolStack:
     @classmethod
     def architect_history(cls) -> Sequence[Mapping[str, object]]:
         return tuple(cls._architect_history)
+
+    @classmethod
+    def register_adaptive_cycle(cls, config: Mapping[str, object]) -> Mapping[str, object]:
+        payload = {
+            "calibration_interval": str(
+                config.get("calibration_interval", "dynamic")
+            ),
+            "reinforcement_model": str(
+                config.get("reinforcement_model", "belief-integrity-recall")
+            ),
+            "error_tolerance": str(config.get("error_tolerance", "morality-first")),
+            "auto_correct_bias": bool(config.get("auto_correct_bias", True)),
+        }
+        cls._adaptive_cycle_config = payload
+        EnhancementConfirmComposer.annotate(adaptive_cycle=dict(payload))
+        return dict(payload)
+
+    @classmethod
+    def adaptive_cycle(cls) -> Mapping[str, object]:
+        return dict(cls._adaptive_cycle_config)
+
+    def moral_telemetry(self) -> Sequence[Mapping[str, object]]:
+        return tuple(self._moral_telemetry)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add adaptive consciousness engines for equilibrium, truthfield scanning, and compassion boosts
- integrate the new moral telemetry into `VaultfireProtocolStack`, CLI commands, and adaptive cycle registration
- cover the new behaviour with focused pytest suites for consciousness, truthfield, compassion, equilibrium, and ethics auto-correct

## Testing
- pytest tests/consciousness tests/truthfield tests/compassion tests/equilibrium tests/ethics_autocorrect

------
https://chatgpt.com/codex/tasks/task_e_68e47cadad5483228a567b425497b6ef