### PR TITLE
Add Ghostprint signature orchestration and soul suite aggregation

### DIFF
--- a/vaultfire/ethics/__init__.py
+++ b/vaultfire/ethics/__init__.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Mapping, MutableSequence, Sequence
+from typing import Mapping, MutableMapping, MutableSequence, Sequence
 
-__all__ = ["BehavioralEthicsMonitor", "ConsentFirstMirror", "EthicsAutoCorrectSuite"]
+__all__ = [
+    "BehavioralEthicsMonitor",
+    "ConsentFirstMirror",
+    "EthicsAutoCorrectSuite",
+    "MoralLedger",
+]
 
 
 def _now_ts() -> str:
@@ -242,4 +247,112 @@ class EthicsAutoCorrectSuite:
     @classmethod
     def last_run(cls) -> Mapping[str, object] | None:
         return cls._runs[-1].to_payload() if cls._runs else None
+
+
+class MoralLedger:
+    """Track moral alignment events with lightweight auditing helpers."""
+
+    _enabled: bool = False
+    _config: Mapping[str, object] = {}
+    _entries: MutableSequence[Mapping[str, object]] = []
+    _history: MutableSequence[Mapping[str, object]] = []
+
+    @classmethod
+    def reset(cls) -> None:
+        cls._enabled = False
+        cls._config = {}
+        cls._entries = []
+        cls._history = []
+
+    @classmethod
+    def enable(
+        cls,
+        *,
+        persistence: bool,
+        audit_window: str,
+        visibility: str,
+    ) -> Mapping[str, object]:
+        config = {
+            "persistence": bool(persistence),
+            "audit_window": str(audit_window).strip(),
+            "visibility": str(visibility).strip(),
+            "enabled_at": _now_ts(),
+        }
+        if not config["audit_window"]:
+            raise ValueError("audit_window cannot be empty")
+        if not config["visibility"]:
+            raise ValueError("visibility cannot be empty")
+        cls._enabled = True
+        cls._config = config
+        cls._history.append({
+            "type": "enable",
+            "timestamp": config["enabled_at"],
+            "payload": dict(config),
+        })
+        return dict(config)
+
+    @classmethod
+    def record(
+        cls,
+        action: str,
+        *,
+        weight: float = 1.0,
+        tags: Sequence[str] | None = None,
+        metadata: Mapping[str, object] | None = None,
+    ) -> Mapping[str, object]:
+        if not cls._enabled:
+            raise RuntimeError("MoralLedger must be enabled before recording events")
+        label = str(action).strip()
+        if not label:
+            raise ValueError("action cannot be empty")
+        timestamp = _now_ts()
+        tag_payload = tuple(
+            tag
+            for tag in (str(tag).strip() for tag in tags or ())
+            if tag
+        )
+        entry: MutableMapping[str, object] = {
+            "action": label,
+            "weight": float(weight),
+            "timestamp": timestamp,
+        }
+        if tag_payload:
+            entry["tags"] = tag_payload
+        if metadata is not None:
+            entry["metadata"] = dict(metadata)
+        cls._entries.append(dict(entry))
+        cls._history.append({
+            "type": "record",
+            "timestamp": timestamp,
+            "payload": dict(entry),
+        })
+        return dict(entry)
+
+    @classmethod
+    def audit(cls) -> Mapping[str, object]:
+        entries = tuple(dict(entry) for entry in cls._entries)
+        total_weight = sum(float(entry["weight"]) for entry in entries)
+        return {
+            "enabled": cls._enabled,
+            "config": dict(cls._config),
+            "entries": entries,
+            "summary": {
+                "entries_recorded": len(entries),
+                "total_weight": total_weight,
+            },
+        }
+
+    @classmethod
+    def history(cls) -> Sequence[Mapping[str, object]]:
+        return tuple(dict(entry) for entry in cls._history)
+
+    @classmethod
+    def status(cls) -> Mapping[str, object]:
+        audit_report = cls.audit()
+        return {
+            "enabled": audit_report["enabled"],
+            "config": audit_report["config"],
+            "entries_recorded": audit_report["summary"]["entries_recorded"],
+            "history": cls.history(),
+        }
 

