### PR TITLE
Add ForgeTrail trial activation workflow support

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,27 @@
 import sys
 from pathlib import Path
+
+import pytest
+
+
 ROOT = Path(__file__).resolve().parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register custom command line options for the Vaultfire test suite."""
+
+    parser.addoption(
+        "--identity",
+        action="store",
+        default="",
+        help="Identity tag used for simulated trial activations.",
+    )
+
+
+@pytest.fixture()
+def identity(request: pytest.FixtureRequest) -> str:
+    """Expose the requested identity tag to tests that simulate live traffic."""
+
+    return request.config.getoption("identity")

--- a/protocol/__init__.py
+++ b/protocol/__init__.py
@@ -1,0 +1,180 @@
+"""Utilities for orchestrating protocol activation flows."""
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, MutableMapping, Sequence
+
+__all__ = ["TrialModeActivationError", "activate_trial_mode"]
+
+
+class TrialModeActivationError(ValueError):
+    """Raised when the ForgeTrail trial activation payload is invalid."""
+
+
+def _validate_non_empty_string(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise TrialModeActivationError(f"{field_name} must be a non-empty string.")
+    return value
+
+
+def _dedupe_preserve_order(values: Sequence[str], field_name: str) -> List[str]:
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        raise TrialModeActivationError(f"{field_name} must be a sequence of strings.")
+    seen = set()
+    result: List[str] = []
+    for item in values:
+        if not isinstance(item, str) or not item.strip():
+            raise TrialModeActivationError(f"{field_name} items must be non-empty strings.")
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def _require_bool(mapping: Mapping[str, Any], key: str, context: str) -> bool:
+    value = mapping.get(key)
+    if not isinstance(value, bool):
+        raise TrialModeActivationError(f"{context}.{key} must be a boolean.")
+    return value
+
+
+def _require_string(mapping: Mapping[str, Any], key: str, context: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise TrialModeActivationError(f"{context}.{key} must be a non-empty string.")
+    return value
+
+
+def activate_trial_mode(
+    *,
+    identity: str,
+    wallet_id: str,
+    trial_codename: str,
+    config: MutableMapping[str, Any],
+) -> Dict[str, Any]:
+    """Validate and normalize a Ghostfire ForgeTrail trial activation payload.
+
+    Parameters
+    ----------
+    identity:
+        ENS name or other verified identity descriptor for the caller.
+    wallet_id:
+        External wallet reference that will anchor the rewards preview mode.
+    trial_codename:
+        Human-friendly codename describing the active trial scenario.
+    config:
+        Mutable mapping describing telemetry, signal, and governance inputs.
+
+    Returns
+    -------
+    dict
+        Rich activation payload summarising the normalized configuration.
+    """
+
+    identity_value = _validate_non_empty_string(identity, "identity")
+    wallet_value = _validate_non_empty_string(wallet_id, "wallet_id")
+    codename_value = _validate_non_empty_string(trial_codename, "trial_codename")
+
+    config_copy: Dict[str, Any] = deepcopy(dict(config))
+
+    telemetry_sinks = _dedupe_preserve_order(
+        config_copy.get("telemetry_sinks", []),
+        "config.telemetry_sinks",
+    )
+    if not telemetry_sinks:
+        raise TrialModeActivationError("config.telemetry_sinks must include at least one sink.")
+
+    signal_trackers = _dedupe_preserve_order(
+        config_copy.get("signal_trackers", []),
+        "config.signal_trackers",
+    )
+    if not signal_trackers:
+        raise TrialModeActivationError("config.signal_trackers must include at least one tracker.")
+
+    yield_engine = config_copy.get("yield_engine")
+    if not isinstance(yield_engine, Mapping):
+        raise TrialModeActivationError("config.yield_engine must be a mapping.")
+
+    retro_mode = _require_bool(yield_engine, "enable_retro_mode", "config.yield_engine")
+    rewards_enabled = _require_bool(yield_engine, "rewards_enabled", "config.yield_engine")
+    epoch_streaming = _require_bool(yield_engine, "epoch_streaming", "config.yield_engine")
+    multiplier_sim = _require_string(yield_engine, "multiplier_sim", "config.yield_engine")
+
+    mesh_layer = config_copy.get("mesh_layer")
+    if not isinstance(mesh_layer, Mapping):
+        raise TrialModeActivationError("config.mesh_layer must be a mapping.")
+
+    detect_ghostkey = _require_bool(mesh_layer, "detect_ghostkey", "config.mesh_layer")
+    hidden_paths = _require_bool(mesh_layer, "enable_hidden_paths", "config.mesh_layer")
+    prophecy_trigger = _require_bool(mesh_layer, "prophecy_trigger", "config.mesh_layer")
+
+    governance_scrutiny = _require_string(config_copy, "governance_scrutiny", "config")
+    traffic_simulation = _require_string(config_copy, "traffic_simulation", "config")
+    auth_by = _require_string(config_copy, "auth_by", "config")
+
+    activated_at = datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    normalized_config = {
+        "telemetry_sinks": telemetry_sinks,
+        "signal_trackers": signal_trackers,
+        "yield_engine": {
+            "enable_retro_mode": retro_mode,
+            "rewards_enabled": rewards_enabled,
+            "epoch_streaming": epoch_streaming,
+            "multiplier_sim": multiplier_sim,
+        },
+        "mesh_layer": {
+            "detect_ghostkey": detect_ghostkey,
+            "enable_hidden_paths": hidden_paths,
+            "prophecy_trigger": prophecy_trigger,
+        },
+        "governance_scrutiny": governance_scrutiny,
+        "traffic_simulation": traffic_simulation,
+        "auth_by": auth_by,
+    }
+
+    telemetry_summary = {
+        "sinks": telemetry_sinks,
+        "trackers": signal_trackers,
+        "validation": "enabled" if telemetry_sinks else "pending",
+        "ingestion_active": bool(telemetry_sinks and signal_trackers),
+    }
+
+    signal_summary = {
+        "intent_channels": signal_trackers,
+        "loop_scanner_active": "LoopScanner" in signal_trackers,
+        "prophecy_watch": prophecy_trigger,
+    }
+
+    flags = {
+        "rewards_preview": rewards_enabled,
+        "retro_mode": retro_mode,
+        "epoch_streaming": epoch_streaming,
+        "prophecy_watch": prophecy_trigger,
+        "ghostkey_detected": detect_ghostkey,
+    }
+
+    summary = (
+        f"ForgeTrail trial '{codename_value}' activated for {identity_value}. "
+        f"Telemetry sinks: {', '.join(telemetry_sinks) or 'none'}. "
+        f"Signal trackers: {', '.join(signal_trackers) or 'none'}."
+    )
+
+    return {
+        "status": "activated",
+        "identity": identity_value,
+        "wallet_id": wallet_value,
+        "trial_codename": codename_value,
+        "activated_at": activated_at,
+        "config": normalized_config,
+        "telemetry": telemetry_summary,
+        "signals": signal_summary,
+        "flags": flags,
+        "governance": {
+            "scrutiny": governance_scrutiny,
+            "auth": auth_by,
+        },
+        "traffic_simulation": traffic_simulation,
+        "summary": summary,
+    }

--- a/tests/test_golden_trial_flow.py
+++ b/tests/test_golden_trial_flow.py
@@ -1,0 +1,90 @@
+import copy
+from datetime import datetime
+
+import pytest
+
+from protocol import TrialModeActivationError, activate_trial_mode
+
+
+@pytest.fixture()
+def forge_config():
+    return {
+        "telemetry_sinks": ["mirrorframe_logger", "guardian_attest"],
+        "signal_trackers": ["IntentPath", "SignalForker", "LoopScanner"],
+        "yield_engine": {
+            "enable_retro_mode": True,
+            "multiplier_sim": "live_belief",
+            "rewards_enabled": True,
+            "epoch_streaming": True,
+        },
+        "mesh_layer": {
+            "detect_ghostkey": True,
+            "enable_hidden_paths": True,
+            "prophecy_trigger": True,
+        },
+        "governance_scrutiny": "sandbox_ready",
+        "traffic_simulation": "Ghostfire Real",
+        "auth_by": "GhostKey-316",
+    }
+
+
+def test_activate_trial_mode_success(forge_config, identity):
+    requested_identity = identity or "ghostkey316.eth"
+    result = activate_trial_mode(
+        identity=requested_identity,
+        wallet_id="bpow20.cb.id",
+        trial_codename="ForgeTrail: Ghostfire Path",
+        config=forge_config,
+    )
+
+    assert result["status"] == "activated"
+    assert result["identity"] == requested_identity
+    assert result["wallet_id"] == "bpow20.cb.id"
+    assert result["config"]["yield_engine"]["multiplier_sim"] == "live_belief"
+    assert result["flags"]["rewards_preview"] is True
+    assert result["telemetry"]["sinks"] == ["mirrorframe_logger", "guardian_attest"]
+    assert result["signals"]["loop_scanner_active"] is True
+    assert result["governance"]["scrutiny"] == "sandbox_ready"
+    # the timestamp should be ISO formatted and convertible back
+    datetime.fromisoformat(result["activated_at"].replace("Z", "+00:00"))
+    assert "ForgeTrail: Ghostfire Path" in result["summary"]
+
+
+def test_activate_trial_mode_does_not_mutate_original_config(forge_config, identity):
+    requested_identity = identity or "ghostkey316.eth"
+    config = copy.deepcopy(forge_config)
+    config["telemetry_sinks"].append("mirrorframe_logger")  # duplicate entry
+    result = activate_trial_mode(
+        identity=requested_identity,
+        wallet_id="bpow20.cb.id",
+        trial_codename="ForgeTrail: Ghostfire Path",
+        config=config,
+    )
+
+    # original config should still contain the duplicate entry
+    assert config["telemetry_sinks"].count("mirrorframe_logger") == 2
+    # normalized config should only contain unique entries in order
+    assert result["config"]["telemetry_sinks"] == ["mirrorframe_logger", "guardian_attest"]
+
+
+def test_activate_trial_mode_missing_required_section_raises(forge_config, identity):
+    config = copy.deepcopy(forge_config)
+    config.pop("telemetry_sinks")
+
+    with pytest.raises(TrialModeActivationError):
+        activate_trial_mode(
+            identity=identity or "ghostkey316.eth",
+            wallet_id="bpow20.cb.id",
+            trial_codename="ForgeTrail: Ghostfire Path",
+            config=config,
+        )
+
+
+def test_activate_trial_mode_requires_non_empty_identity(forge_config):
+    with pytest.raises(TrialModeActivationError):
+        activate_trial_mode(
+            identity=" ",
+            wallet_id="bpow20.cb.id",
+            trial_codename="ForgeTrail: Ghostfire Path",
+            config=forge_config,
+        )


### PR DESCRIPTION
## Summary
- implement a `protocol.activate_trial_mode` helper that normalizes ForgeTrail configuration payloads
- expose a pytest `--identity` option so trial simulations can use tagged identities
- cover the Ghostfire trial activation behavior with a targeted pytest suite

## Testing
- pytest tests/test_golden_trial_flow.py --identity=ghostkey316.eth

------
https://chatgpt.com/codex/tasks/task_e_68e55e374ccc83229ea72837cef5b892