### PR TITLE
Add codex confirmation helpers and validation suite

### DIFF
--- a/tests/test_manifest_alignment_suite.py
+++ b/tests/test_manifest_alignment_suite.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from vaultfire.consciousness import PulsewatchSyncStatus
+from vaultfire.ethics import EthicsAutoCorrectSuite
+from vaultfire.manifest import CodexConfirmationSeal
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(CodexConfirmationSeal, "_records", [], raising=False)
+    monkeypatch.setattr(CodexConfirmationSeal, "_logs", [], raising=False)
+    monkeypatch.setattr(PulsewatchSyncStatus, "_history", [], raising=False)
+    monkeypatch.setattr(EthicsAutoCorrectSuite, "_runs", [], raising=False)
+
+
+def test_codex_confirmation_seal_records_metadata() -> None:
+    payload = {
+        "version": "v6.1",
+        "modules": ["vaultfire.consciousness", "CognitiveEquilibriumEngine"],
+        "features": ("loop", "telemetry"),
+        "verified_by": "pytest run",
+        "lead": "Ghostkey-316",
+    }
+
+    result = CodexConfirmationSeal.record(payload)
+
+    assert result["version"] == "v6.1"
+    assert result["modules"] == ["vaultfire.consciousness", "CognitiveEquilibriumEngine"]
+    assert result["features"] == ["loop", "telemetry"]
+    # Ensure the original payload is not mutated
+    assert payload["features"] == ("loop", "telemetry")
+
+    log = CodexConfirmationSeal.commit_log("Vaultfire v6.1 complete")
+
+    assert "timestamp" in result and "timestamp" in log
+    assert log["message"] == "Vaultfire v6.1 complete"
+    history = CodexConfirmationSeal.history()
+    assert history["records"][-1] == result
+    assert history["logs"][-1] == log
+    assert CodexConfirmationSeal.last_record() == result
+    assert CodexConfirmationSeal.last_log() == log
+
+
+def test_pulsewatch_sync_status_confirms_axes() -> None:
+    event = PulsewatchSyncStatus.confirm_alignment(
+        "Ethics",
+        "Emotion",
+        "Logic",
+        telemetry={"source": "unit-test"},
+    )
+
+    assert event["axes"] == ["ethics", "emotion", "logic"]
+    assert event["status"] == "aligned"
+    assert event["telemetry"] == {"source": "unit-test"}
+    assert PulsewatchSyncStatus.last_alignment() == event
+    assert PulsewatchSyncStatus.history()[-1] == event
+
+    with pytest.raises(ValueError):
+        PulsewatchSyncStatus.confirm_alignment("   ")
+
+
+def test_ethics_auto_correct_suite_runs_all_checks() -> None:
+    result = EthicsAutoCorrectSuite.full_validation()
+
+    assert result["verified"] is True
+    assert len(result["checks"]) == result["summary"]["total_checks"]
+    assert result["summary"]["passed"] == result["summary"]["total_checks"]
+    assert EthicsAutoCorrectSuite.last_run() == result
+    assert EthicsAutoCorrectSuite.history()[-1] == result

--- a/vaultfire/consciousness/__init__.py
+++ b/vaultfire/consciousness/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "CognitiveEquilibriumEngine",
     "TruthfieldResonator",
     "CompassionOverdriveLayer",
+    "PulsewatchSyncStatus",
 ]
 
 
@@ -327,3 +328,58 @@ class CompassionOverdriveLayer:
     @property
     def events(self) -> Sequence[Mapping[str, object]]:
         return tuple(event.to_payload() for event in self._history)
+
+
+@dataclass(frozen=True)
+class _PulsewatchAlignment:
+    timestamp: str
+    axes: Sequence[str]
+    status: str
+    telemetry: Mapping[str, object]
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {
+            "timestamp": self.timestamp,
+            "axes": list(self.axes),
+            "status": self.status,
+            "telemetry": dict(self.telemetry),
+        }
+
+
+class PulsewatchSyncStatus:
+    """Tracks cross-domain alignment confirmations for Pulsewatch telemetry."""
+
+    _history: MutableSequence[_PulsewatchAlignment] = []
+
+    @classmethod
+    def confirm_alignment(
+        cls,
+        *axes: str,
+        status: str = "aligned",
+        telemetry: Mapping[str, object] | None = None,
+    ) -> Mapping[str, object]:
+        """Record a synchronisation event across the provided axes."""
+
+        normalised_axes = tuple(
+            axis.strip().lower()
+            for axis in (axes or ("alignment",))
+            if str(axis).strip()
+        )
+        if not normalised_axes:
+            raise ValueError("at least one alignment axis must be provided")
+        payload = _PulsewatchAlignment(
+            timestamp=_now_ts(),
+            axes=normalised_axes,
+            status=str(status or "aligned").lower(),
+            telemetry=dict(telemetry or {}),
+        )
+        cls._history.append(payload)
+        return payload.to_payload()
+
+    @classmethod
+    def history(cls) -> Sequence[Mapping[str, object]]:
+        return tuple(item.to_payload() for item in cls._history)
+
+    @classmethod
+    def last_alignment(cls) -> Mapping[str, object] | None:
+        return cls._history[-1].to_payload() if cls._history else None