--- a/vaultfire/signature/__init__.py
+++ b/vaultfire/signature/__init__.py
@@ -1,0 +1,194 @@
+"""Signature utilities for encoding Ghostprint identity metadata.
+
+This module provides a lightweight in-memory coordination layer that mirrors
+the behavior described in the Vaultfire Ghostprint activation checklist.  The
+goal is not to reach into any external systems but to offer deterministic,
+test-friendly state that other components (CLI tools, test harnesses, etc.)
+can query to confirm that identity binding and module fingerprinting have
+occurred.
+
+The API intentionally mirrors the activation script shared with the
+repository:
+
+* :func:`Ghostprint.bind_identity` associates an identity handle with the
+  running protocol and records the operation.
+* :func:`Ghostprint.encode_all` attaches deterministic fingerprints to the
+  supplied module names.
+* :func:`Ghostprint.link_origin` ties the activation to a lineage string.
+
+The helpers return serialisable dictionaries to make it easy for tests to
+assert against the behaviour without coupling to internal data structures.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+from typing import Dict, Iterable, Mapping, Sequence
+
+__all__ = ["Ghostprint"]
+
+
+def _timestamp() -> str:
+    """Return a timezone-aware ISO formatted timestamp."""
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalise_module(module: object) -> str:
+    """Normalise an incoming module reference to a non-empty string."""
+
+    if isinstance(module, str):
+        normalised = module.strip()
+    else:
+        normalised = str(module).strip()
+    if not normalised:
+        raise ValueError("module identifier cannot be empty")
+    return normalised
+
+
+@dataclass(frozen=True)
+class _EncodedModule:
+    module: str
+    fingerprint: str
+    encoded_at: str
+
+    def to_payload(self) -> Mapping[str, str]:
+        return {
+            "module": self.module,
+            "fingerprint": self.fingerprint,
+            "encoded_at": self.encoded_at,
+        }
+
+
+class Ghostprint:
+    """In-memory signature state container for Ghostkey activations."""
+
+    _identity: Mapping[str, str] | None = None
+    _origin_lineage: str | None = None
+    _encoded_modules: Dict[str, _EncodedModule] = {}
+    _history: list[Mapping[str, object]] = []
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset stored state.  Primarily used in tests."""
+
+        cls._identity = None
+        cls._origin_lineage = None
+        cls._encoded_modules = {}
+        cls._history = []
+
+    @classmethod
+    def bind_identity(
+        cls,
+        *,
+        wallet: str,
+        tag: str,
+        ENS: str,
+    ) -> Mapping[str, str]:
+        """Bind the Ghostprint identity to a wallet/tag/ENS triple."""
+
+        wallet_id = str(wallet).strip()
+        if not wallet_id:
+            raise ValueError("wallet cannot be empty")
+        tag_id = str(tag).strip()
+        if not tag_id:
+            raise ValueError("tag cannot be empty")
+        ens_handle = str(ENS).strip()
+        if not ens_handle:
+            raise ValueError("ENS cannot be empty")
+        payload = {
+            "wallet": wallet_id,
+            "tag": tag_id,
+            "ens": ens_handle,
+            "bound_at": _timestamp(),
+        }
+        cls._identity = payload
+        cls._history.append({
+            "type": "bind_identity",
+            "timestamp": payload["bound_at"],
+            "payload": dict(payload),
+        })
+        return dict(payload)
+
+    @classmethod
+    def encode_all(
+        cls,
+        modules: Iterable[object],
+        *,
+        include_timestamp: bool = True,
+    ) -> Sequence[Mapping[str, str]]:
+        """Attach fingerprints to the provided module identifiers."""
+
+        modules = tuple(modules)
+        if not modules:
+            raise ValueError("modules cannot be empty")
+        wallet = (cls._identity or {}).get("wallet", "unbound")
+        tag = (cls._identity or {}).get("tag", "ghost")
+        encoded: list[Mapping[str, str]] = []
+        for raw_module in modules:
+            module_name = _normalise_module(raw_module)
+            fingerprint_source = f"{module_name}::{wallet}::{tag}".encode("utf-8")
+            fingerprint = hashlib.sha256(fingerprint_source).hexdigest()
+            encoded_at = _timestamp() if include_timestamp else ""
+            module_record = _EncodedModule(
+                module=module_name,
+                fingerprint=fingerprint,
+                encoded_at=encoded_at,
+            )
+            cls._encoded_modules[module_name] = module_record
+            encoded.append(module_record.to_payload())
+        cls._history.append({
+            "type": "encode_modules",
+            "timestamp": _timestamp(),
+            "modules": tuple(record["module"] for record in encoded),
+        })
+        return tuple(encoded)
+
+    @classmethod
+    def link_origin(cls, lineage: str) -> Mapping[str, str]:
+        """Associate the Ghostprint activation with a lineage string."""
+
+        lineage_text = str(lineage).strip()
+        if not lineage_text:
+            raise ValueError("lineage cannot be empty")
+        timestamp = _timestamp()
+        cls._origin_lineage = lineage_text
+        cls._history.append(
+            {
+                "type": "link_origin",
+                "timestamp": timestamp,
+                "lineage": lineage_text,
+            }
+        )
+        return {"lineage": lineage_text, "linked_at": timestamp}
+
+    @classmethod
+    def encoded_modules(cls) -> Sequence[Mapping[str, str]]:
+        """Return encoded modules as serialisable payloads."""
+
+        return tuple(module.to_payload() for module in cls._encoded_modules.values())
+
+    @classmethod
+    def history(cls) -> Sequence[Mapping[str, object]]:
+        """Return the recorded operation history."""
+
+        return tuple(dict(entry) for entry in cls._history)
+
+    @classmethod
+    def status(cls) -> Mapping[str, object]:
+        """Return a summary of the Ghostprint activation state."""
+
+        identity = dict(cls._identity) if cls._identity else None
+        modules = cls.encoded_modules()
+        return {
+            "identity": identity,
+            "modules": modules,
+            "origin": cls._origin_lineage,
+            "identity_bound": identity is not None,
+            "modules_encoded": bool(modules),
+            "origin_linked": bool(cls._origin_lineage),
+            "history": cls.history(),
+        }
+