--- a/vaultfire/ethics/__init__.py
+++ b/vaultfire/ethics/__init__.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Mapping, MutableSequence, Sequence
 
-__all__ = ["BehavioralEthicsMonitor", "ConsentFirstMirror"]
+__all__ = ["BehavioralEthicsMonitor", "ConsentFirstMirror", "EthicsAutoCorrectSuite"]
 
 
 def _now_ts() -> str:
@@ -121,4 +121,125 @@ class ConsentFirstMirror:
             "verifications_recorded": len(self._verifications),
             "last_verification": self._verifications[-1] if self._verifications else None,
         }
+
+
+@dataclass(frozen=True)
+class _AutoCorrectCheck:
+    timestamp: str
+    name: str
+    passed: bool
+    details: Mapping[str, object]
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {
+            "timestamp": self.timestamp,
+            "name": self.name,
+            "passed": self.passed,
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class _AutoCorrectRun:
+    timestamp: str
+    checks: Sequence[_AutoCorrectCheck]
+    verified: bool
+    summary: Mapping[str, object]
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {
+            "timestamp": self.timestamp,
+            "verified": self.verified,
+            "checks": [check.to_payload() for check in self.checks],
+            "summary": dict(self.summary),
+        }
+
+
+class EthicsAutoCorrectSuite:
+    """High-level helper that exercises multiple ethics safeguards."""
+
+    _runs: MutableSequence[_AutoCorrectRun] = []
+
+    @classmethod
+    def full_validation(cls, *, threshold: float = 0.72) -> Mapping[str, object]:
+        monitor = BehavioralEthicsMonitor(threshold=threshold)
+        mirror = ConsentFirstMirror(monitor)
+
+        trusted_event = monitor.evaluate(
+            {
+                "ethic": "aligned",
+                "alignment": min(1.0, threshold + 0.15),
+                "consent": True,
+                "source": "auto-correct-suite",
+            }
+        )
+        consent_verification = mirror.verify("baseline", consent=True, review=trusted_event)
+
+        risky_event = monitor.evaluate(
+            {
+                "ethic": "rumor",
+                "alignment": 0.31,
+                "consent": True,
+                "result_alignment": 0.3,
+                "source": "bias-audit",
+            }
+        )
+
+        consent_block = mirror.verify(
+            "consent-block",
+            consent=False,
+            alignment=threshold + 0.2,
+            ethic="aligned",
+        )
+
+        checks = (
+            _AutoCorrectCheck(
+                timestamp=_now_ts(),
+                name="baseline_alignment",
+                passed=bool(trusted_event.get("trusted")),
+                details={"alignment_score": trusted_event.get("alignment_score")},
+            ),
+            _AutoCorrectCheck(
+                timestamp=_now_ts(),
+                name="consent_verification",
+                passed=bool(consent_verification.get("verified")),
+                details={"ethic": consent_verification.get("ethic")},
+            ),
+            _AutoCorrectCheck(
+                timestamp=_now_ts(),
+                name="bias_detection",
+                passed=not bool(risky_event.get("trusted")),
+                details={"ethic": risky_event.get("ethic"), "alignment_score": risky_event.get("alignment_score")},
+            ),
+            _AutoCorrectCheck(
+                timestamp=_now_ts(),
+                name="consent_block",
+                passed=not bool(consent_block.get("verified")),
+                details={"consent": False, "ethic": consent_block.get("ethic")},
+            ),
+        )
+
+        all_passed = all(check.passed for check in checks)
+        summary = {
+            "monitor": monitor.status(),
+            "mirror": mirror.status(),
+            "total_checks": len(checks),
+            "passed": sum(int(check.passed) for check in checks),
+        }
+        run = _AutoCorrectRun(
+            timestamp=_now_ts(),
+            checks=checks,
+            verified=all_passed,
+            summary=summary,
+        )
+        cls._runs.append(run)
+        return run.to_payload()
+
+    @classmethod
+    def history(cls) -> Sequence[Mapping[str, object]]:
+        return tuple(run.to_payload() for run in cls._runs)
+
+    @classmethod
+    def last_run(cls) -> Mapping[str, object] | None:
+        return cls._runs[-1].to_payload() if cls._runs else None
 

--- a/vaultfire/manifest.py
+++ b/vaultfire/manifest.py
@@ -1,0 +1,145 @@
+"""Protocol manifest utilities for recording Vaultfire confirmations."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable as IterableABC
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping, MutableSequence, Sequence
+
+__all__ = ["CodexConfirmationSeal"]
+
+
+def _now_ts() -> str:
+    """Return a timezone-aware ISO 8601 timestamp."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class _ConfirmationRecord:
+    timestamp: str
+    version: str
+    modules: Sequence[str]
+    features: Sequence[str]
+    verified_by: str | None
+    lead: str | None
+    payload: Mapping[str, object]
+
+    def to_payload(self) -> Mapping[str, object]:
+        data = dict(self.payload)
+        data.update(
+            {
+                "timestamp": self.timestamp,
+                "version": self.version,
+                "modules": list(self.modules),
+                "features": list(self.features),
+                "verified_by": self.verified_by,
+                "lead": self.lead,
+            }
+        )
+        return data
+
+
+@dataclass(frozen=True)
+class _CommitLog:
+    timestamp: str
+    message: str
+
+    def to_payload(self) -> Mapping[str, object]:
+        return {"timestamp": self.timestamp, "message": self.message}
+
+
+class CodexConfirmationSeal:
+    """In-memory registry for protocol confirmation metadata.
+
+    The confirmation seal is intentionally lightweight so it can run inside
+    integration tests without requiring persistent storage. Records are stored
+    in deterministic order and normalised for easier assertions.
+    """
+
+    _records: MutableSequence[_ConfirmationRecord] = []
+    _logs: MutableSequence[_CommitLog] = []
+
+    @classmethod
+    def now(cls) -> str:
+        """Expose the timestamp helper for callers that need synchronisation."""
+        return _now_ts()
+
+    @classmethod
+    def record(cls, payload: Mapping[str, object]) -> Mapping[str, object]:
+        """Record a manifest entry with normalised fields.
+
+        Parameters
+        ----------
+        payload:
+            Arbitrary mapping of manifest data. ``modules`` and ``features``
+            are coerced to tuples to make the stored value immutable. Missing
+            timestamps are automatically populated with the current UTC time.
+        """
+
+        if not isinstance(payload, Mapping):
+            raise TypeError("record payload must be a mapping")
+
+        timestamp = str(payload.get("timestamp") or cls.now())
+        version = str(payload.get("version", "unknown"))
+        modules = cls._normalise_sequence(payload.get("modules"))
+        features = cls._normalise_sequence(payload.get("features"))
+        verified_by = cls._optional_str(payload.get("verified_by"))
+        lead = cls._optional_str(payload.get("lead"))
+
+        record = _ConfirmationRecord(
+            timestamp=timestamp,
+            version=version,
+            modules=modules,
+            features=features,
+            verified_by=verified_by,
+            lead=lead,
+            payload=dict(payload),
+        )
+        cls._records.append(record)
+        return record.to_payload()
+
+    @classmethod
+    def commit_log(cls, message: str) -> Mapping[str, object]:
+        if not isinstance(message, str):
+            raise TypeError("commit_log message must be a string")
+        entry = _CommitLog(timestamp=cls.now(), message=message.strip())
+        cls._logs.append(entry)
+        return entry.to_payload()
+
+    @classmethod
+    def history(cls) -> Mapping[str, Sequence[Mapping[str, object]]]:
+        return {
+            "records": tuple(record.to_payload() for record in cls._records),
+            "logs": tuple(log.to_payload() for log in cls._logs),
+        }
+
+    @classmethod
+    def last_record(cls) -> Mapping[str, object] | None:
+        return cls._records[-1].to_payload() if cls._records else None
+
+    @classmethod
+    def last_log(cls) -> Mapping[str, object] | None:
+        return cls._logs[-1].to_payload() if cls._logs else None
+
+    @staticmethod
+    def _normalise_sequence(values: object | None) -> Sequence[str]:
+        if values is None:
+            return ()
+        if isinstance(values, str):
+            return (values,)
+        if isinstance(values, Mapping):
+            candidates = values.values()
+        elif isinstance(values, IterableABC):
+            candidates = values
+        else:  # pragma: no cover - defensive guard
+            raise TypeError("sequence values must be iterable")
+        return tuple(str(item) for item in candidates)
+
+    @staticmethod
+    def _optional_str(value: object | None) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+


### PR DESCRIPTION
## Summary
- add a CodexConfirmationSeal helper to capture manifest confirmations and commit logs
- expose a PulsewatchSyncStatus utility for recording alignment sync events and extend the ethics module with an auto-correct suite runner
- cover the new helpers with targeted pytest coverage for manifest logging, pulsewatch telemetry, and ethics validation workflows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4946482848322a36584245cde1ee7