--- a/vaultfire/tests/__init__.py
+++ b/vaultfire/tests/__init__.py
@@ -11,7 +11,7 @@ from vaultfire.instinct import InstinctSuite
 from vaultfire.pulse import MissionMonitor
 from vaultfire.purpose import EchoPath
 
-__all__ = ["InstinctSuite", "DefenseSuite", "PurposeSuite"]
+__all__ = ["InstinctSuite", "DefenseSuite", "PurposeSuite", "SoulSuite"]
 
 
 def _timestamp() -> str:
@@ -198,7 +198,6 @@ class DefenseSuite:
         if "whitelist" in payload and payload["whitelist"]:
             cloned["whitelist"] = tuple(payload["whitelist"])
         return cloned
-
     @staticmethod
     def _clone_lockbox_payload(payload: Mapping[str, object]) -> Mapping[str, object]:
         cloned: MutableMapping[str, object] = {
@@ -227,6 +226,42 @@ class DefenseSuite:
             raise ValueError(
                 f"Lockbox module '{name}' seal timestamp must be ISO formatted"
             )
+
+
+class SoulSuite:
+    """Aggregate Ghostprint, MoralLedger and ProvenanceTracer status."""
+
+    @staticmethod
+    def run_all() -> Mapping[str, object]:
+        from vaultfire.signature import Ghostprint
+        from vaultfire.ethics import MoralLedger
+        from vaultfire.trust import ProvenanceTracer
+
+        ghostprint_state = Ghostprint.status()
+        ledger_state = MoralLedger.audit()
+        provenance_state = ProvenanceTracer.status()
+        passed = all(
+            (
+                ghostprint_state.get("identity_bound"),
+                ghostprint_state.get("modules_encoded"),
+                ghostprint_state.get("origin_linked"),
+                ledger_state.get("enabled"),
+                provenance_state.get("initialized"),
+            )
+        )
+        summary = {
+            "ghostprint_modules": len(ghostprint_state.get("modules", ())),
+            "ledger_entries": ledger_state.get("summary", {}).get("entries_recorded", 0),
+            "provenance_traces": provenance_state.get("traces_recorded", 0),
+        }
+        return {
+            "checked_at": _timestamp(),
+            "ghostprint": ghostprint_state,
+            "moral_ledger": ledger_state,
+            "provenance": provenance_state,
+            "summary": summary,
+            "passed": bool(passed),
+        }
 
 
 class PurposeSuite:

--- a/vaultfire/trust/__init__.py
+++ b/vaultfire/trust/__init__.py
@@ -1,0 +1,124 @@
+"""Trust and provenance tracking helpers for Vaultfire stacks."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Mapping, MutableSequence, Sequence
+
+__all__ = ["ProvenanceTracer"]
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class ProvenanceTracer:
+    """Maintain provenance traces and royalty conditions."""
+
+    _config: Mapping[str, object] = {}
+    _royalty: Mapping[str, str] = {}
+    _traces: MutableSequence[Mapping[str, object]] = []
+    _history: MutableSequence[Mapping[str, object]] = []
+
+    @classmethod
+    def reset(cls) -> None:
+        cls._config = {}
+        cls._royalty = {}
+        cls._traces = []
+        cls._history = []
+
+    @classmethod
+    def initiate(cls, *, network_scope: str, max_depth: int) -> Mapping[str, object]:
+        scope = str(network_scope).strip()
+        if not scope:
+            raise ValueError("network_scope cannot be empty")
+        if max_depth <= 0:
+            raise ValueError("max_depth must be positive")
+        config = {
+            "network_scope": scope,
+            "max_depth": int(max_depth),
+            "initiated_at": _timestamp(),
+        }
+        cls._config = config
+        cls._history.append({
+            "type": "initiate",
+            "timestamp": config["initiated_at"],
+            "payload": dict(config),
+        })
+        return dict(config)
+
+    @classmethod
+    def set_royalty_conditions(cls, *, trigger: str, method: str) -> Mapping[str, str]:
+        if not cls._config:
+            raise RuntimeError("ProvenanceTracer must be initiated before configuring royalties")
+        trigger_label = str(trigger).strip()
+        method_label = str(method).strip()
+        if not trigger_label:
+            raise ValueError("trigger cannot be empty")
+        if not method_label:
+            raise ValueError("method cannot be empty")
+        payload = {
+            "trigger": trigger_label,
+            "method": method_label,
+            "configured_at": _timestamp(),
+        }
+        cls._royalty = payload
+        cls._history.append({
+            "type": "set_royalty",
+            "timestamp": payload["configured_at"],
+            "payload": dict(payload),
+        })
+        return dict(payload)
+
+    @classmethod
+    def trace(
+        cls,
+        source: str,
+        *,
+        weight: float = 1.0,
+        depth: int = 0,
+        context: Mapping[str, object] | None = None,
+    ) -> Mapping[str, object]:
+        if not cls._config:
+            raise RuntimeError("ProvenanceTracer must be initiated before tracing")
+        if depth < 0:
+            raise ValueError("depth cannot be negative")
+        if depth > int(cls._config.get("max_depth", 0)):
+            raise ValueError("depth exceeds configured max_depth")
+        label = str(source).strip()
+        if not label:
+            raise ValueError("source cannot be empty")
+        timestamp = _timestamp()
+        entry = {
+            "source": label,
+            "weight": float(weight),
+            "depth": int(depth),
+            "timestamp": timestamp,
+        }
+        if context is not None:
+            entry["context"] = dict(context)
+        cls._traces.append(dict(entry))
+        cls._history.append({
+            "type": "trace",
+            "timestamp": timestamp,
+            "payload": dict(entry),
+        })
+        return dict(entry)
+
+    @classmethod
+    def traces(cls) -> Sequence[Mapping[str, object]]:
+        return tuple(dict(entry) for entry in cls._traces)
+
+    @classmethod
+    def history(cls) -> Sequence[Mapping[str, object]]:
+        return tuple(dict(entry) for entry in cls._history)
+
+    @classmethod
+    def status(cls) -> Mapping[str, object]:
+        return {
+            "initialized": bool(cls._config),
+            "config": dict(cls._config),
+            "royalty": dict(cls._royalty),
+            "traces_recorded": len(cls._traces),
+            "history": cls.history(),
+        }


### PR DESCRIPTION
## Summary
- add a Ghostprint signature helper that binds identities, encodes module fingerprints, and exposes status payloads
- extend the ethics toolkit with a MoralLedger tracker and add a ProvenanceTracer for trust metadata
- export a SoulSuite integration check that surfaces the combined signature, ethics, and provenance status

## Testing
- pytest tests/test_gift_matrix.py

------
https://chatgpt.com/codex/tasks/task_e_68e4a863273c8322b22ce0342013d272